### PR TITLE
fix: add user-agent to color api requests

### DIFF
--- a/codes.py
+++ b/codes.py
@@ -7,7 +7,7 @@ class MTGCodes:
 
     def __init__(self):
         self.requests_timeout_seconds = 600
-        self.requests_user_agent = {'User-agent': 'application/json;q=0.9,*/*;q=0.8.'}
+        self.requests_user_agent = {"User-agent": "application/json;q=0.9,*/*;q=0.8."}
 
     def encode_color(self, color):
         # Handle colorless case
@@ -46,7 +46,7 @@ class MTGCodes:
 
     def get_set_codes(self):
         url = "https://api.scryfall.com/sets"
-        response = (
-            requests.get(url, headers=self.requests_user_agent, timeout=self.requests_timeout_seconds).json()
-        )
+        response = requests.get(
+            url, headers=self.requests_user_agent, timeout=self.requests_timeout_seconds
+        ).json()
         return [set_record["code"].upper() for set_record in response["data"]]

--- a/magic_card_csv_files_by_color/B.csv
+++ b/magic_card_csv_files_by_color/B.csv
@@ -1,0 +1,1591 @@
+name,cmc,release_year,price,color,image,type_line,artist
+Aberrant Return,6,2026,0.29,#000000,https://cards.scryfall.io/normal/front/a/2/a27a3d4b-caa7-4c5e-b1f3-aa607d3b157d.jpg?1783904606,Sorcery,Aaron Miller
+Abhorrent Overlord,7,2013,0.56,#000000,https://cards.scryfall.io/normal/front/4/4/4415d050-7a76-4f8b-bf78-e33dd21fe4f1.jpg?1783939785,Creature — Demon,Slawomir Maniak
+Abyssal Harvester,3,2024,0.35,#000000,https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg?1783909114,Creature — Demon Warlock,Diana Franco
+Abyssal Horror,6,2001,0.29,#000000,https://cards.scryfall.io/normal/front/c/c/ccb42943-f599-4068-a364-a023e70c4ed2.jpg?1783945517,Creature — Horror,Daren Bader
+Abyssal Hunter,4,1999,0.41,#000000,https://cards.scryfall.io/normal/front/3/c/3c3f6ad7-4782-40db-8eb3-e71d71ec3388.jpg?1783946190,Creature — Human Assassin,Steve Luke
+Abyssal Nocturnus,3,2006,0.66,#000000,https://cards.scryfall.io/normal/front/f/e/fe094903-45a6-4b11-b80e-aabe915c4b7c.jpg?1783943513,Creature — Horror,Jon Foster
+Abyssal Persecutor,4,2017,2.39,#000000,https://cards.scryfall.io/normal/front/9/f/9f2b9f27-459c-4585-9051-b83ffe053a74.jpg?1783935542,Creature — Demon,Chippy
+Acererak the Archlich,3,2021,3.46,#000000,https://cards.scryfall.io/normal/front/d/d/dd52d0bd-3abd-401c-9f56-ee911613da3b.jpg?1783926501,Legendary Creature — Zombie Wizard,Andrey Kuzinskiy
+Aclazotz- Deepest Betrayal // Temple of the Dead,5,2023,11.32,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Bat God // Land,Steve Prescott
+Acornelia- Fashionable Filcher,4,2020,0.31,#d78f42,https://cards.scryfall.io/normal/front/e/9/e9c37a83-3d5e-4019-b180-88e2bc106dd0.jpg?1783931341,Legendary Creature — Squirrel,Bram Sels
+Activated Sleeper,3,2022,1.55,#000000,https://cards.scryfall.io/normal/front/3/4/343d01cf-9806-4c2d-a993-ddc9ed248d7f.jpg?1783921470,Creature — Phyrexian Shapeshifter,Mathias Kollros
+Ad Nauseam,5,2020,12.82,#000000,https://cards.scryfall.io/normal/front/a/9/a9f2c53e-ff58-4aa8-89a6-4f45628cc571.jpg?1783930188,Instant,Jeremy Jarvis
+Aesthetic Consultation,1,2004,0.56,#000000,https://cards.scryfall.io/normal/front/0/4/0464a507-20e5-42d5-8aca-12504a869f21.jpg?1783944254,Instant,David “Help Me” Martin
+Aether Snap,5,2022,0.43,#000000,https://cards.scryfall.io/normal/front/d/d/dd9cade1-b077-4fb0-b55a-01b9916647e7.jpg?1783923273,Sorcery,Kev Walker
+Afterlife from the Loam,8,2025,0.59,#000000,https://cards.scryfall.io/normal/front/9/3/9361b548-a8d9-4e57-98cf-0c464742e1c9.jpg?1783907179,Sorcery,Johann Bodin
+Agadeem Occultist,3,2010,0.56,#000000,https://cards.scryfall.io/normal/front/c/5/c592ef76-d612-4cfe-b906-0e63c44d36f8.jpg?1783942058,Creature — Human Shaman Ally,Vance Kovacs
+Agadeem's Awakening // Agadeem- the Undercrypt,3,2020,28.63,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Land,Dmitry Burmak
+Agent of the Fates,3,2013,0.26,#000000,https://cards.scryfall.io/normal/front/e/c/ecd59977-8788-417d-ba50-e21b8a636bd3.jpg?1783939786,Creature — Human Assassin,Matt Stewart
+Agent Venom,3,2025,0.58,#000000,https://cards.scryfall.io/normal/front/f/5/f5f80d82-d64c-466f-8874-9cfb00469f02.jpg?1783905348,Legendary Creature — Symbiote Soldier Hero,Kevin Sidharta
+Aku Djinn,5,1997,0.91,#000000,https://cards.scryfall.io/normal/front/3/6/369a5df5-fc36-476c-84f4-ec4bdeb4f9d2.jpg?1783946996,Creature — Djinn,Terese Nielsen
+Akuta- Born of Ash,4,2005,0.28,#000000,https://cards.scryfall.io/normal/front/0/8/08730b49-e51e-4868-9cc8-4ddc4a1dce4c.jpg?1783944158,Legendary Creature — Spirit,Ben Thompson
+Alpharael- Stonechosen,5,2025,0.4,#000000,https://cards.scryfall.io/normal/front/3/3/33063d26-37f7-4e35-8da2-5770dfabdc41.jpg?1783905971,Legendary Creature — Human Cleric,Kieran Yanner
+Altar of Bhaal // Bone Offering,2,2022,0.35,#000000,https://cards.scryfall.io/normal/front/3/7/37bd2e21-b292-4c86-bd01-010d4a1af7b2.jpg?1783922771,Artifact // Sorcery — Adventure,Jonas De Ro
+Altar of the Wretched // Wretched Bonemass,3,2023,1.39,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact // Creature — Skeleton Horror,Helge C. Balzer
+Ambition's Cost,4,1999,18.2,#000000,https://cards.scryfall.io/normal/front/0/e/0e0b1613-e879-4c28-b27e-f3997b9ebccd.jpg?1783946117,Sorcery,Junko Taguchi
+Ammit Eternal,3,2017,1.11,#000000,https://cards.scryfall.io/normal/front/1/b/1b04934f-87d1-4768-b7b5-5f7249a09771.jpg?1783936044,Creature — Zombie Crocodile Demon,Mike Bierek
+Ancient Brass Dragon,7,2022,43.28,#000000,https://cards.scryfall.io/normal/front/6/4/6430c61b-407d-471d-9012-07f1ddef28aa.jpg?1783922772,Creature — Elder Dragon,Johan Grenier
+Ancient Cellarspawn,3,2024,7.21,#000000,https://cards.scryfall.io/normal/front/2/7/27e2477d-4f04-408d-8c39-8a886ac81f44.jpg?1783909661,Enchantment Creature — Horror,Alexandre Honoré
+Ancient Craving,4,2015,0.28,#000000,https://cards.scryfall.io/normal/front/c/7/c72cf3e0-6049-45e1-8226-e29f847bfeab.jpg?1783938087,Sorcery,Rob Alexander
+Andradite Leech,3,2000,0.31,#000000,https://cards.scryfall.io/normal/front/6/d/6da0d4f3-9216-406c-8f3e-b9bb0a11dc75.jpg?1783945699,Creature — Leech,Wayne England
+Angel of Suffering,5,2022,4.24,#000000,https://cards.scryfall.io/normal/front/c/d/cd4aee25-496d-453e-95b7-d773fe21cacc.jpg?1783923135,Creature — Nightmare Angel,Martina Fačková
+Animate Dead,2,2025,45.46,#000000,https://cards.scryfall.io/normal/front/a/4/a466aec7-4cda-4a2f-ba8a-eeb3665fbcfc.jpg?1783905164,Enchantment — Aura,Iron Maiden
+Animate Graveyard,5,2022,0.24,#000000,https://cards.scryfall.io/normal/front/8/3/83f7b63b-44b1-4119-a4bf-c10fe3429d91.jpg?1783920586,Enchantment — Aura,Mike Burns
+Anowon- the Ruin Sage,5,2021,2.6,#000000,https://cards.scryfall.io/normal/front/b/8/b8630ae1-8fe9-4d6e-899b-a28d86d4d729.jpg?1783924960,Legendary Creature — Vampire Shaman,Dan Murayama Scott
+Anrakyr the Traveller,5,2022,2.96,#000000,https://cards.scryfall.io/normal/front/6/e/6ea09406-c65e-4ee4-9c74-0553e5110837.jpg?1783920932,Legendary Artifact Creature — Necron,L J Koh
+Aphelia- Viper Whisperer,2,2024,17.22,#d78f42,https://cards.scryfall.io/normal/front/1/a/1a0867be-a861-4fb4-b8ff-cb2966193755.jpg?1783908857,Legendary Creature — Gorgon Assassin,Fuzichoco
+Aphemia- the Cacophony,2,2020,0.24,#000000,https://cards.scryfall.io/normal/front/5/b/5b359607-d699-4ba9-a438-48f0dd8f1bf5.jpg?1783931572,Legendary Enchantment Creature — Harpy,Lucas Graciano
+Apocalypse Demon,6,2017,0.26,#000000,https://cards.scryfall.io/normal/front/3/9/39dfbf99-55e8-468b-bcd9-9179cad7cab6.jpg?1783936042,Creature — Demon,Piotr Jabłoński
+Apprentice Necromancer,2,2017,0.88,#000000,https://cards.scryfall.io/normal/front/d/4/d4a7670c-173e-40c4-9896-f4f08dc970fb.jpg?1783935913,Creature — Zombie Wizard,Randy Vargas
+Archdemon of Paliano,4,2016,0.26,#000000,https://cards.scryfall.io/normal/front/6/3/632122b0-6525-4b41-840f-4fd5bea2f0ea.jpg?1783937355,Creature — Demon,Evan Shipard
+Archdemon of Unx,7,2008,0.23,#000000,https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg?1783942569,Creature — Demon,Dave Allsop
+Archenemy's Charm,3,2025,0.72,#000000,https://cards.scryfall.io/normal/front/d/c/dcde5f27-e2f0-4d2a-afa3-f300896ec4b1.jpg?1783905971,Instant,Brigitte Roka & Clifton Stommel
+Archfiend of Depravity,5,2017,3.8,#000000,https://cards.scryfall.io/normal/front/0/e/0ec85db7-c8ec-4730-b692-c140977436aa.jpg?1783936156,Creature — Demon,Daarken
+Archfiend of Despair,8,2023,23.05,#000000,https://cards.scryfall.io/normal/front/b/6/b6d1e901-cef9-45ca-a946-a4a9cba6702d.jpg?1783915683,Creature — Demon,Josh Hass
+Archfiend of Ifnir,5,2026,0.38,#000000,https://cards.scryfall.io/normal/front/8/3/83057af6-cb88-4401-92ef-5b5d10463140.jpg?1783904563,Creature — Demon,Seb McKinnon
+Archfiend of Spite,7,2019,0.78,#000000,https://cards.scryfall.io/normal/front/1/d/1df2ca13-4062-4827-ae2f-c61cf88ba3b3.jpg?1783932810,Creature — Demon,Tomasz Jedruszek
+Archfiend of the Dross,4,2023,0.34,#000000,https://cards.scryfall.io/normal/front/8/6/86b0edaf-8cfd-4508-9554-6f0fddc2dfc4.jpg?1783918050,Creature — Phyrexian Demon,Lie Setiawan
+Archon of Cruelty,8,2021,11.42,#000000,https://cards.scryfall.io/normal/front/1/b/1be9d9a4-d7ee-4854-abc2-85cabf993ec9.jpg?1783926865,Creature — Archon,Andrew Mar
+Archpriest of Shadows,5,2023,1.88,#000000,https://cards.scryfall.io/normal/front/f/5/f5931746-a55c-4528-9e4a-ee15edab3489.jpg?1783917018,Creature — Human Warlock,Fariba Khamseh
+Arco-Flagellant,3,2022,0.31,#000000,https://cards.scryfall.io/normal/front/0/8/0894d21c-d44c-4c7c-8693-f32dde67b336.jpg?1783920931,Creature — Human,Games Workshop
+Ardyn- the Usurper,8,2025,1.04,#000000,https://cards.scryfall.io/normal/front/4/6/4627072e-9c72-4084-8021-690777342548.jpg?1783906624,Legendary Creature — Elder Human Noble,Russell Lu
+Arguel's Blood Fast // Temple of Aclazotz,2,2017,0.34,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Enchantment // Legendary Land,Daarken
+Armaggon- Future Shark,8,2026,0.39,#000000,https://cards.scryfall.io/normal/front/5/9/5989378b-0eac-43cf-bc83-8f7765536789.jpg?1783904109,Legendary Creature — Shark Horror Mutant,Mathias Kollros
+Army of the Damned,8,2022,1.52,#000000,https://cards.scryfall.io/normal/front/b/f/bf818314-1eb4-48da-8e6f-ff7b89873b63.jpg?1783923272,Sorcery,Ryan Pancoast
+Arvinox- the Mind Flail,7,2024,0.41,#000000,https://cards.scryfall.io/normal/front/f/8/f81e3110-857c-4074-9c55-7e87c22051c9.jpg?1783909623,Legendary Enchantment Creature — Horror,Nikola Matkovic
+Ascendant Evincar,6,2009,3.01,#000000,https://cards.scryfall.io/normal/front/2/1/213ad4ba-5a36-4a90-bd0a-8f5fddca9c9b.jpg?1783942332,Legendary Creature — Phyrexian Vampire Noble,Mark Zug
+Ashcoat of the Shadow Swarm,4,2022,42.39,#000000,https://cards.scryfall.io/normal/front/2/f/2fce5989-a2a0-4825-b90a-a1f78659b6e0.jpg?1783919189,Legendary Creature — Rat Warlock,Christina Kraus
+Ashen Powder,4,1999,1.23,#000000,https://cards.scryfall.io/normal/front/d/6/d6fa11f5-546b-4a14-afd0-80866d4968ab.jpg?1783946188,Sorcery,Geofrey Darrow
+Ashiok- Wicked Manipulator,5,2023,0.55,#000000,https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg?1783915111,Legendary Planeswalker — Ashiok,Raymond Swanland
+Ashling- the Extinguisher,4,2008,30.3,#000000,https://cards.scryfall.io/normal/front/3/5/350580d8-45db-4428-a292-cc4802bf1e4d.jpg?1783942688,Legendary Creature — Elemental Shaman,Wayne Reynolds
+Ashnod- Flesh Mechanist,1,2022,0.41,#000000,https://cards.scryfall.io/normal/front/5/e/5eb43c15-50a9-488f-b0be-84a5e0a6d10b.jpg?1783920096,Legendary Creature — Human Artificer,Howard Lyon
+Asmodeus the Archfiend,6,2021,0.33,#000000,https://cards.scryfall.io/normal/front/a/5/a5e6b864-58e7-43b9-9d79-1d0361340960.jpg?1783926501,Legendary Creature — Devil God,Aleksi Briclot
+Astarion's Thirst,4,2022,2.22,#000000,https://cards.scryfall.io/normal/front/2/3/2366640a-ca4a-4325-8578-1ec78d0382cc.jpg?1783922768,Instant,Winona Nelson
+Asylum Visitor,2,2019,0.22,#000000,https://cards.scryfall.io/normal/front/f/7/f7b601c3-eb95-4140-8550-4a1ec616a0fa.jpg?1783932772,Creature — Vampire Wizard,Bastien L. Deharme
+Attrition,3,2011,19.82,#000000,https://cards.scryfall.io/normal/front/f/8/f8f29b57-172e-407b-b55e-32fe96198f92.jpg?1783941230,Enchantment,Scott M. Fischer
+Auntie's Snitch,3,2008,0.23,#000000,https://cards.scryfall.io/normal/front/d/c/dc5caf12-9358-490b-aafa-fc4d2b8b9b22.jpg?1783942794,Creature — Goblin Rogue,Warren Mahy
+Author of Shadows,5,2021,0.48,#000000,https://cards.scryfall.io/normal/front/9/5/95b5fc08-5c50-4ec9-9788-54f95c4ce916.jpg?1783927602,Creature — Shade Warlock,Alex Brock
+Avatar of Woe,8,2018,5.29,#000000,https://cards.scryfall.io/normal/front/7/e/7e8e34de-4b0a-48fe-bb13-c7e181d37e6c.jpg?1783934759,Creature — Avatar,rk post
+Avenger of the Fallen,3,2025,0.89,#000000,https://cards.scryfall.io/normal/front/d/5/d5397366-151f-46b0-b9b2-fa4d5bd892d8.jpg?1783907380,Creature — Human Warrior,Winona Nelson
+Awaken the Erstwhile,5,2019,0.37,#000000,https://cards.scryfall.io/normal/front/e/a/ea166114-2f9b-4ca6-b573-1f49f7485580.jpg?1783933700,Sorcery,Jason A. Engle
+Ayara- First of Locthwain,3,2019,8.83,#000000,https://cards.scryfall.io/normal/front/e/d/ed0ace28-9a33-4f0d-b8c8-f5517f20ccf1.jpg?1783932644,Legendary Creature — Elf Noble,Ryan Pancoast
+Ayara's Oathsworn,2,2023,0.41,#000000,https://cards.scryfall.io/normal/front/5/3/5330e6b7-eca3-46a4-8905-8f1de16f76af.jpg?1783916526,Creature — Human Knight,Johann Bodin
+Ayara- Widow of the Realm // Ayara- Furnace Queen,3,2023,0.39,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elf Noble // Legendary Creature — Phyrexian Elf Noble,Anna Podedworna
+Azula- Ruthless Firebender,3,2025,0.71,#000000,https://cards.scryfall.io/normal/front/c/1/c1aab711-c113-458c-848e-9369c0149d61.jpg?1783904827,Legendary Creature — Human Noble,Rose Benjamin
+Back in Town,3,2024,4.76,#000000,https://cards.scryfall.io/normal/front/3/9/393a864c-caa0-4030-b8bd-be0bb967eb72.jpg?1783911966,Sorcery,Greg Staples
+Bad Moon,2,2014,2.94,#000000,https://cards.scryfall.io/normal/front/8/f/8f8a75da-ea3c-43e7-9d32-1c92f8ec0fd2.jpg?1783938752,Enchantment,Gary Leach
+Bag of Devouring,1,2021,0.33,#000000,https://cards.scryfall.io/normal/front/d/1/d183e52b-432d-4b4d-803c-33f7a5f178f1.jpg?1783926251,Artifact,Sean Murray
+Bala Ged Thief,4,2009,0.34,#000000,https://cards.scryfall.io/normal/front/0/b/0b4598ec-cf36-4a51-9f67-b91c146c3c4f.jpg?1783942157,Creature — Human Rogue Ally,Matt Cavotta
+Baleful Mastery,4,2024,3.66,#000000,https://cards.scryfall.io/normal/front/5/7/579e20e7-1395-4a6c-a836-ae3419fc8808.jpg?1783911932,Instant,Chris Cold
+Balthor the Defiled,4,2002,12.17,#000000,https://cards.scryfall.io/normal/front/e/d/ed4cc273-adc3-4f46-9743-134b552d1d56.jpg?1783945124,Legendary Creature — Zombie Dwarf,Carl Critchlow
+Baneful Omen,7,2010,1.85,#000000,https://cards.scryfall.io/normal/front/2/b/2bff6e03-b6af-4f54-b365-9a6db2dbb595.jpg?1783941989,Enchantment,Karl Kopinski
+Bane of the Living,4,2019,0.33,#000000,https://cards.scryfall.io/normal/front/9/4/946a0fb7-0e36-47d5-8083-09f48725dff1.jpg?1783932772,Creature — Insect,Filip Burburan
+Barbed Servitor,4,2024,0.31,#000000,https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg?1783912901,Artifact Creature — Construct,Simon Dominic
+Baron Helmut Zemo,3,2026,0.34,#000000,https://cards.scryfall.io/normal/front/c/2/c2aadc25-7755-4bc8-a8af-b01d27eec364.jpg?1783902947,Legendary Creature — Human Noble Villain,Wero Gallo
+Barrowgoyf,3,2024,14.01,#000000,https://cards.scryfall.io/normal/front/c/e/cea3b218-0e6e-443a-84f7-380f1021e8e1.jpg?1783911410,Creature — Lhurgoyf,Igor Kieryluk
+Battle at the Bridge,1,2017,0.28,#000000,https://cards.scryfall.io/normal/front/7/4/74d8b644-4cca-451e-a46c-5237c13bf373.jpg?1783936766,Sorcery,Chris Rallis
+Beacon of Unrest,5,2020,0.45,#000000,https://cards.scryfall.io/normal/front/0/6/06bd199b-1855-4208-8bf7-8930e91ab139.jpg?1783930187,Sorcery,Joseph Meehan
+Bebop- Skull & Crossbones,2,2026,0.26,#000000,https://cards.scryfall.io/normal/front/a/f/af2a1494-9c0d-4590-999b-2c52725dc5d0.jpg?1783904171,Legendary Creature — Boar Mutant,Benjamin Ee
+Behold the Beyond,7,2016,1.04,#000000,https://cards.scryfall.io/normal/front/f/d/fd22350b-d48c-4ae6-b95f-63336fabe0e3.jpg?1783937781,Sorcery,Noah Bradley
+Behold the Sinister Six!,7,2025,3.58,#000000,https://cards.scryfall.io/normal/front/1/9/1919bfec-1906-4178-ad32-d4589842e563.jpg?1783905348,Sorcery,Nathaniel Himawan
+Bellowing Fiend,5,2001,0.15,#000000,https://cards.scryfall.io/normal/front/2/b/2b0962d7-d797-4f07-bd73-9cd7a11ffad8.jpg?1783945515,Creature — Spirit,Chippy
+Bellowing Mauler,5,2022,0.28,#000000,https://cards.scryfall.io/normal/front/d/8/d885b5af-f77f-481c-be6c-bfc1980638c4.jpg?1783923367,Creature — Ogre Warrior,Daarken
+Beseech the Mirror,4,2023,20.53,#000000,https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg?1783915111,Sorcery,Cynthia Sheppard
+Beseech the Queen,6,2026,12.89,#000000,https://cards.scryfall.io/normal/front/c/3/c3a62fec-80eb-4945-80e9-37610e636bfa.jpg?1783904247,Sorcery,Anna Podedworna
+B.F.M. (Big Furry Monster),15,1998,17.89,#000000,https://cards.scryfall.io/normal/front/a/9/a9f9c279-e382-4feb-9575-196e7cf5d7dc.jpg?1783946432,Creature — The Biggest, Baddest, Nastiest,,Douglas Shuler
+B.F.M. (Big Furry Monster),15,1998,21.08,#000000,https://cards.scryfall.io/normal/front/d/1/d15c6375-2e4e-47f7-88e1-d90794e7f724.jpg?1783946431,Scariest Creature You'll Ever See,Douglas Shuler
+Biotransference,4,2022,8.83,#000000,https://cards.scryfall.io/normal/front/7/5/75a787a3-5838-4121-bbaf-745d22c4b0bc.jpg?1783920930,Enchantment,Anthony Devine
+Biting-Palm Ninja,3,2022,0.39,#000000,https://cards.scryfall.io/normal/front/3/0/3017df51-67ae-4c3d-8210-086f83bc2040.jpg?1783923890,Creature — Human Ninja,Andreas Zafiratos
+Bitterbloom Bearer,2,2026,15.66,#000000,https://cards.scryfall.io/normal/front/7/1/7127164d-f2a3-4d79-b6db-93507ff5ab47.jpg?1783904470,Creature — Faerie Rogue,Chris Rahn
+Bitterblossom,2,2022,34.45,#000000,https://cards.scryfall.io/normal/front/b/9/b9640cbf-b016-410e-9eff-e8924883517b.jpg?1783921908,Kindred Enchantment — Faerie,Rebecca Guay
+Bitter Ordeal,3,2007,19.13,#000000,https://cards.scryfall.io/normal/front/2/8/2879e7a1-0256-4116-be22-7c9972e4ce0b.jpg?1783943112,Sorcery,Daarken
+Bitter Triumph,2,2025,1.25,#000000,https://cards.scryfall.io/normal/front/1/2/12d77fbd-c172-41f1-9122-ea7858ab37b9.jpg?1783906069,Instant,Aaron J. Riley
+Black Carriage,5,1995,0.82,#000000,https://cards.scryfall.io/normal/front/8/7/87068116-6000-44ee-b47f-f5cb8c233bb2.jpg?1783947293,Creature — Horse,David A. Cherry
+Black Cat- Cunning Thief,5,2025,0.91,#000000,https://cards.scryfall.io/normal/front/0/e/0ed36ada-22c8-4e40-86c5-c116a0bee1c2.jpg?1783905347,Legendary Creature — Human Rogue Villain,Alessandra Pisano
+Black Hole,4,2022,0.2,#000000,https://cards.scryfall.io/normal/front/9/e/9ed3fc60-9079-486b-a05e-00f926a99b4e.jpg?1783920586,Sorcery,Greg Bobrowski
+Blacklance Paragon,2,2019,0.35,#000000,https://cards.scryfall.io/normal/front/f/e/fe0a63bb-dd94-429f-aa9b-21f3d1c53ae5.jpg?1783932644,Creature — Human Knight,Victor Adame Minguez
+Black Market,5,2022,5.76,#000000,https://cards.scryfall.io/normal/front/7/8/78c80c6d-f3ae-48d3-ba6a-b9b738e1affb.jpg?1783922463,Enchantment,Jeff Easley
+Black Sun's Twilight,1,2023,0.35,#000000,https://cards.scryfall.io/normal/front/e/5/e5bb4def-c67c-44c2-b3b2-8c53a077432d.jpg?1783918050,Instant,Jonas De Ro
+Black Sun's Zenith,2,2026,0.36,#000000,https://cards.scryfall.io/normal/front/e/d/eda98f51-a918-4ef7-a123-7d4200c79620.jpg?1783904562,Sorcery,Daniel Ljunggren
+Black Widow- Daring Operative,5,2026,13.4,#000000,https://cards.scryfall.io/normal/front/b/1/b1dc3b66-51a2-4ed5-ac79-5dcc39fd8ca4.jpg?1783902998,Legendary Creature — Human Spy Hero,Julie Bell
+Black Widow- Deadly Hunter,3,2026,2.3,#000000,https://cards.scryfall.io/normal/front/c/5/c51a2ec4-2a8b-451b-b0b4-a778b9377948.jpg?1783903065,Legendary Creature — Human Assassin Hero,Victor Adame Minguez
+Black Widow- Super Spy,2,2026,2.19,#000000,https://cards.scryfall.io/normal/front/6/3/63ce0909-7d7d-410d-ab6c-c87fa3e23877.jpg?1783902946,Legendary Creature — Human Spy Hero,Dan Brereton
+Blade of the Oni,2,2022,1.54,#000000,https://cards.scryfall.io/normal/front/b/6/b6bc3f71-b4ce-4c05-be3c-7a0faad476c3.jpg?1783923890,Artifact Creature — Equipment Demon,Jason A. Engle
+Blasphemous Edict,5,2024,4.6,#000000,https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg?1783909112,Sorcery,Andrew Mar
+Blex- Vexing Pest // Search for Blex,3,2021,12.1,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Pest // Sorcery,Ekaterina Burmak
+Blight Grenade,5,2022,0.38,#000000,https://cards.scryfall.io/normal/front/8/8/88cdcf69-e04d-46ab-9cce-76f1fac5bc40.jpg?1783920928,Sorcery,Alexey Kruglov
+Blight Mound,3,2026,0.37,#000000,https://cards.scryfall.io/normal/front/d/c/dc060028-e01c-4bc7-8b52-7d0e2a350061.jpg?1783903787,Enchantment,Oriana Menendez
+Blight Titan,6,2023,0.32,#000000,https://cards.scryfall.io/normal/front/e/0/e00c55f4-676f-40dc-a7f7-a53f07dd3107.jpg?1783917285,Creature — Phyrexian Giant,Martin de Diego Sádaba
+Blightwing Bandit,4,2023,5.46,#000000,https://cards.scryfall.io/normal/front/b/9/b91c8318-85a0-4c2e-9cef-cc00429218b1.jpg?1783914988,Creature — Faerie Rogue,Marie Magny
+Blitzwing- Cruel Tormentor // Blitzwing- Adaptive Assailant,6,2022,2.06,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact Creature — Robot // Legendary Artifact — Vehicle,Volta Creation
+Bloated Processor,3,2023,0.28,#000000,https://cards.scryfall.io/normal/front/6/6/66ddcca8-5720-4341-acce-c6694ddc97f8.jpg?1783917016,Creature — Phyrexian,Brock Grossman
+Blood Artist,2,2020,10.46,#000000,https://cards.scryfall.io/normal/front/8/a/8a5b65ed-250c-42a6-84c0-ac06662ca5ed.jpg?1783930779,Creature — Vampire,Joshua Howard
+Bloodchief Ascension,1,2023,20.41,#000000,https://cards.scryfall.io/normal/front/d/5/d56d1535-d9de-459f-bc31-0923f621e0e9.jpg?1783915683,Enchantment,Adi Granov
+Blood-Chin Fanatic,3,2015,0.19,#000000,https://cards.scryfall.io/normal/front/4/e/4eb00d55-de56-4bbb-9545-e8cfb25a4f23.jpg?1783938601,Creature — Orc Warrior,David Palumbo
+Bloodcrazed Paladin,2,2017,0.33,#000000,https://cards.scryfall.io/normal/front/3/e/3e2160e9-14a0-4c75-b7b0-fb09051ddb32.jpg?1783935766,Creature — Vampire Knight,Daarken
+Bloodcurdler,2,2001,0.31,#000000,https://cards.scryfall.io/normal/front/d/d/dd1452ff-cec6-4df3-8bdc-bfb7869553a1.jpg?1783945253,Creature — Horror,Adam Rex
+Blood Funnel,2,2005,2.17,#000000,https://cards.scryfall.io/normal/front/5/f/5f4e8084-4b9e-48e0-bf59-d45543e176f8.jpg?1783943674,Enchantment,Thomas M. Baxa
+Bloodghast,2,2026,0.66,#000000,https://cards.scryfall.io/normal/front/c/e/cee85485-598f-4dfc-aa0b-7b1de86c7788.jpg?1783903786,Creature — Vampire Spirit,Lixin Yin
+Bloodgift Demon,5,2014,0.87,#000000,https://cards.scryfall.io/normal/front/6/a/6a2e1d4a-8df4-472f-a98f-d6b71c1dd1c4.jpg?1783938844,Creature — Demon,Peter Mohrbacher
+Bloodletter of Aclazotz,4,2023,36.64,#000000,https://cards.scryfall.io/normal/front/d/4/d4f6027a-003a-4f9d-929a-0b6da1fa42c9.jpg?1783913782,Creature — Vampire Demon,Antonio José Manzanedo
+Bloodline Bidding,8,2026,2.09,#000000,https://cards.scryfall.io/normal/front/8/7/877d9b75-ad2f-45a6-94d8-68e80d7db789.jpg?1783904470,Sorcery,Drew Baker
+Bloodline Culling,3,2021,0.28,#000000,https://cards.scryfall.io/normal/front/f/a/fac827f7-a587-4adf-8408-2d9ccd9c1343.jpg?1783925624,Instant,Liiga Smilshkalne
+Bloodline Keeper // Lord of Lineage,4,2025,9.51,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Vampire // Creature — Vampire,Jason Chan
+Bloodline Recollector // Ancestral Craving,2,2026,89.99,#000000,https://cards.scryfall.io/normal/front/4/f/4fcc913e-f736-460a-b24b-022fa2e861b9.jpg?1783902768,Creature — Vampire Warlock // Instant,Cynthia Sheppard
+Bloodlord of Vaasgoth,5,2021,0.59,#000000,https://cards.scryfall.io/normal/front/5/1/510c65ea-7c9f-461f-b038-ef119db1ca30.jpg?1783924959,Creature — Vampire Warrior,Greg Staples
+Blood Money,7,2023,1.8,#000000,https://cards.scryfall.io/normal/front/b/b/bbbc5c9d-110a-44cd-a2c9-8bad7dac4b5f.jpg?1783913879,Sorcery,Inka Schulz
+Blood on the Snow,6,2021,0.3,#000000,https://cards.scryfall.io/normal/front/d/8/d8606f40-0af4-443b-a413-a88dc3e8f32e.jpg?1783928254,Snow Sorcery,Martina Fačková
+Blood Operative,3,2018,0.19,#000000,https://cards.scryfall.io/normal/front/0/0/000ac9e5-3c95-4e87-9424-109e2eea6b45.jpg?1783934178,Creature — Vampire Assassin,Livia Prima
+Blood Scrivener,2,2013,0.33,#000000,https://cards.scryfall.io/normal/front/9/e/9ea8179a-d3c9-4cdc-a5b5-68cc73279050.jpg?1783940040,Creature — Zombie Wizard,Peter Mohrbacher
+Bloodsoaked Champion,1,2022,0.37,#000000,https://cards.scryfall.io/normal/front/2/7/275d6137-5eff-4e82-8232-64e8679bc11c.jpg?1783922459,Creature — Human Warrior,Aaron Miller
+Bloodthirsty Conqueror,5,2024,37.71,#000000,https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg?1783909112,Creature — Vampire Knight,Dmitry Burmak
+Bloodtracker,4,2023,0.31,#000000,https://cards.scryfall.io/normal/front/d/6/d654462f-5346-454f-9905-41218cf6b29e.jpg?1783913877,Creature — Vampire Wizard,Magali Villeneuve
+Blood Tribute,6,2017,5.78,#000000,https://cards.scryfall.io/normal/front/3/6/361912f4-5205-44a5-b21e-17402526c1fd.jpg?1783935911,Sorcery,Volkan Baǵa
+Bloodvial Purveyor,4,2021,0.26,#000000,https://cards.scryfall.io/normal/front/4/8/4889c58b-8b84-42af-a56c-e886655aa997.jpg?1783924871,Creature — Vampire,Fesbra
+Body Count,3,2022,2.99,#000000,https://cards.scryfall.io/normal/front/0/2/024bf289-2802-4f11-aebf-9373ffbd9c46.jpg?1783923366,Instant,Vladimir Krisetskiy
+Body Launderer,4,2022,1.46,#000000,https://cards.scryfall.io/normal/front/2/4/24d7d77a-35b6-451a-af44-ecaf38facccb.jpg?1783923136,Creature — Ogre Rogue,Matt Stewart
+Body Snatcher,4,2023,0.22,#000000,https://cards.scryfall.io/normal/front/2/d/2d7d83a8-3bad-40cf-991c-fc7f8e399c42.jpg?1783918483,Creature — Phyrexian Minion,Mark Zug
+Bogbrew Witch,4,2020,0.27,#000000,https://cards.scryfall.io/normal/front/6/c/6ce1aa49-fe00-4390-8c4b-d1203cc337cd.jpg?1783930433,Creature — Human Wizard,Eric Deschamps
+Bog Elemental,5,2000,0.31,#000000,https://cards.scryfall.io/normal/front/7/5/75191915-352e-4de7-b216-63f0ff588ba5.jpg?1783945787,Creature — Elemental,Glen Angus
+Boggart Mob,4,2007,4.2,#000000,https://cards.scryfall.io/normal/front/a/6/a61990de-0daf-4340-8e6b-c49852d46980.jpg?1783942893,Creature — Goblin Warrior,Thomas Denmark
+Boiling Rock Rioter,3,2025,0.24,#000000,https://cards.scryfall.io/normal/front/7/3/739653cc-35c8-4a66-95d8-3e80fa6114f0.jpg?1783904976,Creature — Human Rogue Ally,Airi Yoshihisa
+Bolas's Citadel,6,2019,15.8,#000000,https://cards.scryfall.io/normal/front/d/2/d2124603-d20e-40eb-97f0-a66323397ac2.jpg?1783933451,Legendary Artifact,Jonas De Ro
+Bold Plagiarist,4,2021,0.38,#000000,https://cards.scryfall.io/normal/front/b/0/b0e0f5f6-8b63-4c63-bd1d-445613bc106b.jpg?1783927598,Creature — Vampire Rogue,Miguel Mercado
+Bone Dancer,3,1997,3.22,#000000,https://cards.scryfall.io/normal/front/2/0/207bb4cd-4525-47e0-b412-0d0e29717d44.jpg?1783946737,Creature — Zombie,Scott Kirschner
+Bone Devourer,4,2025,0.24,#000000,https://cards.scryfall.io/normal/front/5/a/5acb9bd4-ed86-400e-9f5d-4c26351242f2.jpg?1783907177,Creature — Dragon,Diana Franco
+Bone Dragon,5,2018,0.95,#000000,https://cards.scryfall.io/normal/front/0/8/08a0de62-6e9f-4ee9-9d8d-ee6f6a115307.jpg?1783934576,Creature — Dragon Skeleton,Jason A. Engle
+Bone Miser,5,2019,30.17,#000000,https://cards.scryfall.io/normal/front/a/7/a7fa6901-e74f-448c-9d26-99a692092512.jpg?1783932810,Creature — Zombie Wizard,Antonio José Manzanedo
+Bone Splinters,1,2022,1.83,#000000,https://cards.scryfall.io/normal/front/0/a/0a35bb96-89de-4a0a-a53e-aa97f800e92f.jpg?1783919218,Sorcery,Fajareka Setiawan
+Boneyard Mycodrax,3,2020,0.3,#000000,https://cards.scryfall.io/normal/front/f/6/f6ac1131-8e96-46be-85e0-55844d0d2935.jpg?1783931218,Creature — Fungus,Yeong-Hao Han
+Boneyard Parley,7,2019,0.32,#000000,https://cards.scryfall.io/normal/front/0/4/04a82af7-309d-46f5-b3ec-ea301dfa042f.jpg?1783932772,Sorcery,James Ryman
+Boneyard Scourge,4,2017,7.55,#000000,https://cards.scryfall.io/normal/front/5/5/55a3a094-48c5-4da5-8626-e30a0e8d8f3a.jpg?1783935947,Creature — Zombie Dragon,Grzegorz Rutkowski
+Bontu's Last Reckoning,3,2017,0.53,#000000,https://cards.scryfall.io/normal/front/1/b/1b4d0102-c0d6-4d50-941a-dd1c3575a3a8.jpg?1783936042,Sorcery,Victor Adame Minguez
+Bontu the Glorified,3,2017,5.91,#000000,https://cards.scryfall.io/normal/front/4/b/4bc07386-909f-4946-9120-3acb58622e2f.jpg?1783936509,Legendary Creature — God,Chase Stone
+Bottomless Pit,3,2023,19.63,#000000,https://cards.scryfall.io/normal/front/a/7/a7fd9517-a063-4c42-8e1c-c298b314b798.jpg?1783915171,Enchantment,Ryan Roadkill
+Bounty Hunter,4,1997,4.98,#000000,https://cards.scryfall.io/normal/front/9/8/98319fd3-0aad-4fc3-bb83-3c027d0ed652.jpg?1783946646,Creature — Human Archer Minion,Brian Snõddy
+Braids- Arisen Nightmare,3,2025,4.3,#000000,https://cards.scryfall.io/normal/front/f/9/f96223d0-04c4-40c2-87a9-0c6bc74adddb.jpg?1783906041,Legendary Creature — Nightmare,Heonhwa
+Braids- Cabal Minion,4,2021,1.0,#000000,https://cards.scryfall.io/normal/front/2/7/27691efa-052d-4afe-b9ef-159858ca660f.jpg?1783926786,Legendary Creature — Human Minion,Eric Peterson
+Brainstealer Dragon,7,2024,10.39,#000000,https://cards.scryfall.io/normal/front/8/8/884d4eea-77c0-4b78-bb83-3f855cc77298.jpg?1783911933,Creature — Dragon Horror,Joshua Raphael
+Breach the Multiverse,7,2023,11.21,#000000,https://cards.scryfall.io/normal/front/d/a/daf51a76-7a57-4462-ae18-a19e817e49e5.jpg?1783917016,Sorcery,Liiga Smilshkalne
+Bridge from Below,3,2018,0.83,#000000,https://cards.scryfall.io/normal/front/3/f/3faaa657-8b02-41a9-8a99-31a223d2caa5.jpg?1783933827,Enchantment,Daarken
+Bringer of the Black Dawn,9,2004,1.64,#d78f42,https://cards.scryfall.io/normal/front/5/4/54e5e882-02d4-4d69-aabf-ae9bf31f2923.jpg?1783944401,Creature — Bringer,Carl Critchlow
+Bringer of the Last Gift,8,2023,0.49,#000000,https://cards.scryfall.io/normal/front/1/9/19775c18-4cc0-49d3-86e4-0841768cbf4d.jpg?1783913781,Creature — Vampire Demon,Wero Gallo
+Brink of Madness,4,1999,0.48,#000000,https://cards.scryfall.io/normal/front/f/f/ff5391d8-b546-4159-955e-16bb58052311.jpg?1783946243,Enchantment,Donato Giancola
+Broken Visage,5,1997,0.38,#000000,https://cards.scryfall.io/normal/front/8/2/824823fb-5ae1-48b1-bc46-e452afa73cd8.jpg?1783946934,Instant,Margaret Organ-Kean
+Brutal Hordechief,4,2016,2.67,#d78f42,https://cards.scryfall.io/normal/front/d/f/dfa94402-1613-4e65-8470-a05bf4bbb8a8.jpg?1783937068,Creature — Orc Warrior,Tyler Jacobson
+Buried Alive,3,2024,23.41,#000000,https://cards.scryfall.io/normal/front/b/0/b06ef600-51a0-48e7-b19b-0b15b3e6fc69.jpg?1783910871,Sorcery,Filipe Pagliuso
+Burning-Rune Demon,6,2021,5.37,#000000,https://cards.scryfall.io/normal/front/f/3/f358a52b-8044-404e-8d04-2ec5903386cc.jpg?1783928253,Creature — Demon Berserker,Andrew Mar
+Burnt Offering,1,2025,18.42,#d78f42,https://cards.scryfall.io/normal/front/4/b/4b73009e-1ded-4614-af7a-0ad8e2afa7b1.jpg?1783905145,Instant,Iron Maiden
+Butcher of Malakir,7,2023,0.37,#000000,https://cards.scryfall.io/normal/front/9/d/9d805499-0739-403e-8447-ed2707dc9eb2.jpg?1783913878,Creature — Vampire Warrior,Jason Chan
+Cabal Conditioning,7,2003,3.18,#000000,https://cards.scryfall.io/normal/front/e/b/eb81c6e6-fded-4cd3-a6fa-486419a5408a.jpg?1783944882,Sorcery,Scott M. Fischer
+Cabal Patriarch,6,2001,0.34,#000000,https://cards.scryfall.io/normal/front/0/d/0d2f0da3-a13e-4a45-98dc-6227cf952a5e.jpg?1783945251,Legendary Creature — Human Wizard,Mark Zug
+Cabal Ritual,2,2025,14.03,#000000,https://cards.scryfall.io/normal/front/b/6/b6f93fe0-76f7-4db7-9315-adc26252c059.jpg?1783905140,Instant,Bastien L. Deharme
+Cabal Shrine,3,2001,0.32,#000000,https://cards.scryfall.io/normal/front/d/d/dd376a52-5dfd-49f3-a520-537cd4527439.jpg?1783945251,Enchantment,Ben Thompson
+Cabal Therapist,1,2019,0.27,#000000,https://cards.scryfall.io/normal/front/e/a/eaa8f485-0f3d-4a0b-bcdf-6c27d1d2bce0.jpg?1783933132,Creature — Horror,Mitchell Malloy
+Cacophony Unleashed,7,2023,1.01,#000000,https://cards.scryfall.io/normal/front/9/0/908d9aa5-818c-4651-b135-cc6d1983ad99.jpg?1783915482,Enchantment,Deruchenko Alexander
+Cairn Wanderer,5,2020,0.33,#000000,https://cards.scryfall.io/normal/front/f/8/f84b53c7-10db-40f6-a1d4-0baab88355e5.jpg?1783931181,Creature — Shapeshifter,Nils Hamm
+Calculating Lich,6,2022,0.76,#000000,https://cards.scryfall.io/normal/front/a/5/a5dccdab-9dda-4964-9b1a-eec6d31c7995.jpg?1783922457,Creature — Zombie Wizard,Antonio José Manzanedo
+Call of the Ring,2,2023,3.68,#000000,https://cards.scryfall.io/normal/front/a/9/a92a2c5a-e450-494a-b23b-7ac0a6c50535.jpg?1783916310,Enchantment,Anato Finnstark
+Callous Bloodmage,3,2021,0.34,#000000,https://cards.scryfall.io/normal/front/8/1/81358736-65cf-44d8-819e-d0268d14cc76.jpg?1783927369,Creature — Vampire Warlock,Jokubas Uogintas
+Call to the Grave,5,2011,2.56,#000000,https://cards.scryfall.io/normal/front/5/e/5e1324b6-dba0-4aff-a403-a45d2b405f5b.jpg?1783941084,Enchantment,Daarken
+Call to the Void,5,2022,0.29,#000000,https://cards.scryfall.io/normal/front/6/8/6836cfea-c203-49f4-b8d1-f1e8aa790db5.jpg?1783922765,Sorcery,Liiga Smilshkalne
+Cao Cao- Lord of Wei,5,1999,52.67,#000000,https://cards.scryfall.io/normal/front/d/7/d7e5a530-c954-4696-85ce-6afaf7de1808.jpg?1783946117,Legendary Creature — Human Soldier,Gao Jianzhang
+Cao Ren- Wei Commander,4,1999,101.82,#000000,https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg?1783946117,Legendary Creature — Human Soldier Warrior,Junko Taguchi
+Capital Punishment,6,2016,5.55,#000000,https://cards.scryfall.io/normal/front/0/5/051830bb-1baa-4c11-9177-efcd908fbcaf.jpg?1783937353,Sorcery,Lake Hurwitz
+Captivating Vampire,3,2025,3.59,#000000,https://cards.scryfall.io/normal/front/0/f/0f87aadf-7638-4691-b5a5-86f928e98462.jpg?1783908149,Creature — Vampire,Eric Deschamps
+Carnifex Demon,6,2026,0.29,#000000,https://cards.scryfall.io/normal/front/7/e/7eec26a5-1d2b-43ff-b340-bc72f4a71ae8.jpg?1783904562,Creature — Phyrexian Demon,Aleksi Briclot
+Carnival of Souls,2,1999,13.13,#000000,https://cards.scryfall.io/normal/front/8/4/847340fb-9251-4439-b33b-f86bff507dcd.jpg?1783946074,Enchantment,Brian Snõddy
+Carrion,3,1996,3.11,#000000,https://cards.scryfall.io/normal/front/9/e/9e6c7750-bc3b-4790-bc9d-88e2cf16881e.jpg?1783947097,Instant,Geofrey Darrow
+Carrion Ants,4,1994,20.57,#000000,https://cards.scryfall.io/normal/front/c/b/cbc0b009-3951-4aa3-985a-97139882da7e.jpg?1783948069,Creature — Insect,Richard Thomas
+Carrionette,2,1997,1.66,#000000,https://cards.scryfall.io/normal/front/8/8/884e19fb-67a4-42d8-b163-720a99cb8506.jpg?1783946645,Creature — Skeleton,Pete Venters
+Carrion Feeder,1,2022,44.81,#000000,https://cards.scryfall.io/normal/front/c/0/c0e175cb-ffea-473f-8422-53273f263016.jpg?1783919210,Creature — Zombie,Junji Ito
+Case of the Stashed Skeleton,2,2024,0.34,#000000,https://cards.scryfall.io/normal/front/4/b/4b120cbe-f0af-46c5-863f-03ecadf0435c.jpg?1783912902,Enchantment — Case,Camille Alquier
+Catacomb Dragon,6,1996,3.53,#000000,https://cards.scryfall.io/normal/front/4/6/46daebe4-199e-4580-8a52-1aebc8492d8c.jpg?1783947097,Creature — Dragon,David O'Connor
+Cateran Overlord,7,1999,0.7,#000000,https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg?1783945955,Creature — Horror Mercenary,Michael Sutfin
+Cateran Slaver,6,1999,0.73,#000000,https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg?1783945954,Creature — Horror Mercenary,Carl Critchlow
+Cauldron Familiar,1,2024,3.06,#000000,https://cards.scryfall.io/normal/front/3/8/38afc2f2-29d2-413d-abee-d8ad9fa85dec.jpg?1783909217,Creature — Cat,Scott Buoncristiano
+Caustic Bronco,2,2024,0.35,#000000,https://cards.scryfall.io/normal/front/e/9/e9a268ba-c442-4fe4-90b4-2810c8474f4e.jpg?1783911835,Creature — Snake Horse Mount,Brent Hollowell
+Cavalier of Night,5,2019,9.1,#000000,https://cards.scryfall.io/normal/front/f/0/f03109b9-54a8-4d68-97c2-e42c7d5c2d41.jpg?1783932996,Creature — Elemental Knight,Viktor Titov
+Cecil- Dark Knight // Cecil- Redeemed Paladin,1,2025,0.75,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Knight // Legendary Creature — Human Knight,Josu Hernaiz
+Cemetery Desecrator,6,2021,0.34,#000000,https://cards.scryfall.io/normal/front/4/8/48da33b1-d59c-43f1-8e55-480096b674e5.jpg?1783924869,Creature — Zombie,Dan Murayama Scott
+Cemetery Reaper,3,2021,0.38,#000000,https://cards.scryfall.io/normal/front/9/0/9008e94a-cfec-473f-ae75-57586e45098d.jpg?1783925343,Creature — Zombie,Dave Allsop
+Cemetery Tampering,3,2024,0.36,#000000,https://cards.scryfall.io/normal/front/b/6/b6d4cf14-c43e-454b-ae76-3678617067f8.jpg?1783909621,Enchantment,Taras Susak
+Chainer- Dementia Master,5,2023,0.31,#000000,https://cards.scryfall.io/normal/front/1/8/186c30e6-2b84-415d-83e4-ecddaeb11ca1.jpg?1783915682,Legendary Creature — Human Minion,Mark Zug
+Champion of Dusk,5,2023,0.24,#000000,https://cards.scryfall.io/normal/front/5/f/5fa1674a-86cc-4fdf-8671-860b2bf5043d.jpg?1783913877,Creature — Vampire Knight,Josh Hass
+Champion of Stray Souls,6,2019,0.36,#000000,https://cards.scryfall.io/normal/front/f/0/f0efbddb-c076-4552-b417-3608e0696a77.jpg?1783932770,Creature — Skeleton Warrior,Aleksi Briclot
+Champion of the Perished,1,2021,0.6,#000000,https://cards.scryfall.io/normal/front/8/d/8d8e6941-ad6e-4d2f-93c0-be79e75bdf06.jpg?1783925622,Creature — Zombie,Kekai Kotaki
+Champion of the Weird,4,2026,0.21,#000000,https://cards.scryfall.io/normal/front/e/6/e600dd01-65ac-489c-a52a-decbc3a9a4f3.jpg?1783904467,Creature — Goblin Berserker,Lucas Graciano
+Chancellor of the Dross,7,2011,1.08,#000000,https://cards.scryfall.io/normal/front/e/e/eec6d85e-6263-44b4-a91f-d51585c561c2.jpg?1783941316,Creature — Phyrexian Vampire,Stephan Martiniere
+Changing Loyalty,2,2026,0.78,#000000,https://cards.scryfall.io/normal/front/5/c/5c2e30d4-98ab-46a7-87ab-1c36c43ab34a.jpg?1783903859,Enchantment — Aura,Nino Vecia
+Chaos Shrine's Black Crystal,4,2025,4.35,#000000,https://cards.scryfall.io/normal/front/4/1/417d0d15-4c90-45dc-86f8-4c17fc2dd3f4.jpg?1783904656,Legendary Artifact,David Rapoza
+Charnel Serenade,6,2024,0.28,#000000,https://cards.scryfall.io/normal/front/0/5/05a2477e-a9a2-49fb-86e6-53d3e153a965.jpg?1783913045,Sorcery,Alex Stone
+Charred Graverobber,3,2024,0.3,#000000,https://cards.scryfall.io/normal/front/7/b/7bbebce1-88d1-4002-8c28-746b0976d662.jpg?1783911966,Creature — Skeleton Mercenary,Matt Stewart
+Chittering Witch,4,2025,0.3,#000000,https://cards.scryfall.io/normal/front/7/e/7e361851-346e-4747-bbce-e2dc19e39b31.jpg?1783907093,Creature — Human Warlock,Winona Nelson
+Choice of Damnations,6,2005,18.42,#000000,https://cards.scryfall.io/normal/front/0/5/05939f15-2d95-47df-b66f-131c3e7ea95f.jpg?1783944159,Sorcery — Arcane,Greg Hildebrandt
+Chorale of the Void,4,2025,0.3,#000000,https://cards.scryfall.io/normal/front/7/3/7389fe88-f6ff-4497-a037-9ca283fb89e3.jpg?1783905969,Enchantment — Aura,Alix Branwyn
+Chronomancer,2,2022,1.47,#000000,https://cards.scryfall.io/normal/front/a/9/a960acea-3404-4834-9296-d6715add49af.jpg?1783920929,Artifact Creature — Necron Wizard,Alexey Kruglov
+Chthonian Nightmare,2,2024,0.48,#000000,https://cards.scryfall.io/normal/front/c/e/ce5dd2c1-b6e0-4914-b5c9-7dd451c29e22.jpg?1783911283,Enchantment,Josu Solano
+Citizen V- Helmut Zemo,3,2026,0.64,#000000,https://cards.scryfall.io/normal/front/4/c/4c2bdc18-9648-44a2-97dd-b0e03789d186.jpg?1783903065,Legendary Creature — Human Noble Villain,Toni Infante
+Clackbridge Troll,5,2019,0.59,#000000,https://cards.scryfall.io/normal/front/8/5/85929131-4df6-415c-b592-aefb2943c477.jpg?1783932641,Creature — Troll,Svetlin Velinov
+Cleaving Reaper,5,2021,0.3,#000000,https://cards.scryfall.io/normal/front/b/5/b59dadef-74e5-47c7-a3e0-51075ddb82b1.jpg?1783928123,Creature — Angel Berserker,Victor Adame Minguez
+Coercive Impetus,3,2026,0.33,#000000,https://cards.scryfall.io/normal/front/f/9/f98ca390-d2ea-41c8-93ed-57fcd22737d8.jpg?1783903858,Enchantment — Aura,Kieran Yanner
+Coffin Puppets,5,2000,0.16,#000000,https://cards.scryfall.io/normal/front/a/f/afcda8e4-d3dc-44f8-b277-b61fa261666b.jpg?1783945785,Creature — Zombie,Arnie Swekel
+Coiling Rebirth,5,2024,0.35,#000000,https://cards.scryfall.io/normal/front/9/6/96d5de3e-0440-4dd1-899c-ab40c0752343.jpg?1783910837,Sorcery,Rovina Cai
+Colfenor's Plans,4,2007,0.38,#000000,https://cards.scryfall.io/normal/front/f/8/f8d06368-d226-4089-84d4-950a3ebdfb15.jpg?1783942893,Enchantment,Darrell Riche
+Collective Brutality,2,2025,0.33,#000000,https://cards.scryfall.io/normal/front/a/e/ae35b6c5-3bfd-483e-9c85-58629b717d7f.jpg?1783908148,Sorcery,Johann Bodin
+Come Back Wrong,3,2024,0.35,#000000,https://cards.scryfall.io/normal/front/7/2/72ee3b45-aa4e-4c5b-a9e6-608bfbd93f8b.jpg?1783909485,Sorcery,David Auden Nash
+Command the Dreadhorde,6,2019,0.38,#000000,https://cards.scryfall.io/normal/front/d/e/de7ec307-45e0-4853-85fe-9ce859b188c2.jpg?1783933449,Sorcery,Daarken
+Concealing Curtains // Revealing Eye,1,2021,0.35,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Wall // Creature — Eye Horror,Brian Valeza
+Confront the Past,1,2021,0.23,#000000,https://cards.scryfall.io/normal/front/e/1/e1951763-be97-400c-aa95-6b101f47bddf.jpg?1783927369,Sorcery — Lesson,Kieran Yanner
+Conspiracy,5,1999,3.22,#000000,https://cards.scryfall.io/normal/front/4/1/411c9f22-2df0-4a63-b2be-fa02612a6ef8.jpg?1783945954,Enchantment,Jeff Easley
+Construct a Cosmic Cube,3,2026,0.48,#000000,https://cards.scryfall.io/normal/front/4/4/448de757-ac16-4529-b851-1a1331b821a5.jpg?1783902946,Enchantment — Plan,Eugene Maslovski
+Consume Spirit,2,2012,8.24,#000000,https://cards.scryfall.io/normal/front/f/2/f267137c-57f5-43b1-9a4b-98f2b84106b9.jpg?1783940438,Sorcery,Dan Murayama Scott
+Consume the Meek,5,2015,0.19,#000000,https://cards.scryfall.io/normal/front/c/9/c94dcaed-55da-41f4-a61f-2a79ef6c1459.jpg?1783938256,Instant,Richard Wright
+Consuming Vapors,4,2021,0.27,#000000,https://cards.scryfall.io/normal/front/7/b/7b6e74a3-f390-4ad2-93de-930af0e5585c.jpg?1783926222,Sorcery,Trevor Claxton
+Consumptive Goo,2,2003,0.52,#000000,https://cards.scryfall.io/normal/front/0/f/0f0f549f-6607-483a-9d89-2019ca9ef571.jpg?1783944881,Creature — Ooze,Carl Critchlow
+Contamination,3,1998,17.7,#000000,https://cards.scryfall.io/normal/front/8/6/86067dfe-65c3-4c96-bccd-b3915d6663f9.jpg?1783946347,Enchantment,Stephen Daniele
+Cordial Vampire,2,2023,1.93,#000000,https://cards.scryfall.io/normal/front/0/d/0d91e61d-e3bf-4ddc-9f01-18b1abe35a61.jpg?1783913876,Creature — Vampire,Winona Nelson
+Corpses of the Lost,3,2023,0.34,#000000,https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1783913781,Enchantment,Izzy
+Corpseweft,3,2015,0.15,#000000,https://cards.scryfall.io/normal/front/2/5/25cf24e7-2e6e-46e0-aedd-89e17953811c.jpg?1783938599,Enchantment,Nils Hamm
+Corrupt,6,2013,7.05,#000000,https://cards.scryfall.io/normal/front/a/4/a4ca5099-48d1-4581-9345-b906c2e5b894.jpg?1783940050,Sorcery,Alex Horley-Orlandelli
+Corrupt Official,5,1999,0.37,#000000,https://cards.scryfall.io/normal/front/5/c/5cb652fc-5a21-4e02-a776-a38fb41ad18c.jpg?1783945954,Creature — Human Minion,Greg Hildebrandt & Tim Hildebrandt
+Costly Plunder,2,2024,0.33,#000000,https://cards.scryfall.io/normal/front/5/4/549fb475-4d69-48ae-9da1-f05c21b375d2.jpg?1783911517,Instant,Ben Maier
+Court of Ambition,4,2020,5.4,#000000,https://cards.scryfall.io/normal/front/5/d/5deb0185-62b3-474b-83a1-25473fdae4fa.jpg?1783928844,Enchantment,Ravenna Tran
+Court of Locthwain,4,2023,6.67,#000000,https://cards.scryfall.io/normal/front/a/8/a8e1f698-1c04-4f31-aeaa-b796c5eb5070.jpg?1783914984,Enchantment,Julie Dillon
+Cover of Darkness,2,2002,21.28,#000000,https://cards.scryfall.io/normal/front/0/d/0d6d7d88-d82b-40f4-bf57-ec5d7c480689.jpg?1783945072,Enchantment,Kev Walker
+Coveted Prize,5,2020,0.29,#000000,https://cards.scryfall.io/normal/front/5/a/5afbc5d3-318f-4545-88d6-fc81e5466238.jpg?1783929381,Sorcery,Lie Setiawan
+Crabomination,6,2024,0.29,#000000,https://cards.scryfall.io/normal/front/f/3/f328d6e0-d808-4abe-b6a2-cc557b27c329.jpg?1783911283,Creature — Crab Demon,Nicholas Gregory
+Cramped Vents // Access Maze,11,2024,0.34,#000000,https://cards.scryfall.io/normal/front/7/b/7ba1e27e-ed0d-438c-9ec6-a48a04718512.jpg?1783909659,Enchantment — Room // Enchantment — Room,Arthur Yuan
+Cranial Extraction,4,2004,0.59,#000000,https://cards.scryfall.io/normal/front/a/8/a8cad7a3-777e-4c84-b404-5f504844ab3b.jpg?1783944317,Sorcery — Arcane,Dave Allsop
+Crimson Cowl- Master of Evil,3,2026,0.98,#000000,https://cards.scryfall.io/normal/front/5/8/58f35061-20d7-464a-a58d-8e07ed23fa27.jpg?1783903063,Legendary Creature — Human Villain,Miguel Mercado
+Crippling Fear,4,2023,2.87,#000000,https://cards.scryfall.io/normal/front/7/1/713a28c0-0d12-4c62-bc91-59c2ddfc9ef8.jpg?1783915437,Sorcery,Néstor Ossandón Leal
+Crossway Troublemakers,6,2023,0.34,#000000,https://cards.scryfall.io/normal/front/9/5/95ef4f86-9b96-4181-9442-44adce180984.jpg?1783913876,Creature — Vampire,Aaron J. Riley
+Crowded Crypt,3,2021,0.84,#000000,https://cards.scryfall.io/normal/front/3/d/3d6114bd-d5d3-441a-80a5-67eb7a355506.jpg?1783925378,Artifact,Jarel Threat
+Cruelclaw's Heist,2,2024,0.32,#000000,https://cards.scryfall.io/normal/front/c/a/cab4539a-0157-4cbe-b50f-6e2575df74e9.jpg?1783910836,Sorcery,Brian Valeza
+Cruel Entertainment,7,2016,8.28,#000000,https://cards.scryfall.io/normal/front/3/e/3e304424-4a50-43bb-aee0-e9f960583aac.jpg?1783937089,Sorcery,David Palumbo
+Cruel Reality,7,2017,2.9,#000000,https://cards.scryfall.io/normal/front/0/6/06a91cf5-4eab-4d9b-90bd-fb933bb00540.jpg?1783936510,Enchantment — Aura Curse,Kieran Yanner
+Cruel Sadist,1,2014,0.22,#000000,https://cards.scryfall.io/normal/front/a/3/a31c94f3-c45b-4ced-b523-15e80ae1a82d.jpg?1783939185,Creature — Human Assassin,Min Yum
+Cruel Somnophage // Can't Wake Up,2,2023,0.84,#d78f42,https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1783915066,Creature — Nightmare // Sorcery — Adventure,Jason A. Engle
+Cruel Tutor,3,1997,43.77,#000000,https://cards.scryfall.io/normal/front/6/c/6c05bfb5-dd36-44c5-a60d-43f7f8c68a6b.jpg?1783946830,Sorcery,Kev Walker
+Crux of Fate,5,2017,4.15,#000000,https://cards.scryfall.io/normal/front/1/1/11721b88-2654-482c-b9d4-80e54efdbf63.jpg?1783935910,Sorcery,Michael Komarck
+Crypt Angel,5,2000,1.34,#000000,https://cards.scryfall.io/normal/front/5/2/522ddc6f-ec13-4a70-8f4c-b3c846b102fd.jpg?1783945699,Creature — Angel,Todd Lockwood
+Cryptbreaker,1,2016,1.18,#000000,https://cards.scryfall.io/normal/front/6/2/629e37d1-c0f3-44f2-926e-41eb3687c1d9.jpg?1783937487,Creature — Zombie,Darek Zabrocki
+Cryptcaller Chariot,4,2025,0.44,#000000,https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg?1783907897,Artifact — Vehicle,Aaron Miller
+Cryptek,4,2022,0.79,#000000,https://cards.scryfall.io/normal/front/e/a/ea8483a2-9135-48d1-994d-9525d5ffcabb.jpg?1783920928,Artifact Creature — Necron Wizard,David Álvarez
+Crypt Ghast,4,2024,21.1,#000000,https://cards.scryfall.io/normal/front/6/0/60bebd79-f88c-44ef-8920-e19031bad1d6.jpg?1783913328,Creature — Spirit,Chris Rahn
+Culling the Weak,1,2026,9.79,#000000,https://cards.scryfall.io/normal/front/6/c/6c84aa77-bcb0-4a59-b94c-8cb9cbf6af76.jpg?1783903926,Instant,Aitor Sebastián
+Cultist of the Absolute,1,2022,0.33,#000000,https://cards.scryfall.io/normal/front/b/0/b0c7b4af-d521-4f4f-8910-7e05f2f60eb6.jpg?1783922764,Legendary Enchantment — Background,Artur Treffner
+Cunning Lethemancer,3,2008,7.54,#000000,https://cards.scryfall.io/normal/front/9/7/972891e6-6a23-40df-af22-adf8cd7ea582.jpg?1783942568,Creature — Human Wizard,Paul Bonner
+Cunning Rhetoric,3,2024,3.88,#000000,https://cards.scryfall.io/normal/front/4/a/4a163794-db93-4cf6-a2ea-1af288109dc1.jpg?1783911932,Enchantment,Chris Rallis
+Cursecloth Wrappings,4,2025,0.33,#000000,https://cards.scryfall.io/normal/front/d/5/d5803b32-4a81-46c2-9b10-3198a709611d.jpg?1783907896,Artifact,Dominik Mayer
+Cursed Monstrosity,5,2001,0.32,#000000,https://cards.scryfall.io/normal/front/8/d/8de97585-3d24-4e8d-8bf9-edd75ee88443.jpg?1783945248,Creature — Horror,Jeff Remmer
+Curse of Death's Hold,5,2011,0.97,#000000,https://cards.scryfall.io/normal/front/1/7/1774d0a8-1cd3-4582-ace0-1caff92af0e7.jpg?1783940958,Enchantment — Aura Curse,Clint Cearley
+Curse of Fool's Wisdom,6,2019,4.25,#000000,https://cards.scryfall.io/normal/front/9/b/9b77ded4-a8af-4065-8c4a-fd76e7cdcc59.jpg?1783932810,Enchantment — Aura Curse,Daarken
+Curse of Leeches // Leeching Lurker,3,2021,0.3,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Aura Curse // Creature — Leech Horror,Uriah Voth
+Curse of Misfortunes,5,2012,0.66,#000000,https://cards.scryfall.io/normal/front/c/5/c531d218-ff1c-4333-a19d-446d709b1e28.jpg?1783940833,Enchantment — Aura Curse,Terese Nielsen
+Curse of the Cabal,10,2006,2.68,#000000,https://cards.scryfall.io/normal/front/d/4/d4323aa6-a1fb-42ee-9634-3747129fde3b.jpg?1783943235,Sorcery,John Avon
+Curse of the Restless Dead,3,2021,4.2,#000000,https://cards.scryfall.io/normal/front/c/d/cdde244a-d2f4-44b3-badd-d6142785e25c.jpg?1783925377,Enchantment — Aura Curse,Brian Valeza
+Curse of Vengeance,1,2016,8.83,#000000,https://cards.scryfall.io/normal/front/2/2/22e7d0e3-a87c-414f-8f12-314083539a2a.jpg?1783937089,Enchantment — Aura Curse,Bastien L. Deharme
+Curtains' Call,6,2024,0.55,#000000,https://cards.scryfall.io/normal/front/9/8/9899d9c7-7c68-4d10-8249-5d1193f77030.jpg?1783911931,Instant,James Ryman
+Custodi Lich,5,2022,0.34,#000000,https://cards.scryfall.io/normal/front/5/d/5d77f50f-f63d-47bd-8bf9-01febee315fd.jpg?1783923270,Creature — Zombie Cleric,Bastien L. Deharme
+Cut of the Profits,2,2022,0.29,#000000,https://cards.scryfall.io/normal/front/8/0/80e86078-1629-40dc-88a9-102c543255b8.jpg?1783923136,Sorcery,Donato Giancola
+Dakmor Lancer,6,1999,0.5,#000000,https://cards.scryfall.io/normal/front/9/d/9d012ddf-abe1-4de9-89cb-78d82afb9e7b.jpg?1783946037,Creature — Human Knight,Chippy
+Dakmor Sorceress,6,1999,6.49,#000000,https://cards.scryfall.io/normal/front/e/8/e8e355d8-a142-4504-9a27-721b6140dc8a.jpg?1783946035,Creature — Human Wizard Sorcerer,Matthew D. Wilson
+Dalek Drone,5,2023,0.38,#000000,https://cards.scryfall.io/normal/front/b/a/ba77763c-b50c-4787-b352-68af16e4c741.jpg?1783914661,Artifact Creature — Dalek,Bartek Fedyczak
+Damn,2,2023,1.79,#d78f42,https://cards.scryfall.io/normal/front/8/4/84056124-1a6f-4274-bee2-74cf0debddb5.jpg?1783913875,Sorcery,Lucas Graciano
+Damnable Pact,2,2022,1.46,#000000,https://cards.scryfall.io/normal/front/1/7/17fa6dc2-5a2e-4758-9ca4-e020eb032d74.jpg?1783923269,Sorcery,Zack Stella
+Damnation,4,2022,20.48,#000000,https://cards.scryfall.io/normal/front/d/3/d3c0aac5-b9f1-4446-bfea-3e1dd1cf1f2f.jpg?1783921909,Sorcery,Kev Walker
+Damocles Base- Sword of Kang,5,2026,0.41,#000000,https://cards.scryfall.io/normal/front/8/9/89936964-7131-4ebf-b956-9692659866c1.jpg?1783903287,Legendary Artifact — Vehicle,Anthony Devine
+Danse Macabre,5,2021,2.56,#000000,https://cards.scryfall.io/normal/front/5/1/5151b81b-6d10-40de-9e65-89923e4c03d9.jpg?1783926251,Sorcery,Randy Vargas
+Daring Fiendbonder,4,2020,0.9,#000000,https://cards.scryfall.io/normal/front/2/7/27dd910a-a3ca-46ac-9350-f2a22496f4e6.jpg?1783931218,Creature — Human Warlock,Yongjae Choi
+Dark Confidant,2,2025,3.76,#000000,https://cards.scryfall.io/normal/front/2/5/2520ab23-a068-4462-b261-2754409b4108.jpg?1783906622,Creature — Human Wizard,Immanuela Crovius
+Dark Deal,3,2024,13.16,#000000,https://cards.scryfall.io/normal/front/0/e/0e234227-d91e-4049-ad4a-3beca6b89023.jpg?1783909719,Sorcery,Tyler Jacobson
+Darkest Hour,1,2001,4.58,#000000,https://cards.scryfall.io/normal/front/a/e/aeeb0f91-2084-448a-8226-95d7c87dd6bb.jpg?1783945509,Enchantment,Ciruelo
+Dark Hatchling,6,2022,0.26,#000000,https://cards.scryfall.io/normal/front/1/3/133e9654-74a3-4997-b371-7f36b5d9c4f1.jpg?1783922456,Creature — Horror,Brad Rigney
+Dark Impostor,3,2021,0.47,#000000,https://cards.scryfall.io/normal/front/b/d/bd9384c2-1b55-4da3-91f1-db3d65e98a85.jpg?1783924955,Creature — Vampire Assassin,Johannes Voss
+Darkness,1,2025,10.77,#000000,https://cards.scryfall.io/normal/front/e/f/ef4c2c08-0a4d-4588-bc35-078da7120937.jpg?1783905795,Instant,Wojtek Łebski
+Dark Petition,5,2015,2.76,#000000,https://cards.scryfall.io/normal/front/e/9/e9df9c5e-7087-42b2-9001-c89d40a66c68.jpg?1783938344,Sorcery,Igor Kieryluk
+Dark Prophecy,3,2013,6.99,#000000,https://cards.scryfall.io/normal/front/e/c/ecf82c3b-7a35-43dd-8bf3-ebc68dc1b8fc.jpg?1783939925,Enchantment,Scott Chou
+Dark Salvation,1,2021,0.59,#000000,https://cards.scryfall.io/normal/front/1/f/1fc4eec7-ce6c-4b63-aca8-fa409cc5ee5a.jpg?1783925341,Sorcery,Cynthia Sheppard
+Darkstar Augur,3,2024,1.01,#000000,https://cards.scryfall.io/normal/front/1/c/1c603751-1e2b-4c8e-a8d2-5c0876e7254f.jpg?1783910836,Creature — Bat Warlock,Aurore Folny
+Dark Suspicions,4,2001,0.55,#000000,https://cards.scryfall.io/normal/front/d/5/d518e2fd-7767-43d7-92e3-62a4a465154c.jpg?1783945622,Enchantment,Matt Cavotta
+Dark Tutelage,3,2010,0.24,#000000,https://cards.scryfall.io/normal/front/9/e/9ec3dd9f-3969-4fd7-97f7-e9868eb19a64.jpg?1783941817,Enchantment,James Ryman
+Dauthi Voidwalker,2,2025,5.16,#000000,https://cards.scryfall.io/normal/front/3/5/3573b9a2-7911-475c-8ae7-25bd0dbb7159.jpg?1783907090,Creature — Dauthi Rogue,Sidharth Chaturvedi
+Dawnhand Dissident,1,2026,0.35,#000000,https://cards.scryfall.io/normal/front/6/a/6ac1f765-f348-4813-88dc-26376e0f3f33.jpg?1783904467,Creature — Elf Warlock,Jacob Walker
+Dawn of the Dead,5,2002,2.15,#000000,https://cards.scryfall.io/normal/front/b/a/baabadd3-3fc1-4c9a-ad3b-c79d60fb3390.jpg?1783945158,Enchantment,Pete Venters
+Daxos's Torment,4,2015,0.4,#000000,https://cards.scryfall.io/normal/front/8/8/885284bd-492e-4fc1-921a-a55a069c3fa9.jpg?1783938113,Enchantment,Jakub Kasper
+Day of Black Sun,2,2025,1.06,#000000,https://cards.scryfall.io/normal/front/d/0/d0e24797-3e45-4c2b-b4b0-1ef44d42eaee.jpg?1783904975,Sorcery,Matteo Bassini
+Deadeye Tracker,1,2017,0.33,#000000,https://cards.scryfall.io/normal/front/8/4/848902db-7a10-4754-b50a-57a9e845705a.jpg?1783935762,Creature — Human Pirate,Deruchenko Alexander
+Deadly Cover-Up,5,2024,0.41,#000000,https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg?1783912899,Sorcery,Sam Guay
+Deadly Dispute,2,2026,1.14,#000000,https://cards.scryfall.io/normal/front/e/0/e0f658ff-323e-4e32-beaa-1d5753b4f081.jpg?1783903315,Instant,Mark Brooks
+Deadly Embrace,5,2025,0.27,#000000,https://cards.scryfall.io/normal/front/a/1/a11cb85c-85dd-435c-8303-4d0d18bdb1e9.jpg?1783906435,Sorcery,Lius Lasahido
+Deadly Rollick,4,2023,27.37,#000000,https://cards.scryfall.io/normal/front/0/e/0e13f735-54fa-42b6-aea4-ced33811d7d4.jpg?1783915679,Instant,Izzy
+Deadly Tempest,6,2021,0.8,#000000,https://cards.scryfall.io/normal/front/5/f/5f673d4a-76fa-4e9d-b7f6-299d80c55cb5.jpg?1783927555,Sorcery,Cliff Childs
+Dead Man's Chest,2,2021,0.39,#000000,https://cards.scryfall.io/normal/front/7/a/7a0b60a2-50de-4328-85dc-040bf8a4dac9.jpg?1783926218,Enchantment — Aura,Jason A. Engle
+Dead of Winter,3,2019,0.39,#000000,https://cards.scryfall.io/normal/front/f/4/f480df6d-e227-4ccb-ad6d-a4ad48a360ad.jpg?1783933131,Sorcery,Zack Stella
+Death Baron,3,2024,5.32,#000000,https://cards.scryfall.io/normal/front/3/4/34a27142-cf45-4164-9e10-373e5c8bf7c6.jpg?1783908959,Creature — Zombie Wizard,Nils Hamm
+Deathbringer Regent,7,2022,0.34,#000000,https://cards.scryfall.io/normal/front/8/0/8006515a-69de-4713-8318-79c0ef78a6d1.jpg?1783923269,Creature — Dragon,Adam Paquette
+Death Cloud,3,2013,3.83,#000000,https://cards.scryfall.io/normal/front/b/0/b0870b88-2794-4646-9f51-f3af03bc8bc8.jpg?1783939991,Sorcery,Stephen Tappin
+Death in Heaven,4,2023,0.31,#000000,https://cards.scryfall.io/normal/front/9/6/96c55c73-eed0-433c-b1a4-c2edae06a77f.jpg?1783914658,Enchantment — Saga,Justyna Dura
+Deathlace,1,1995,0.38,#000000,https://cards.scryfall.io/normal/front/2/3/237e37fb-383d-432c-8ac3-1332096567db.jpg?1783947845,Instant,Sandra Everingham
+Death Match,4,2002,0.68,#000000,https://cards.scryfall.io/normal/front/1/4/143e9057-267a-4c78-b72a-4f8018b627a8.jpg?1783945071,Enchantment,rk post
+Death Pit Offering,4,2003,0.37,#000000,https://cards.scryfall.io/normal/front/f/6/f6404e26-353a-478e-81db-03499be8e24b.jpg?1783944769,Enchantment,Pete Venters
+Death's Shadow,1,2020,1.31,#000000,https://cards.scryfall.io/normal/front/5/5/5526ff6e-c079-4ad4-ac8d-5e26ecacf50d.jpg?1783930184,Creature — Avatar,Howard Lyon
+Death Tyrant,5,2021,2.4,#000000,https://cards.scryfall.io/normal/front/b/9/b9e508e9-c190-4db2-a278-9dbb09515ae2.jpg?1783926251,Creature — Beholder Skeleton,Nicholas Gregory
+Death Wish,3,2002,0.72,#000000,https://cards.scryfall.io/normal/front/7/b/7bf134c9-a50d-4eff-a5a8-7cfe6a010080.jpg?1783945123,Sorcery,Jeff Easley
+Decaying Soil,3,2001,0.52,#000000,https://cards.scryfall.io/normal/front/f/2/f2bea0ec-52e0-4f45-a445-8805dc6ed596.jpg?1783945248,Enchantment,Don Hazeltine
+Decorum Dissertation,5,2026,5.89,#000000,https://cards.scryfall.io/normal/front/f/4/f4ab2d9b-c73d-478d-aac7-4d3bb24296d2.jpg?1783903683,Sorcery — Lesson,Mila Pesic
+Decree of Pain,8,2024,0.31,#000000,https://cards.scryfall.io/normal/front/b/d/bd594aeb-f5cc-4435-8ea8-c35c5824b58c.jpg?1783909622,Sorcery,Mathias Kollros
+Deep-Cavern Bat,2,2025,0.96,#000000,https://cards.scryfall.io/normal/front/2/f/2feace11-77aa-4cde-a7ae-8310f2192b0d.jpg?1783907485,Creature — Bat,Maxime Minard
+Defiant Bloodlord,7,2021,0.42,#000000,https://cards.scryfall.io/normal/front/4/e/4e7ae077-52c7-49a1-a61a-61e50b494616.jpg?1783927554,Creature — Vampire,Craig J Spearing
+Defile,1,2024,4.37,#000000,https://cards.scryfall.io/normal/front/b/4/b48bd5d8-65f7-42a6-9910-556ad12e8899.jpg?1783909709,Instant,Cabrol
+Defiler of Flesh,4,2022,0.47,#000000,https://cards.scryfall.io/normal/front/6/1/61a4dd11-6166-4a54-95c0-728c623d0fbc.jpg?1783921334,Creature — Phyrexian Horror,Mathias Kollros
+Defiling Daemogoth,5,2026,0.8,#000000,https://cards.scryfall.io/normal/front/2/c/2cde79eb-91c3-4a42-a2d3-e733e3b56846.jpg?1783903860,Creature — Demon,Quintin Gleim
+Deliver Unto Evil,3,2019,0.31,#000000,https://cards.scryfall.io/normal/front/6/7/67aa7104-7acc-4827-b763-ac053c99baab.jpg?1783933447,Sorcery,Seb McKinnon
+Delraich,7,1999,0.86,#000000,https://cards.scryfall.io/normal/front/d/a/da64094f-df6e-4c43-b4ae-03aab6b92816.jpg?1783945953,Creature — Horror,Todd Lockwood
+Deluge of Doom,3,2024,0.26,#000000,https://cards.scryfall.io/normal/front/9/4/948927b2-087a-4f57-844e-68fc8ab01bc0.jpg?1783909659,Sorcery,Nereida
+Demonic Bargain,3,2021,0.3,#000000,https://cards.scryfall.io/normal/front/8/0/80c3741e-cf04-4aa2-a6a9-ce19f043b22c.jpg?1783924868,Sorcery,Sam Guay
+Demonic Collusion,5,2006,3.41,#000000,https://cards.scryfall.io/normal/front/f/1/f1a68a28-05fa-4c6e-896d-ddb9aea3a38d.jpg?1783943234,Sorcery,Jim Nelson
+Demonic Consultation,1,2025,8.24,#000000,https://cards.scryfall.io/normal/front/4/f/4f2f0fda-592f-4420-9703-defa07ffa2dc.jpg?1783905117,Instant,Edward Steed
+Demonic Counsel,2,2024,2.65,#000000,https://cards.scryfall.io/normal/front/f/f/ff79c845-4115-4fbf-b20f-37470f2bf7fb.jpg?1783909484,Sorcery,Babs Webb
+Demonic Covenant,6,2024,0.35,#000000,https://cards.scryfall.io/normal/front/9/0/90e9b488-37fd-42db-b0f2-b6c5a15a6e36.jpg?1783909658,Kindred Enchantment — Demon,L.A. Draws
+Demonic Embrace,3,2020,0.34,#000000,https://cards.scryfall.io/normal/front/5/6/56149192-ddc1-45a4-b7aa-be311da5fe8e.jpg?1783930711,Enchantment — Aura,Sidharth Chaturvedi
+Demonic Junker,7,2025,0.37,#000000,https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg?1783907896,Artifact — Vehicle,Stephan Martiniere
+Demonic Pact,4,2024,0.3,#000000,https://cards.scryfall.io/normal/front/5/b/5b0b7242-df91-48cf-bf4e-b68306c9965f.jpg?1783908933,Enchantment,Manuel Castañón
+Demonic Rising,5,2012,0.21,#000000,https://cards.scryfall.io/normal/front/a/2/a2136a82-b535-47f6-9eee-5b7585ac5cf1.jpg?1783940702,Enchantment,Trevor Claxton
+Demonic Tutor,2,2023,75.5,#000000,https://cards.scryfall.io/normal/front/a/2/a24b4cb6-cebb-428b-8654-74347a6a8d63.jpg?1783915679,Sorcery,Zack Stella
+Demonlord Belzenlok,6,2023,0.47,#000000,https://cards.scryfall.io/normal/front/b/0/b07114d8-40b3-4102-8d70-e3ed94a7f515.jpg?1783915680,Legendary Creature — Elder Demon,Tyler Jacobson
+Demonlord of Ashmouth,4,2012,0.28,#000000,https://cards.scryfall.io/normal/front/7/8/785da9a3-09af-45aa-bc04-4ab69cfb2ba4.jpg?1783940701,Creature — Demon,Lucas Graciano
+Demon of Catastrophes,4,2018,0.33,#000000,https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg?1783934573,Creature — Demon,Sidharth Chaturvedi
+Demon of Dark Schemes,6,2016,1.4,#000000,https://cards.scryfall.io/normal/front/9/9/99c99736-5c9c-4d2f-946d-05606fcdd039.jpg?1783937212,Creature — Demon,Daarken
+Demon of Death's Gate,9,2010,2.49,#000000,https://cards.scryfall.io/normal/front/5/7/57fab4fc-c8de-47ef-a717-3adb58c2f5b6.jpg?1783941817,Creature — Demon,Vance Kovacs
+Demon of Fate's Design,6,2024,0.43,#000000,https://cards.scryfall.io/normal/front/0/d/0d3668fe-78d9-4c2c-8c83-5cace9d39e03.jpg?1783909621,Enchantment Creature — Demon,Fajareka Setiawan
+Demon of Loathing,7,2020,0.49,#000000,https://cards.scryfall.io/normal/front/5/7/57564f6f-7c99-4325-8a0e-22342e73767b.jpg?1783931489,Creature — Demon,Tomasz Jedruszek
+Demon of Wailing Agonies,5,2014,1.8,#000000,https://cards.scryfall.io/normal/front/a/c/ace249fc-0d05-4132-8c0c-4abdc3b42119.jpg?1783938871,Creature — Demon,Dave Kendall
+Derelor,4,1999,0.39,#000000,https://cards.scryfall.io/normal/front/5/3/530043ad-d4bf-4fb0-b6e0-f8a744968cfc.jpg?1783946187,Creature — Thrull,Anson Maddocks
+Descent into Madness,5,2012,0.34,#000000,https://cards.scryfall.io/normal/front/f/a/fa016bb7-ad8b-40d5-90db-412a9cf19e4e.jpg?1783940701,Enchantment,Anthony Francisco
+Desecration Demon,4,2024,0.18,#000000,https://cards.scryfall.io/normal/front/5/2/52bf6460-0df6-4dd3-8af8-df728683bcaa.jpg?1783908930,Creature — Demon,Jason Chan
+Desmond Miles,2,2024,0.44,#000000,https://cards.scryfall.io/normal/front/c/9/c9523cd1-c3cf-4745-af09-77c1a83ac86f.jpg?1783910981,Legendary Creature — Human Assassin,Julia Vasilyeva
+Desolation Angel,5,2001,3.68,#d78f42,https://cards.scryfall.io/normal/front/4/4/445127d4-8afb-47cf-b2a1-564540b1fdae.jpg?1783945350,Creature — Angel,Brom
+Desperate Plea,2,2025,0.3,#000000,https://cards.scryfall.io/normal/front/b/4/b42b4b0e-39f6-4f93-a358-9bcec8d13b65.jpg?1783904827,Sorcery — Lesson,Shiyu
+Desperate Research,2,2000,0.54,#000000,https://cards.scryfall.io/normal/front/6/a/6a42ac7e-4a27-488c-a2e7-338b18103b02.jpg?1783945698,Sorcery,Ron Spencer
+Despoiler of Souls,2,2016,0.17,#000000,https://cards.scryfall.io/normal/front/9/f/9f1fb659-70fe-4d8a-ba2c-07ab0d75c218.jpg?1783937263,Creature — Horror,Greg Staples
+Devouring Strossus,8,2000,0.75,#000000,https://cards.scryfall.io/normal/front/0/6/064f013f-e74f-419d-8d17-7748bd91885e.jpg?1783945696,Creature — Phyrexian Horror,D. Alexander Gregory
+Devouring Sugarmaw // Have for Dinner,4,2023,0.24,#d78f42,https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1783915066,Creature — Horror // Instant — Adventure,Nino Vecia
+Diabolic Intent,2,2022,17.73,#000000,https://cards.scryfall.io/normal/front/d/7/d72ab698-de67-4ca8-8e42-b05346bf52fa.jpg?1783920094,Sorcery,Dan Murayama Scott
+Diabolic Revelation,5,2012,10.22,#000000,https://cards.scryfall.io/normal/front/1/4/145d6d7b-1e87-47b7-baf3-d201458ad996.jpg?1783940497,Sorcery,Raymond Swanland
+Diabolic Tutor,4,2024,9.98,#000000,https://cards.scryfall.io/normal/front/d/f/df6ba63e-0168-45e4-abf3-f7a5b87a4b85.jpg?1783911044,Sorcery,Leonardo Santanna
+Dictate of Erebos,5,2014,17.95,#000000,https://cards.scryfall.io/normal/front/9/f/9f06db70-95f9-41eb-8e5f-8bc56fd34c09.jpg?1783939437,Enchantment,Michael C. Hayes
+Dimension X Pizzasaur,4,2026,0.3,#000000,https://cards.scryfall.io/normal/front/f/e/fe4ab58f-3fb5-45fa-8ea1-794efa6f7da9.jpg?1783904336,Artifact Creature — Food Alien Mutant,Xavier Ribeiro
+Dire Fleet Poisoner,2,2018,0.44,#000000,https://cards.scryfall.io/normal/front/8/8/88273b1e-b33b-44d3-8777-4e78a04eed65.jpg?1783935313,Creature — Human Pirate,Ben Maier
+Dire Fleet Ravager,5,2024,0.36,#000000,https://cards.scryfall.io/normal/front/0/d/0d114e88-c5bd-416d-b9f1-25be1432c98c.jpg?1783911931,Creature — Orc Pirate Wizard,Bram Sels
+Diregraf Colossus,3,2021,5.82,#000000,https://cards.scryfall.io/normal/front/0/2/02351d67-2d73-43e3-82f7-5277c532d7ac.jpg?1783925341,Creature — Zombie Giant,Vincent Proce
+Dirge Bat,4,2020,0.33,#000000,https://cards.scryfall.io/normal/front/5/9/59677c76-8148-4b6f-95b0-0e3ccf137a3f.jpg?1783931062,Creature — Bat,Paul Scott Canavan
+Disciple of Bolas,4,2025,0.38,#000000,https://cards.scryfall.io/normal/front/0/1/01ea8333-38a8-4b7b-9f03-c5534df28353.jpg?1783907090,Creature — Human Wizard,Slawomir Maniak
+Discordant Dirge,5,1998,0.51,#000000,https://cards.scryfall.io/normal/front/d/4/d48e753c-ba11-4aa3-9a73-584f8a7538f5.jpg?1783946345,Enchantment,Carl Critchlow
+Discreet Retreat,4,2024,0.34,#000000,https://cards.scryfall.io/normal/front/b/2/b221b4d0-7d9f-45bf-8bcd-ce0cea01abdf.jpg?1783911966,Enchantment — Aura,Ben Wootten
+Dismember,3,2026,3.16,#000000,https://cards.scryfall.io/normal/front/9/4/94c131d2-6b55-456c-a30d-e5ffb6d5efd7.jpg?1783903925,Instant,Matthew G. Lewis
+Dispossess,3,2017,0.13,#000000,https://cards.scryfall.io/normal/front/4/e/4eb88be3-f790-45d7-a6d1-c78f6ba00208.jpg?1783936508,Sorcery,Mark Behm
+Divining Witch,2,2000,0.86,#000000,https://cards.scryfall.io/normal/front/b/e/be981eef-9dd2-4233-82c9-03f9f2e82c59.jpg?1783945828,Creature — Human Spellshaper,Donato Giancola
+Dockside Chef,1,2024,8.1,#000000,https://cards.scryfall.io/normal/front/6/9/697fcd59-1ad7-439f-8307-abe92c457b05.jpg?1783912022,Enchantment Creature — Human Citizen,Phoebe Wahl
+Doctor Doom,6,2026,3.75,#000000,https://cards.scryfall.io/normal/front/9/b/9b1f213a-e1d4-4a0f-954b-c83915698d98.jpg?1783902944,Legendary Creature — Human Scientist Villain,David Palumbo
+Doctor Doom- Unrivaled,4,2026,60.32,#000000,https://cards.scryfall.io/normal/front/2/9/2973e855-fe93-41a1-a62e-4699ef2c3d1d.jpg?1783903062,Legendary Creature — Human Sorcerer Villain,Vilhelmas Banys
+Dogged Detective,2,2024,0.24,#000000,https://cards.scryfall.io/normal/front/5/7/57d1f729-0d7c-4122-9bca-f3b08cf6fe4f.jpg?1783913007,Creature — Human Rogue,Caroline Gariba
+Doom Blade,2,2024,4.91,#000000,https://cards.scryfall.io/normal/front/3/d/3da9358b-cfe4-4e95-9a9e-a236d6373dcf.jpg?1783911476,Instant,Cynthia Sheppard
+Doomed Necromancer,3,2021,0.36,#000000,https://cards.scryfall.io/normal/front/2/d/2d3225e8-9902-4826-9cb3-68ecfaebb1e9.jpg?1783926219,Creature — Human Cleric Mercenary,Volkan Baǵa
+Doom Reigns Supreme,2,2026,0.34,#000000,https://cards.scryfall.io/normal/front/9/b/9b99894b-c774-45c2-9ee9-4d6a8e7522f5.jpg?1783902944,Enchantment — Plan,Alexander Gering
+Doomsday,3,2026,2.99,#000000,https://cards.scryfall.io/normal/front/7/2/72cd296e-e550-46bf-9378-586a24c9b2a7.jpg?1783903013,Sorcery,David Palumbo
+Doomsday Confluence,1,2023,0.34,#000000,https://cards.scryfall.io/normal/front/a/4/a4e86622-6f30-41b2-87d0-d345110e2387.jpg?1783914657,Sorcery,Dominik Mayer
+Doomsday Excruciator,6,2024,0.96,#000000,https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg?1783909483,Creature — Demon,Denys Tsiperko
+Doomwake Giant,5,2026,0.32,#000000,https://cards.scryfall.io/normal/front/0/b/0be3f848-ba01-4890-a3a1-ed0dfb564632.jpg?1783903786,Enchantment Creature — Giant,Kev Walker
+Doom Weaver,6,2021,2.77,#000000,https://cards.scryfall.io/normal/front/0/8/08c79a77-810d-4ee2-8afc-18ddfba41ad1.jpg?1783924996,Creature — Spider Horror,Helge C. Balzer
+Doom Whisperer,5,2024,5.79,#000000,https://cards.scryfall.io/normal/front/e/8/e8aabcaf-0968-402f-bc9f-289756e4d4b7.jpg?1783913007,Creature — Nightmare Demon,Vincent Proce
+Do or Die,2,2000,8.67,#000000,https://cards.scryfall.io/normal/front/0/5/05f63cd9-e82b-4cf8-b8ce-f0aa0157692b.jpg?1783945696,Sorcery,Christopher Moeller
+Drag to the Bottom,4,2022,0.23,#000000,https://cards.scryfall.io/normal/front/9/d/9d243099-94b1-4571-96af-4c5a34241911.jpg?1783921333,Sorcery,Nino Is
+Drana- Kalastria Bloodchief,5,2017,0.56,#000000,https://cards.scryfall.io/normal/front/2/c/2c58ce5e-b038-4376-a5f4-9849baa255b9.jpg?1783935907,Legendary Creature — Vampire Shaman,Mike Bierek
+Drana- Liberator of Malakir,3,2023,0.64,#000000,https://cards.scryfall.io/normal/front/0/8/0850b41d-3589-40cd-ae22-cc5b4ddee1c4.jpg?1783913874,Legendary Creature — Vampire Ally,Mike Bierek
+Drana's Chosen,4,2016,0.2,#000000,https://cards.scryfall.io/normal/front/1/8/189abe2f-5899-438b-9f54-3c98e50f037a.jpg?1783937912,Creature — Vampire Shaman Ally,Deruchenko Alexander
+Drana- the Last Bloodchief,5,2020,1.68,#000000,https://cards.scryfall.io/normal/front/5/c/5cd4154e-7681-444b-a0f2-33e887791ba7.jpg?1783929379,Legendary Creature — Vampire Cleric,Tyler Jacobson
+Draugr Necromancer,4,2021,0.34,#000000,https://cards.scryfall.io/normal/front/7/6/76d8e0ff-e720-41ca-af69-35585a2d7ae2.jpg?1783928251,Snow Creature — Zombie Cleric,David Rapoza
+Dread,6,2007,8.17,#000000,https://cards.scryfall.io/normal/front/9/b/9b608658-9150-439b-b0a0-4a994722b95c.jpg?1783942892,Creature — Elemental Incarnation,Matt Cavotta
+Dread Cacodemon,10,2017,4.57,#000000,https://cards.scryfall.io/normal/front/2/5/25344729-19a5-496f-8e6f-ce7b69afdc68.jpg?1783936285,Creature — Demon,Izzy
+Dread Charge,4,1997,0.72,#000000,https://cards.scryfall.io/normal/front/e/d/ed0ca934-6989-415b-8816-7c66d22b4707.jpg?1783946829,Sorcery,Ted Naifeh
+Dreadfeast Demon,7,2021,0.4,#000000,https://cards.scryfall.io/normal/front/2/6/269199ea-2106-4299-ade0-10cce1320434.jpg?1783924865,Creature — Demon,Andrew Mar
+Dreadhorde Invasion,2,2023,1.12,#000000,https://cards.scryfall.io/normal/front/2/4/241a6a3b-8809-4d22-bf1e-c4620c609aba.jpg?1783915436,Enchantment,Stanton Feng
+Dread Presence,4,2019,2.26,#000000,https://cards.scryfall.io/normal/front/0/4/0430db1a-5cad-4444-ba93-57fb32e65606.jpg?1783932995,Creature — Nightmare,Anthony Palumbo
+Dread Shade,3,2018,0.28,#000000,https://cards.scryfall.io/normal/front/4/6/46b8b1d7-9d2b-4943-bb3b-238a6333ce93.jpg?1783935009,Creature — Shade,G-host Lee
+Dread Slaver,5,2012,0.26,#000000,https://cards.scryfall.io/normal/front/3/d/3d8a3abd-a4a2-48e6-b709-1c0240a76c5e.jpg?1783940701,Creature — Zombie Horror,Dave Kendall
+Dread Summons,2,2024,0.19,#000000,https://cards.scryfall.io/normal/front/d/f/dfb5dd33-6e5b-4d78-92fa-678c9f01c606.jpg?1783908931,Sorcery,Izzy
+Dread Wanderer,1,2017,0.28,#000000,https://cards.scryfall.io/normal/front/3/4/343fc82d-7d10-4489-8f7e-9995322114e2.jpg?1783936506,Creature — Zombie Jackal,Josh Hass
+Dread Wight,5,1995,0.86,#000000,https://cards.scryfall.io/normal/front/6/5/65d332e2-4b2d-4131-84f7-862cb138c477.jpg?1783947504,Creature — Zombie,Daniel Gelon
+Dream Devourer,2,2021,1.81,#000000,https://cards.scryfall.io/normal/front/f/f/ff1d88a6-a74d-44b5-b7a8-866e866807f1.jpg?1783928250,Creature — Demon Cleric,David Rapoza
+Dreamstealer,3,2017,0.28,#000000,https://cards.scryfall.io/normal/front/5/c/5c4fcde3-03c9-43e6-a34b-29f6ce44e7c4.jpg?1783936042,Creature — Human Wizard,Yongjae Choi
+Dredge the Mire,4,2020,0.36,#000000,https://cards.scryfall.io/normal/front/f/5/f57b4b40-bd46-4859-89f0-fa0bd04cc6e9.jpg?1783931216,Sorcery,Lie Setiawan
+Dregs of Sorrow,5,2014,0.69,#000000,https://cards.scryfall.io/normal/front/3/c/3c004cd1-9190-4356-ad68-5012c7ef63de.jpg?1783938843,Sorcery,Thomas Gianni
+Drinker of Sorrow,3,2003,2.83,#000000,https://cards.scryfall.io/normal/front/2/b/2bc8758b-68cc-45ab-85d0-b870cef7dd85.jpg?1783944916,Creature — Horror,Carl Critchlow
+Drivnod- Carnage Dominus,5,2023,6.99,#000000,https://cards.scryfall.io/normal/front/6/b/6bc26bca-c4d8-4e8b-a96a-9529fc2daed7.jpg?1783918048,Legendary Creature — Phyrexian Horror,Bogdan Rezunenko
+Dross Harvester,3,2022,0.32,#000000,https://cards.scryfall.io/normal/front/3/5/35f77a00-1880-416c-813b-c6a870dd5f58.jpg?1783922451,Creature — Horror,Michael Sutfin
+Dusk Legion Sergeant,2,2023,0.29,#000000,https://cards.scryfall.io/normal/front/5/b/5bfc9243-7aec-48e6-9f3b-1bbbb5370063.jpg?1783913913,Creature — Vampire Soldier,Igor Kieryluk
+Dusk Urchins,3,2026,0.27,#000000,https://cards.scryfall.io/normal/front/f/c/fce69f5c-c4c4-4c8b-aa29-8cc8a84587d1.jpg?1783904559,Creature — Ouphe,Darrell Riche
+Dying to Serve,3,2021,0.4,#000000,https://cards.scryfall.io/normal/front/c/2/c2ea16cd-801e-478a-b924-5431582b70d1.jpg?1783924866,Enchantment,Steven Belledin
+Earwig Squad,5,2013,0.48,#000000,https://cards.scryfall.io/normal/front/c/1/c12759ab-97c7-406a-bf57-eec74839f8f6.jpg?1783939990,Creature — Goblin Rogue,Warren Mahy
+Eastern Paladin,4,2003,0.4,#000000,https://cards.scryfall.io/normal/front/d/7/d75f7d29-9c73-4b5e-a6fd-5608bb737278.jpg?1783944764,Creature — Phyrexian Zombie Knight,Carl Critchlow
+Eater of Hope,7,2021,0.2,#000000,https://cards.scryfall.io/normal/front/a/7/a7c62113-48c1-47ae-8ede-c05c1c914c3b.jpg?1783925339,Creature — Demon,Mathias Kollros
+Eat to Extinction,4,2020,0.34,#000000,https://cards.scryfall.io/normal/front/a/0/a0fae55a-6edd-42ea-b909-ccc39a64a0ed.jpg?1783931568,Instant,Vincent Proce
+Ebonblade Reaper,3,2002,6.94,#000000,https://cards.scryfall.io/normal/front/1/6/16ebef2c-8bb2-4816-a628-0062f95e512e.jpg?1783945070,Creature — Human Cleric,Wayne England
+Ebondeath- Dracolich,4,2021,3.97,#000000,https://cards.scryfall.io/normal/front/e/6/e6b3f460-92ba-4af0-aad9-cf86615d4177.jpg?1783926497,Legendary Creature — Zombie Dragon,Lars Grant-West
+Eddie Brock // Venom- Lethal Protector,3,2025,3.0,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Hero Villain // Legendary Creature — Symbiote Hero Villain,Greg Staples
+Egon- God of Death // Throne of Death,3,2021,0.38,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact,Jason A. Engle
+Eirdu- Carrier of Dawn // Isilu- Carrier of Twilight,5,2026,2.6,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elemental God // Legendary Creature — Elemental God,Lucas Graciano
+Elbrus- the Binding Blade // Withengar Unbound,7,2012,9.6,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact — Equipment // Legendary Creature — Demon,Eric Deschamps
+Elder Brain,7,2022,0.75,#000000,https://cards.scryfall.io/normal/front/b/8/b82a13bf-da32-4c12-a9dd-271d8ca45c21.jpg?1783922764,Creature — Horror,Daarken
+Eldritch Pact,7,2022,0.35,#000000,https://cards.scryfall.io/normal/front/d/5/d578bdc3-1edf-4267-b612-2236b54329c6.jpg?1783922764,Sorcery,Peter Polach
+Elegy Acolyte,4,2025,0.35,#000000,https://cards.scryfall.io/normal/front/c/6/c69ed7c7-1f49-4299-b3e6-75150258ac59.jpg?1783905969,Creature — Human Cleric,Diana Franco
+Elektra- Daughter of the Hand,4,2026,0.36,#000000,https://cards.scryfall.io/normal/front/a/c/ac3e586c-d654-4631-beda-a5e29cf04717.jpg?1783902943,Legendary Creature — Human Ninja Villain,Bastien L. Deharme
+El-Hajjâj,3,1995,0.37,#000000,https://cards.scryfall.io/normal/front/c/f/cf371bd2-89ad-487e-8f27-37a6e75ca0f5.jpg?1783947845,Creature — Human Wizard,Dameon Willich
+Eliminate the Competition,5,2025,0.22,#000000,https://cards.scryfall.io/normal/front/e/6/e6e54953-0d6d-4f65-85cb-d26e66a76dce.jpg?1783907089,Sorcery,Joseph Meehan
+Elusive Tormentor // Insidious Mist,4,2016,0.25,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Vampire Wizard // Creature — Elemental,Izzy
+Elvish Dreadlord,5,2020,0.36,#000000,https://cards.scryfall.io/normal/front/1/f/1f452927-4d04-4c1d-9d88-19901fd06937.jpg?1783928840,Creature — Zombie Elf,Randy Vargas
+Embodiment of Agonies,3,2019,0.38,#000000,https://cards.scryfall.io/normal/front/7/7/77972745-8689-4733-9a9d-39ae9d6273a2.jpg?1783932995,Creature — Demon,Igor Kieryluk
+Emeritus of Woe // Demonic Tutor,4,2026,12.82,#000000,https://cards.scryfall.io/normal/front/7/e/7eb9e83d-515d-4911-a06b-9982200277b2.jpg?1783903682,Creature — Vampire Warlock // Sorcery,Jodie Muir
+Emperor of Bones,2,2024,1.58,#000000,https://cards.scryfall.io/normal/front/d/f/df9d9075-2d1e-4848-b661-816d539e05eb.jpg?1783911281,Creature — Skeleton Noble,Josh Hass
+Empty the Catacombs,4,2005,0.29,#000000,https://cards.scryfall.io/normal/front/e/4/e41cbd0b-9f54-4e8f-9a4b-fed8e435a2e0.jpg?1783943670,Sorcery,Mark A. Nelson
+Empty the Pits,4,2014,0.75,#000000,https://cards.scryfall.io/normal/front/e/9/e94b1ac7-dd7b-46a1-a74e-aa0563bab3cd.jpg?1783939081,Instant,Ryan Alexander Lee
+Endemic Plague,4,2002,0.21,#000000,https://cards.scryfall.io/normal/front/1/5/15326971-a53b-45f2-8f1d-1b82935286e1.jpg?1783945069,Sorcery,Nelson DeCastro
+Endless Cockroaches,3,2013,0.62,#000000,https://cards.scryfall.io/normal/front/d/e/de7f26a4-da23-4508-b8b4-817a66d7852a.jpg?1783939676,Creature — Insect,Ron Spencer
+Endless Ranks of the Dead,4,2021,5.89,#000000,https://cards.scryfall.io/normal/front/1/5/155ae16c-f32b-421d-a92a-bf13d9f32891.jpg?1783925339,Enchantment,Ryan Yee
+Endless Whispers,4,2004,5.63,#000000,https://cards.scryfall.io/normal/front/2/6/266323da-9528-462e-a0a8-6ef2dda5f1ee.jpg?1783944400,Enchantment,Carl Critchlow
+Endling,4,2019,0.33,#000000,https://cards.scryfall.io/normal/front/3/3/337b6047-3f8d-4530-9e45-b5ce397a2829.jpg?1783933129,Creature — Zombie Shapeshifter,Livia Prima
+Endrek Sahr- Master Breeder,5,2023,2.79,#000000,https://cards.scryfall.io/normal/front/1/2/123490fb-5908-45f2-b376-7959ccdf9c3e.jpg?1783915678,Legendary Creature — Human Wizard,Lucas Graciano
+Enduring Tenacity,4,2024,12.22,#000000,https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg?1783909481,Enchantment Creature — Snake Glimmer,Isis
+Enter the Dungeon,2,2020,0.17,#000000,https://cards.scryfall.io/normal/front/d/6/d696f3a6-88c3-4aab-9c1f-05b5e36094fa.jpg?1783931337,Sorcery,Luca Zontini
+Entomb,1,2023,17.07,#000000,https://cards.scryfall.io/normal/front/3/c/3caa9c55-5e3b-436b-84a9-b7ccebf63799.jpg?1783918480,Instant,Seb McKinnon
+Entrails Feaster,1,2002,0.44,#000000,https://cards.scryfall.io/normal/front/c/d/cdddab92-3e1f-49dc-afd0-8c84d0d952c2.jpg?1783945069,Creature — Zombie Cat,John Matson
+Entreat the Dead,3,2018,1.48,#000000,https://cards.scryfall.io/normal/front/3/1/31a147bb-37ef-4a52-82e2-160a53323516.jpg?1783934339,Sorcery,Deruchenko Alexander
+Entropic Battlecruiser,4,2025,0.35,#000000,https://cards.scryfall.io/normal/front/c/c/cc59796b-9025-44b6-a188-cf6684ebffb9.jpg?1783905967,Artifact — Spacecraft,Josiah "Jo" Cameron
+Entropic Specter,5,1998,0.42,#000000,https://cards.scryfall.io/normal/front/b/d/bdb04d81-b0ab-4bc7-935d-c31005887240.jpg?1783946517,Creature — Specter Spirit,Ron Spencer
+Eradicator Valkyrie,4,2021,3.08,#000000,https://cards.scryfall.io/normal/front/d/0/d00edda3-ddbc-44ee-a14b-47a701445bb0.jpg?1783928247,Creature — Angel Berserker,Tyler Jacobson
+Erebos- Bleak-Hearted,4,2023,1.71,#000000,https://cards.scryfall.io/normal/front/8/4/84701927-799f-4af4-85b8-389f903c5bc0.jpg?1783915435,Legendary Enchantment Creature — God,Chase Stone
+Erebos- God of the Dead,4,2013,11.3,#000000,https://cards.scryfall.io/normal/front/d/0/d0787e1f-0b75-44ab-a8fd-90358906a787.jpg?1783939779,Legendary Enchantment Creature — God,Peter Mohrbacher
+Erebos's Intervention,1,2020,0.48,#000000,https://cards.scryfall.io/normal/front/8/8/88e35c80-6cfe-49fc-8138-562233ccf987.jpg?1783931569,Instant,Mathias Kollros
+Erebos's Titan,4,2015,0.36,#000000,https://cards.scryfall.io/normal/front/f/5/f5972911-2d41-4a0c-8a8f-b3d35a6594d8.jpg?1783938343,Creature — Giant,Peter Mohrbacher
+Espers to Magicite,4,2025,0.25,#000000,https://cards.scryfall.io/normal/front/6/c/6cb18871-dd23-4ce8-a535-16adefae63c0.jpg?1783906359,Instant,AKAGI
+Essence Pulse,4,2021,0.34,#000000,https://cards.scryfall.io/normal/front/e/3/e3e32d1b-e580-4d09-b285-c8d6c5297896.jpg?1783927600,Sorcery,Kieran Yanner
+Eumidian Wastewaker,4,2025,0.23,#000000,https://cards.scryfall.io/normal/front/3/e/3ee18d18-0167-4caa-adad-9d4435689c80.jpg?1783906065,Creature — Insect Cleric,Mathias Kollros
+Eventide's Shadow,5,2026,0.24,#000000,https://cards.scryfall.io/normal/front/9/c/9c5d71a6-8e68-4aee-b781-486276d17fce.jpg?1783904606,Sorcery,Jabari Weathers
+Ever After,6,2020,0.32,#000000,https://cards.scryfall.io/normal/front/a/4/a4e6a08b-e0d6-4d41-b143-e09ac53b6249.jpg?1783931180,Sorcery,Ryan Alexander Lee
+Evereth- Viceroy of Plunder,3,2024,2.7,#d78f42,https://cards.scryfall.io/normal/front/f/9/f9c9c0be-8c69-45e5-bdcb-e62ddb05e532.jpg?1783908858,Legendary Creature — Vampire Soldier,Yuichi Murakami
+Evin- Waterdeep Opportunist,4,2025,11.14,#000000,https://cards.scryfall.io/normal/front/c/3/c35accd3-92ee-4b0b-a30a-4dcd3252d1b8.jpg?1783906766,Legendary Creature — Human Rogue,Igor Grechanyi
+Eviscerator,5,1999,0.46,#000000,https://cards.scryfall.io/normal/front/1/6/167e7f67-8d44-4134-b7b9-54ccdfb8675c.jpg?1783946242,Creature — Phyrexian Horror,Michael Sutfin
+Evolved Sleeper,1,2022,0.24,#000000,https://cards.scryfall.io/normal/front/e/b/ebeafbc2-0399-4335-8f63-76a3e085e8c6.jpg?1783921332,Creature — Human,Jason A. Engle
+Exit Through the Grift Shop,3,2022,0.19,#000000,https://cards.scryfall.io/normal/front/c/d/cd9b584e-4646-4301-b1de-44717336e590.jpg?1783920583,Sorcery,Chris Seaman
+Exquisite Blood,5,2023,36.88,#000000,https://cards.scryfall.io/normal/front/0/e/0e8ccfa7-4178-476a-a155-0ca1c98556c9.jpg?1783913874,Enchantment,Cynthia Sheppard
+Exsanguinator Cavalry,3,2023,3.18,#000000,https://cards.scryfall.io/normal/front/e/f/efbd35cd-8f5c-4698-b4e2-f6b1f61cd653.jpg?1783917285,Creature — Vampire Knight,Quintin Gleim
+Extinction,5,1997,0.86,#000000,https://cards.scryfall.io/normal/front/a/2/a233a244-7f84-4525-b0ce-e10db0a95385.jpg?1783946640,Sorcery,Una Fricker
+Extinction Event,4,2020,0.39,#000000,https://cards.scryfall.io/normal/front/8/7/8725a869-462b-4381-880a-b4bcc63a655b.jpg?1783931062,Sorcery,Filip Burburan
+Extinguish All Hope,6,2014,0.26,#000000,https://cards.scryfall.io/normal/front/6/8/6895024f-a04b-46cf-b020-df4487d0c758.jpg?1783939436,Sorcery,Chase Stone
+Extirpate,1,2021,1.2,#000000,https://cards.scryfall.io/normal/front/4/1/4171dbd3-96d6-4e7a-afac-5b2882bf3872.jpg?1783927823,Instant,Jon Foster
+Extortion,5,1999,0.37,#000000,https://cards.scryfall.io/normal/front/a/6/a66742db-4750-49ce-ad05-b825af7222c4.jpg?1783945953,Sorcery,Pete Venters
+Extractor Demon,6,2018,0.24,#000000,https://cards.scryfall.io/normal/front/c/8/c8d09723-3729-44b7-8f3d-3de47c135849.jpg?1783934758,Creature — Demon,Carl Critchlow
+Eye of Duskmantle,7,2024,0.33,#000000,https://cards.scryfall.io/normal/front/9/0/905fa4ed-e496-43d8-9c4a-38e85d9b7651.jpg?1783913045,Creature — Eye,Anthony Devine
+Eye of Nidhogg,3,2025,1.96,#000000,https://cards.scryfall.io/normal/front/1/8/186862e7-91ba-47e9-bc38-e8e20772d40c.jpg?1783906359,Legendary Enchantment — Aura,Erion Makuo
+Ezio Auditore da Firenze,2,2024,3.13,#d78f42,https://cards.scryfall.io/normal/front/d/a/dae9ee75-30b8-4e24-af8b-031c816d3221.jpg?1783910980,Legendary Creature — Human Assassin,Fajareka Setiawan
+Faerie Bladecrafter,3,2023,4.77,#000000,https://cards.scryfall.io/normal/front/f/f/fffdf7f3-a230-417a-883a-069aabcbcca7.jpg?1783914987,Creature — Faerie Rogue,Jodie Muir
+Faerie Macabre,3,2026,7.89,#000000,https://cards.scryfall.io/normal/front/b/7/b7873964-b590-47c6-a170-c9290b27e6fc.jpg?1783904338,Creature — Faerie Rogue,Nathanna Erica
+Fain- the Broker,3,2024,3.93,#000000,https://cards.scryfall.io/normal/front/7/f/7f1ff9e5-3d69-43a9-965c-2d87951cfd2b.jpg?1783911932,Legendary Creature — Human Warlock,Lius Lasahido
+Falkenrath Forebear,3,2021,0.32,#000000,https://cards.scryfall.io/normal/front/4/5/451559d0-b62d-4757-8eb5-f6b0e240899c.jpg?1783924862,Creature — Vampire,Aurore Folny
+Fallen Angel,5,2017,0.47,#000000,https://cards.scryfall.io/normal/front/8/9/8925ab01-4999-4988-8521-b98c92a1be91.jpg?1783936287,Creature — Angel,Matthew D. Wilson
+False Cure,2,2002,12.05,#000000,https://cards.scryfall.io/normal/front/e/f/ef397db1-2d99-4cb0-a6e9-6f72d615ebad.jpg?1783945069,Instant,Bradley Williams
+Fandaniel- Telophoroi Ascian,5,2025,0.34,#000000,https://cards.scryfall.io/normal/front/0/8/08c9bf6c-fc52-4565-96d1-951a314e59e5.jpg?1783906359,Legendary Creature — Elder Wizard,Paulius Daščioras
+Fatal Lore,4,1996,0.67,#000000,https://cards.scryfall.io/normal/front/2/4/24ba0b83-9671-4ee7-996d-57a3616b9c66.jpg?1783947187,Sorcery,Lawrence Snelly
+Fatal Push,1,2025,37.71,#000000,https://cards.scryfall.io/normal/front/8/7/8779045c-c592-4692-845f-2c5e228ea396.jpg?1783905568,Instant,Veronica Fish
+Fated Return,7,2020,0.29,#000000,https://cards.scryfall.io/normal/front/5/d/5d168856-5568-4ee0-942d-78865d2bb1ef.jpg?1783929479,Instant,Peter Mohrbacher
+Fateful Handoff,4,2022,0.24,#000000,https://cards.scryfall.io/normal/front/0/b/0bbed8f9-3615-428b-8d0d-18291c5a99be.jpg?1783920092,Sorcery,Gaboleps
+Fate Unraveler,4,2024,3.85,#000000,https://cards.scryfall.io/normal/front/3/0/30250c4d-2c16-4d03-874e-aec39d8e72a9.jpg?1783909619,Enchantment Creature — Hag,David Palumbo
+Fathom Fleet Captain,2,2023,0.25,#000000,https://cards.scryfall.io/normal/front/7/3/7374d12c-6a0a-457a-b7b8-5aaf3c11e009.jpg?1783913872,Creature — Human Pirate,Matt Stewart
+Feast of Blood,2,2012,2.74,#000000,https://cards.scryfall.io/normal/front/6/5/658bf8b7-fbc4-4046-9300-249cdeb87924.jpg?1783940786,Sorcery,Christopher Moeller
+Feed the Swarm,2,2025,2.59,#000000,https://cards.scryfall.io/normal/front/c/f/cf10e116-d1da-4570-be0e-c597a9e75d72.jpg?1783905387,Sorcery,Ed Hannigan & Pablo Marcos
+Fell Beast of Mordor,4,2023,1.28,#000000,https://cards.scryfall.io/normal/front/d/a/daa9c5dd-e7d9-4a7b-b75a-897911a3411b.jpg?1783914191,Creature — Drake Beast,Campbell White
+Fell Shepherd,7,2013,0.18,#000000,https://cards.scryfall.io/normal/front/a/f/afd27b8d-3c1f-401b-aad1-268a7aa79f0f.jpg?1783939676,Creature — Avatar,Brad Rigney
+Fendeep Summoner,5,2008,0.58,#000000,https://cards.scryfall.io/normal/front/1/0/10fb2b62-eea7-469f-b237-fdce20b8bdcf.jpg?1783942793,Creature — Treefolk Shaman,Jesper Ejsing
+Feral Ghoul,3,2024,3.48,#000000,https://cards.scryfall.io/normal/front/f/b/fbdef99d-6ce9-495d-a55b-e6ba799d3da7.jpg?1783912408,Creature — Zombie Mutant,Sergio Cosmai
+Fevered Convulsions,2,1997,0.61,#000000,https://cards.scryfall.io/normal/front/3/a/3a790769-e76e-49e9-9d6d-05ce8e858243.jpg?1783946640,Enchantment,Jeff Miracola
+Fiend of the Shadows,5,2021,0.29,#000000,https://cards.scryfall.io/normal/front/3/7/373f24b1-e763-475c-9760-aefae4be3ea0.jpg?1783926217,Creature — Vampire Wizard,Igor Kieryluk
+Final Act,6,2026,0.34,#000000,https://cards.scryfall.io/normal/front/a/8/a86671d1-4f4b-486e-a0b3-671608974a82.jpg?1783903784,Sorcery,Nils Hamm
+Finale of Eternity,2,2019,0.99,#000000,https://cards.scryfall.io/normal/front/8/5/85c60177-8b71-4e24-87e7-395d5e4f93ff.jpg?1783933444,Sorcery,Daarken
+Final Punishment,5,2005,0.21,#000000,https://cards.scryfall.io/normal/front/7/2/72df60bb-3309-43e0-ab4a-cec1390fc7cf.jpg?1783944004,Sorcery,Matt Thompson
+Final Strike,4,1997,5.68,#000000,https://cards.scryfall.io/normal/front/e/c/ecdfcb03-2f77-4f54-af62-3012cd3efd4f.jpg?1783946828,Sorcery,John Coulthart
+Fire Lord Ozai,4,2025,0.99,#d78f42,https://cards.scryfall.io/normal/front/7/7/77e548c9-8bed-40c3-bcdd-9d97a82c885d.jpg?1783904825,Legendary Creature — Human Noble,Ryuichi Sakuma
+Fire Nation Occupation,3,2025,0.42,#000000,https://cards.scryfall.io/normal/front/3/4/3455d55e-aef5-4eb1-bcd9-1ff9d1ab3698.jpg?1783904825,Enchantment,Arthur Yuan
+Fire Nation Salvagers,5,2025,0.16,#000000,https://cards.scryfall.io/normal/front/f/e/fea1319c-7589-480d-a204-65ec68837e59.jpg?1783904824,Creature — Human Soldier,Susumu Kuroi
+Fire Nation Sentinels,5,2025,0.81,#000000,https://cards.scryfall.io/normal/front/4/a/4a08c7c4-d20f-4c5b-a308-b8c84c9030a9.jpg?1783904781,Creature — Human Soldier,Tition
+Flare of Malice,4,2024,2.07,#000000,https://cards.scryfall.io/normal/front/1/9/19efb9ce-62eb-4cbf-b01e-979f3fd09ba6.jpg?1783911280,Instant,David Palumbo
+Flesh Carver,3,2014,0.39,#000000,https://cards.scryfall.io/normal/front/c/f/cf0f88d9-681c-4152-bb45-628850717430.jpg?1783938870,Creature — Human Wizard,Jesper Ejsing
+Flow of Maggots,3,1995,0.98,#000000,https://cards.scryfall.io/normal/front/6/8/6880a4d3-5cbc-4a01-9190-3565617efcc9.jpg?1783947503,Creature — Insect,Ron Spencer
+Foggy Swamp Visions,3,2025,0.3,#000000,https://cards.scryfall.io/normal/front/3/a/3a46deaa-88f7-4eec-aa99-b85073847918.jpg?1783904969,Sorcery,Hori Airi
+Font of Agonies,1,2019,0.68,#000000,https://cards.scryfall.io/normal/front/d/7/d7c02aec-4a89-4ccc-8525-6f979c10d799.jpg?1783933694,Enchantment,Jason A. Engle
+Foot Chopper,2,2026,0.33,#000000,https://cards.scryfall.io/normal/front/f/4/f43fa5c7-51e6-4824-95f8-837ccc77a6ce.jpg?1783904170,Artifact — Equipment,Adrián Rodríguez Pérez
+Forbidden Crypt,5,1999,1.05,#000000,https://cards.scryfall.io/normal/front/7/6/76f5f509-707b-4ed6-9824-626dea5869b0.jpg?1783946184,Enchantment,D. Alexander Gregory
+Forbidden Ritual,4,1997,1.09,#000000,https://cards.scryfall.io/normal/front/f/5/f5327e6d-db4e-4b44-a00e-b764e80b8946.jpg?1783946994,Sorcery,Christopher Rush
+Forced March,3,1999,0.96,#000000,https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg?1783945952,Sorcery,Greg Hildebrandt & Tim Hildebrandt
+Force of Despair,3,2019,8.42,#000000,https://cards.scryfall.io/normal/front/8/f/8f497b0d-4448-4201-bd55-c147da1a216d.jpg?1783933128,Instant,Seb McKinnon
+Foreboding Steamboat,5,2024,0.29,#000000,https://cards.scryfall.io/normal/front/c/b/cbd9a0cb-e1ea-446e-aa57-4305d4b3b92e.jpg?1783913045,Artifact — Vehicle,Josu Solano
+Forsaken Wastes,3,1996,14.83,#000000,https://cards.scryfall.io/normal/front/c/9/c9dbfc7c-164d-47b8-8f05-987864fca89b.jpg?1783947093,World Enchantment,Kev Walker
+Forsworn Paladin,1,2021,0.41,#000000,https://cards.scryfall.io/normal/front/4/a/4acaf396-f950-42da-85ab-149ffb31fee6.jpg?1783926494,Creature — Human Knight,Lorenzo Mastroianni
+Foul Renewal,4,2015,0.26,#000000,https://cards.scryfall.io/normal/front/e/3/e319b7ca-d0a4-43ff-8e87-2af6ead089f5.jpg?1783938597,Instant,Filip Burburan
+Francisco- Fowl Marauder,2,2023,0.28,#000000,https://cards.scryfall.io/normal/front/5/1/5182b527-739e-4523-8611-01244ced26ac.jpg?1783913911,Legendary Creature — Bird Pirate,Rudy Siswanto
+Frankenstein's Monster,2,1994,8.16,#000000,https://cards.scryfall.io/normal/front/8/f/8f99894d-5ece-44f1-acce-474494ae2084.jpg?1783947939,Creature — Zombie,Anson Maddocks
+Fraying Omnipotence,5,2018,1.06,#000000,https://cards.scryfall.io/normal/front/f/0/f0fa0ad8-854a-4b4e-9f87-e1dfaa11253c.jpg?1783934570,Sorcery,Svetlin Velinov
+From the Catacombs,5,2022,0.9,#000000,https://cards.scryfall.io/normal/front/0/8/08737950-4662-4d36-a1ea-6fd87e38c02b.jpg?1783922506,Sorcery,Ben Wootten
+From Under the Floorboards,5,2019,0.32,#000000,https://cards.scryfall.io/normal/front/c/f/cf31fec2-40d6-4810-8575-c7814bb4b6b4.jpg?1783932769,Sorcery,Steven Belledin
+Fumulus- the Infestation,4,2024,6.98,#000000,https://cards.scryfall.io/normal/front/e/e/ee5e47c2-7648-4218-b42c-ed9650e12914.jpg?1783908857,Legendary Creature — Vampire Insect,Takotto
+Funeral Room // Awakening Hall,11,2024,5.8,#000000,https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1783909480,Enchantment — Room // Enchantment — Room,Miklós Ligeti
+Gallowbraid,5,1997,1.04,#000000,https://cards.scryfall.io/normal/front/8/d/8df86192-6374-42ac-94bc-95e2e8284bd6.jpg?1783946734,Legendary Creature — Phyrexian Horror,Carl Critchlow
+Game Over,5,2026,0.4,#000000,https://cards.scryfall.io/normal/front/f/1/f1eb50a6-07e2-41de-b948-8075bba197ee.jpg?1783904170,Sorcery,Kim Sokol
+Gangrenous Goliath,5,2002,0.19,#000000,https://cards.scryfall.io/normal/front/6/9/69b58b6b-24cd-4440-b99c-d88d44b3c41c.jpg?1783945068,Creature — Zombie Giant,Justin Sweet
+Garza's Assassin,3,2006,1.14,#000000,https://cards.scryfall.io/normal/front/3/4/3407ccbd-788d-4fe3-a039-0497724a94b5.jpg?1783943351,Creature — Human Assassin,Paolo Parente
+Gas Guzzler,1,2025,0.3,#000000,https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg?1783907896,Creature — Vampire Rogue,Yohann Schepacz
+Gelatinous Cube,4,2021,0.28,#000000,https://cards.scryfall.io/normal/front/1/c/1c472e70-300c-4881-86e7-c5ca690ab9b6.jpg?1783926493,Creature — Ooze,Olivier Bernard
+Genesis of the Daleks,6,2023,0.37,#000000,https://cards.scryfall.io/normal/front/6/c/6ce10eb6-9718-4739-a796-da33d823a463.jpg?1783914657,Enchantment — Saga,Dominik Mayer
+Geralf's Messenger,3,2012,3.63,#000000,https://cards.scryfall.io/normal/front/b/f/bffaad78-97ff-431f-bfb0-e96c7558f974.jpg?1783940831,Creature — Zombie,Kev Walker
+Geth- Lord of the Vault,6,2020,0.82,#000000,https://cards.scryfall.io/normal/front/9/2/920d56a4-fc94-43d8-9d65-361b66172a5f.jpg?1783930180,Legendary Creature — Phyrexian Zombie,Whit Brachna
+Geth's Summons,4,2023,0.41,#000000,https://cards.scryfall.io/normal/front/9/c/9cdab166-c0d2-45c4-8326-f4670cd7efd4.jpg?1783918160,Sorcery,Johann Bodin
+Geth- Thane of Contracts,3,2023,0.12,#000000,https://cards.scryfall.io/normal/front/c/2/c26e18be-81a1-4645-866a-fae5c2fdf7c9.jpg?1783918044,Legendary Creature — Phyrexian Zombie,Martin de Diego Sádaba
+Ghastly Conscription,7,2019,0.32,#000000,https://cards.scryfall.io/normal/front/8/4/8495d903-ef30-4aaa-9fe6-239dc0e34977.jpg?1783932768,Sorcery,YW Tang
+Ghastly Remains,3,2003,0.33,#000000,https://cards.scryfall.io/normal/front/6/3/63e67323-df54-4043-a6b6-18bb89ef1f62.jpg?1783944914,Creature — Zombie,Edward P. Beard, Jr.
+Ghoulcaller Gisa,5,2023,3.71,#000000,https://cards.scryfall.io/normal/front/4/4/44d7906e-8a89-4644-acb5-46fbe97ab39f.jpg?1783915675,Legendary Creature — Human Wizard,Karla Ortiz
+Ghoulish Impetus,3,2026,0.46,#000000,https://cards.scryfall.io/normal/front/f/6/f6fab24d-0174-4248-8481-52194e05d6f9.jpg?1783903785,Enchantment — Aura,Steve Ellis
+Ghouls' Night Out,5,2021,0.44,#000000,https://cards.scryfall.io/normal/front/f/5/f532dce5-66b7-4f42-87c3-c7cb8d47d10e.jpg?1783925378,Sorcery,Fajareka Setiawan
+Gibbering Descent,6,2007,2.63,#000000,https://cards.scryfall.io/normal/front/d/4/d4839a0b-47db-4464-9e9a-0e976d468106.jpg?1783943115,Enchantment,Ittoku
+Gifted Aetherborn,2,2023,0.48,#000000,https://cards.scryfall.io/normal/front/b/a/ba312f2e-c9c2-4c61-bcbd-d46f913ae329.jpg?1783915227,Creature — Aetherborn Vampire,Lie Setiawan
+Gift of Doom,5,2019,4.57,#000000,https://cards.scryfall.io/normal/front/a/d/ad6e1ba7-047b-41a3-8ab4-17a5c5476749.jpg?1783932809,Enchantment — Aura,James Zapata
+Gild,4,2015,0.11,#000000,https://cards.scryfall.io/normal/front/e/a/ea315dab-e35d-4fdf-8574-b22e70643063.jpg?1783938083,Sorcery,Richard Wright
+Gilt-Leaf Winnower,5,2015,0.18,#000000,https://cards.scryfall.io/normal/front/c/9/c9667cae-6801-434b-9d91-ea1f2bd2449e.jpg?1783938341,Creature — Elf Warrior,Viktor Titov
+Gisa- Glorious Resurrector,4,2021,2.98,#000000,https://cards.scryfall.io/normal/front/6/3/63461076-a13d-488d-bd82-ceac441341c8.jpg?1783925617,Legendary Creature — Human Wizard,Yongjae Choi
+Gisa's Favorite Shovel,2,2023,22.99,#000000,https://cards.scryfall.io/normal/front/8/1/8139bb44-47e8-4076-99ed-ad3623198ad9.jpg?1783915139,Legendary Artifact — Equipment,Svetlin Velinov
+Gisa- the Hellraiser,5,2024,5.35,#000000,https://cards.scryfall.io/normal/front/d/b/db7c07b2-02b2-4e62-bf1b-4848e06eec28.jpg?1783911832,Legendary Creature — Human Warlock,Chris Rahn
+Gixian Puppeteer,4,2022,1.92,#000000,https://cards.scryfall.io/normal/front/2/c/2cc86e18-ffbc-4c5f-a694-922332b146cc.jpg?1783920087,Creature — Phyrexian Warlock,Bastien L. Deharme
+Gix's Command,5,2022,0.59,#000000,https://cards.scryfall.io/normal/front/9/6/9606de75-c25f-411b-a271-258ac5a60987.jpg?1783920087,Sorcery,Dominik Mayer
+Gix- Yawgmoth Praetor,3,2025,0.5,#000000,https://cards.scryfall.io/normal/front/1/3/135c5948-4c95-4f24-b648-eda55ab637c8.jpg?1783907088,Legendary Creature — Phyrexian Praetor,Anna Podedworna
+Glass-Cast Heart,3,2023,0.35,#000000,https://cards.scryfall.io/normal/front/f/3/f36a4054-903c-468a-877b-0ba43a403cc1.jpg?1783913873,Artifact,Alayna Danner
+Glint-Sleeve Siphoner,2,2017,0.26,#000000,https://cards.scryfall.io/normal/front/3/1/315976db-4cab-4393-8386-ce3b0ae3f490.jpg?1783936762,Creature — Human Rogue,Greg Opalinski
+Glistening Oil,2,2011,12.78,#000000,https://cards.scryfall.io/normal/front/4/8/483e99fd-7e48-400d-9817-451089089e0c.jpg?1783941313,Enchantment — Aura,Steven Belledin
+Gloom Ripper,5,2026,0.25,#000000,https://cards.scryfall.io/normal/front/e/9/e9ee5d4f-05d1-4e3a-b8d6-f22d0fddedf7.jpg?1783904462,Creature — Elf Assassin,Annie Stegg
+Gloom Surgeon,2,2012,0.13,#000000,https://cards.scryfall.io/normal/front/1/b/1b00c711-007d-4c85-9dd9-dd9d52f1649d.jpg?1783940698,Creature — Spirit,Volkan Baǵa
+God-Eternal Bontu,5,2025,0.4,#000000,https://cards.scryfall.io/normal/front/1/4/142b0860-8a82-4830-a4ff-2bbfc102437e.jpg?1783906039,Legendary Creature — Zombie God,Lius Lasahido
+Go for the Throat,2,2025,6.55,#000000,https://cards.scryfall.io/normal/front/f/6/f608fcd6-b59d-457e-879e-bcc53e15bc15.jpg?1783905574,Instant,Kael Ngu
+Golgari Thug,2,2019,4.89,#000000,https://cards.scryfall.io/normal/front/f/d/fddee704-5315-4b35-9f77-0c12def26ce1.jpg?1783931626,Creature — Human Warrior,Dan Mumford
+Gollum- Obsessed Stalker,2,2023,0.33,#000000,https://cards.scryfall.io/normal/front/e/5/e5a43cf0-60b3-4770-945c-41ee3ec54d5a.jpg?1783916031,Legendary Creature — Halfling Horror,John Di Giovanni
+Gollum- Riddle Master,2,2026,19.8,#000000,https://cards.scryfall.io/normal/front/b/b/bbdc7e37-c65a-497a-92b7-a30a6e369c71.jpg?1784376959,Legendary Creature — Halfling Horror,Irvin Rodriguez
+Gollum- Scheming Guide,2,2023,2.02,#000000,https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg?1783916217,Legendary Creature — Halfling Horror,Dmitry Burmak
+Gonti- Lord of Luxury,4,2024,0.39,#000000,https://cards.scryfall.io/normal/front/f/b/fbbb3aef-af1f-4b77-b7d6-64cfd706a9d9.jpg?1783911930,Legendary Creature — Aetherborn Rogue,Daarken
+Gonti- Night Minister,4,2025,1.06,#000000,https://cards.scryfall.io/normal/front/d/7/d79ca40a-e5c0-4956-8df0-ecbd2a25656f.jpg?1783907895,Legendary Creature — Aetherborn Rogue,Scott M. Fischer
+Gorex- the Tombshell,8,2021,0.27,#000000,https://cards.scryfall.io/normal/front/3/9/398ecf98-b36b-45e1-8ac1-9d364e12d79e.jpg?1783925375,Legendary Creature — Zombie Turtle,Wisnu Tan
+Goryo's Vengeance,2,2018,12.42,#000000,https://cards.scryfall.io/normal/front/6/2/6261205d-3506-4f0a-98ce-690f40df7a5a.jpg?1783933822,Instant — Arcane,Randy Vargas
+Graf Reaver,2,2021,0.19,#000000,https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg?1783924863,Creature — Zombie Warrior,Dave Kendall
+Grafted Butcher,2,2023,0.36,#000000,https://cards.scryfall.io/normal/front/e/2/e22f11a1-0cbd-4b36-8dbd-37ba29ad4608.jpg?1783917008,Creature — Phyrexian Samurai,Zack Stella
+Grave Betrayal,7,2012,3.57,#000000,https://cards.scryfall.io/normal/front/4/7/47b38c68-8e72-4afc-bb5e-0b40880fdda9.jpg?1783940362,Enchantment,Lucas Graciano
+Gravebind,1,1995,0.94,#000000,https://cards.scryfall.io/normal/front/4/7/4782fd4f-2474-4d0d-8301-e0b52af93746.jpg?1783947502,Instant,Drew Tucker
+Graveblade Marauder,3,2022,0.22,#000000,https://cards.scryfall.io/normal/front/1/8/188692aa-a326-43c9-845b-9fdc17a05d55.jpg?1783923267,Creature — Human Warrior,Jason Rainville
+Graveborn Muse,4,2007,10.6,#000000,https://cards.scryfall.io/normal/front/3/d/3d460b79-f1a5-41c4-a5b3-61f703fd97df.jpg?1783943036,Creature — Zombie Spirit,Kev Walker
+Gravebreaker Lamia,5,2020,0.63,#000000,https://cards.scryfall.io/normal/front/4/0/408a2073-d068-44bc-b596-5a3a3a446ee1.jpg?1783931567,Enchantment Creature — Snake Lamia,Lius Lasahido
+Gravecrawler,1,2025,1.48,#000000,https://cards.scryfall.io/normal/front/6/9/6987d609-ba0f-42bf-9b61-bdfb943c03b5.jpg?1783907138,Creature — Zombie,Danny Schwartz
+Grave Endeavor,7,2021,2.24,#000000,https://cards.scryfall.io/normal/front/1/e/1ef4b0fb-d4a5-43ce-a079-10d346e194d5.jpg?1783926252,Instant,YW Tang
+Grave Pact,4,2023,36.52,#000000,https://cards.scryfall.io/normal/front/f/5/f5a4970b-2ba6-4c91-a301-369369cdf360.jpg?1783915673,Enchantment,Billy Christian
+Grave Researcher // Reanimate,3,2026,2.66,#000000,https://cards.scryfall.io/normal/front/8/b/8b1e10e8-ea14-4761-910b-4072e2a18456.jpg?1783903680,Creature — Troll Warlock // Sorcery,Izzy
+Grave Robbers,3,1994,5.74,#000000,https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg?1783947938,Creature — Human Rogue,Quinton Hoover
+Gravespawn Sovereign,6,2021,0.33,#000000,https://cards.scryfall.io/normal/front/5/8/58d36326-882e-46bb-a00c-5ea0f6515f65.jpg?1783925336,Creature — Zombie,Adam Rex
+Gravestorm,3,2001,7.19,#000000,https://cards.scryfall.io/normal/front/5/e/5e273b71-85ca-49d2-ba96-70cc0ae8d718.jpg?1783945245,Enchantment,Alex Horley-Orlandelli
+Grave Titan,6,2026,0.4,#000000,https://cards.scryfall.io/normal/front/3/b/3b4faa6e-5013-4c59-80f5-662a386672eb.jpg?1783904558,Creature — Giant,Nils Hamm
+Grave Venerations,4,2026,0.62,#000000,https://cards.scryfall.io/normal/front/e/c/ec52f819-038a-41c3-91ef-91b1975d094c.jpg?1783904607,Enchantment,Omar Rayyan
+Gravewaker,6,2020,0.22,#000000,https://cards.scryfall.io/normal/front/d/3/d3c5eb7a-abb2-46bd-8fbd-19af63e70c9c.jpg?1783930423,Creature — Bird Spirit,Daniel Ljunggren
+Graveyard Marshal,2,2018,0.33,#000000,https://cards.scryfall.io/normal/front/4/d/4dc5f62c-2d29-4a94-8501-13dc6a93c5a1.jpg?1783934570,Creature — Zombie Soldier,Mark Behm
+Graveyard Trespasser // Graveyard Glutton,3,2021,0.44,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Chris Rallis
+Gray Merchant of Asphodel,5,2025,8.14,#000000,https://cards.scryfall.io/normal/front/d/7/d7655424-a6c9-4c90-bc27-b4b4c3d78d12.jpg?1783905114,Creature — Zombie,Jack Hughes
+Greater Harvester,5,2004,1.69,#000000,https://cards.scryfall.io/normal/front/c/0/c0b9c148-5f31-405e-9215-a12bafcac99a.jpg?1783944444,Creature — Horror,Daren Bader
+Great Unclean One,5,2022,5.55,#000000,https://cards.scryfall.io/normal/front/7/5/757e79f2-23dc-44de-8531-6eb3e2f015f3.jpg?1783920925,Creature — Demon,Helge C. Balzer
+Greed,4,2013,0.51,#000000,https://cards.scryfall.io/normal/front/c/3/c39d94fb-a092-4307-b99b-73fb97998cc2.jpg?1783939675,Enchantment,Izzy
+Greed's Gambit,4,2024,0.36,#000000,https://cards.scryfall.io/normal/front/5/b/5b60a1a6-b2ca-4dc2-a6d9-eff97092079a.jpg?1783912002,Enchantment,Inkognit
+Greel- Mind Raker,5,2000,0.54,#000000,https://cards.scryfall.io/normal/front/e/9/e9d1f317-efd1-4595-92e2-44815a2b8147.jpg?1783945784,Legendary Creature — Horror Spellshaper,Brom
+Green Goblin- Back for More,5,2026,1.89,#000000,https://cards.scryfall.io/normal/front/5/a/5a1d3cb7-cd6a-4a81-b2b1-8fb5eeb49595.jpg?1783903062,Legendary Creature — Goblin Human Villain,Colin Boyer
+Grief,4,2021,3.1,#000000,https://cards.scryfall.io/normal/front/e/6/e6befbc4-1320-4f26-bd9f-b1814fedda10.jpg?1783926861,Creature — Elemental Incarnation,Nicholas Gregory
+Grievous Wound,5,2024,0.51,#000000,https://cards.scryfall.io/normal/front/6/e/6ed3dd5e-cd27-4b18-ad60-f5c4d9a811b9.jpg?1783909480,Enchantment — Aura,Martina Fačková
+Gríma Wormtongue,3,2023,6.83,#000000,https://cards.scryfall.io/normal/front/b/2/b2731d3c-48be-46d1-8fb3-13a99ac380b4.jpg?1783915185,Legendary Creature — Human Advisor,Bakshi Productions
+Grim Haruspex,3,2022,3.09,#000000,https://cards.scryfall.io/normal/front/f/5/f5c19b87-e114-46d4-9f6c-c02e838a08dd.jpg?1783922449,Creature — Human Wizard,Seb McKinnon
+Grim Hireling,4,2022,11.46,#000000,https://cards.scryfall.io/normal/front/3/8/38326f48-548c-4b18-9ad2-0b7c23385deb.jpg?1783922451,Creature — Tiefling Rogue,Tomas Duchek
+Grim Reaper's Scythe,3,2026,0.76,#000000,https://cards.scryfall.io/normal/front/1/6/16e47e94-4bab-4818-8197-47435af7dab2.jpg?1783903061,Legendary Artifact,Jason Smith
+Grim Reminder,3,2003,0.27,#000000,https://cards.scryfall.io/normal/front/3/5/35baa726-8c2f-4a0b-93d1-d7ecfae69fe4.jpg?1783944547,Instant,Wayne England
+Grim Return,3,2013,0.49,#000000,https://cards.scryfall.io/normal/front/1/5/15b69f74-3b54-4db4-abf3-b71db8cc9562.jpg?1783939923,Instant,Seb McKinnon
+Grim Tutor,3,2020,26.1,#000000,https://cards.scryfall.io/normal/front/9/2/928558ab-e29a-44cb-ac2f-88443571f41a.jpg?1783930707,Sorcery,Igor Kieryluk
+Grinning Demon,4,2002,3.72,#000000,https://cards.scryfall.io/normal/front/7/2/72de2f66-0b86-4c21-b4c8-c2d97e3fd095.jpg?1783945067,Creature — Demon,Mark Zug
+Griselbrand,8,2025,7.97,#000000,https://cards.scryfall.io/normal/front/4/0/4069e510-f3f3-4668-9f13-3546fa9bc7c3.jpg?1783908139,Legendary Creature — Demon,Igor Kieryluk
+Grub- Storied Matriarch // Grub- Notorious Auntie,3,2026,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Goblin Warlock // Legendary Creature — Goblin Warrior,Jesper Ejsing
+Gruesome Menagerie,5,2018,0.19,#000000,https://cards.scryfall.io/normal/front/7/3/73c0e4d9-bf0d-4e28-a647-9010701a915e.jpg?1783934175,Sorcery,Yeong-Hao Han
+Guiltfeeder,5,2022,1.38,#000000,https://cards.scryfall.io/normal/front/8/2/8276b064-60ba-4079-b790-e2eea831e35e.jpg?1783922456,Creature — Horror,Helge C. Balzer
+Gumdrop Poisoner // Tempt with Treats,3,2023,0.28,#000000,https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1783915106,Creature — Human Warlock // Instant — Adventure,Brian Valeza
+Gutterbones,1,2019,0.39,#000000,https://cards.scryfall.io/normal/front/6/a/6a1c710b-bd67-4174-ab02-6ae98a7575ac.jpg?1783933694,Creature — Skeleton Warrior,Grzegorz Rutkowski
+Guul Draz Assassin,1,2010,2.66,#000000,https://cards.scryfall.io/normal/front/7/2/72de01ef-cdf2-44ad-bf2f-a927d82a4f72.jpg?1783941984,Creature — Vampire Assassin,James Ryman
+Guul Draz Overseer,6,2015,0.27,#000000,https://cards.scryfall.io/normal/front/7/9/793bb4e0-8fdd-440e-9e6e-92a899794cae.jpg?1783938201,Creature — Vampire,Karl Kopinski
+Guul Draz Specter,4,2016,0.21,#000000,https://cards.scryfall.io/normal/front/e/d/edb0546f-f893-460c-8af4-79b24c373ebe.jpg?1783937312,Creature — Specter,Mark Tedin
+Gwenom- Remorseless,5,2025,4.71,#000000,https://cards.scryfall.io/normal/front/4/6/46b6cc5d-7a37-4e8b-a1a5-9a573056610c.jpg?1783905344,Legendary Creature — Symbiote Spider Hero,Lordigan
+Haakon- Stromgald Scourge,3,2023,0.87,#000000,https://cards.scryfall.io/normal/front/7/e/7e7d463b-e74e-4ebe-9f92-02ccdeadbf96.jpg?1783917159,Legendary Creature — Zombie Knight,Mark Zug
+Hagra Mauling // Hagra Broodpit,4,2020,0.9,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Instant // Land,Victor Adame Minguez
+Halo Hunter,5,2009,0.24,#000000,https://cards.scryfall.io/normal/front/5/f/5f96344c-4b1f-42a6-bbf2-dc5cf11cdb02.jpg?1783942153,Creature — Demon,Chris Rahn
+Hancock- Ghoulish Mayor,3,2024,1.5,#000000,https://cards.scryfall.io/normal/front/3/9/39bda1b4-3f02-4cbc-9573-f5b6e6c991d5.jpg?1783912408,Legendary Creature — Zombie Mutant Advisor,Wonchun Choi
+Hand of the Praetors,4,2010,4.5,#000000,https://cards.scryfall.io/normal/front/9/4/94ca493e-f09b-4b11-bb47-0562dfc203ca.jpg?1783941730,Creature — Phyrexian Zombie,Izzy
+Hangman,1,2017,0.37,#000000,https://cards.scryfall.io/normal/front/3/8/380d297c-674a-4d0f-964d-7405db81b27a.jpg?1783935435,Creature — Human Villain,Alex Konstad
+Harbinger of Night,4,1996,31.34,#000000,https://cards.scryfall.io/normal/front/3/3/33124133-ed2c-4b86-a135-ac76f4fe4da5.jpg?1783947092,Creature — Spirit,Tom Kyffin
+Harvester of Misery,5,2024,2.67,#000000,https://cards.scryfall.io/normal/front/a/3/a3012af9-621d-4fae-b00d-079a89ae35fe.jpg?1783912001,Creature — Spirit,Jorge Jacinto
+Harvester of Souls,6,2020,2.38,#000000,https://cards.scryfall.io/normal/front/8/7/870ebc0b-b748-4a21-b939-a48811451bba.jpg?1783930420,Creature — Demon,Slawomir Maniak
+Hatred,5,1998,62.82,#000000,https://cards.scryfall.io/normal/front/2/3/2383a8d9-96fd-4f9a-bcf9-eb81fdb15ead.jpg?1783946517,Instant,Brom
+Haunting Echoes,5,2010,0.27,#000000,https://cards.scryfall.io/normal/front/5/a/5aa96bc7-b92f-4df5-89b5-0793b9e56509.jpg?1783941815,Sorcery,Nils Hamm
+Haunting Voyage,6,2026,0.35,#000000,https://cards.scryfall.io/normal/front/2/0/203ddc5e-3824-4a97-b97d-aeda7b82c704.jpg?1783904559,Sorcery,Ryan Yee
+Havoc Demon,7,2003,0.43,#000000,https://cards.scryfall.io/normal/front/6/4/6477802a-349d-41e1-b050-58da0d806abf.jpg?1783944913,Creature — Demon,Thomas M. Baxa
+Hazel's Brewmaster,4,2024,3.09,#000000,https://cards.scryfall.io/normal/front/5/2/52af8b70-a9c8-40d7-99da-fa51dc293688.jpg?1783910733,Creature — Squirrel Warlock,Simon Dominic
+Head Games,5,2007,3.9,#000000,https://cards.scryfall.io/normal/front/7/3/73ab3037-7e62-46a7-800e-8bfa7d33f237.jpg?1783943036,Sorcery,Terese Nielsen
+Headless Rider,3,2021,4.09,#000000,https://cards.scryfall.io/normal/front/c/2/c24018e8-b8f1-44a5-9355-8b79f363569d.jpg?1783924858,Creature — Zombie,E. M. Gist
+Heartless Conscription,8,2024,2.33,#000000,https://cards.scryfall.io/normal/front/5/2/52fc4862-b57b-42d7-be8b-d9915a0bb4fd.jpg?1783911966,Sorcery,Eli Minaya
+Heartless Summoning,2,2025,1.64,#000000,https://cards.scryfall.io/normal/front/c/5/c50fdb09-e06c-463c-87dd-3c46f4db889a.jpg?1783908139,Enchantment,Anthony Palumbo
+Hedonist's Trove,7,2019,0.29,#000000,https://cards.scryfall.io/normal/front/f/3/f323fb2f-f637-4b87-8a5e-8cb7da606658.jpg?1783932765,Enchantment,Peter Mohrbacher
+Hellcarver Demon,6,2010,7.15,#000000,https://cards.scryfall.io/normal/front/9/8/984a037b-63c0-497d-b3b1-15726ef11a60.jpg?1783941983,Creature — Demon,Greg Staples
+Helldozer,6,2009,0.98,#000000,https://cards.scryfall.io/normal/front/4/d/4dd086af-ee93-4124-a023-f3fc99457dc5.jpg?1783942329,Creature — Zombie Giant,Zoltan Boros & Gabor Szikszai
+Hellish Rebuke,3,2021,4.12,#000000,https://cards.scryfall.io/normal/front/b/4/b4b558cf-8754-4c4f-87f1-8e6d84b93658.jpg?1783926248,Instant,Heonhwa
+Hell's Caretaker,4,2018,1.8,#000000,https://cards.scryfall.io/normal/front/8/4/84a65ccf-37b6-48a3-9873-7a4cafef27cb.jpg?1783935165,Creature — Horror,Greg Staples
+Henrika Domnathi // Henrika- Infernal Seer,4,2021,1.3,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Vampire // Legendary Creature — Vampire,Billy Christian
+Herald of Anguish,7,2017,0.68,#000000,https://cards.scryfall.io/normal/front/3/1/31a69ebe-4229-4067-8414-381b123fe63c.jpg?1783936761,Creature — Demon,Vincent Proce
+Herald of Leshrac,7,2006,5.5,#000000,https://cards.scryfall.io/normal/front/a/d/ad6080b1-b032-4172-8594-4d894a60a80d.jpg?1783943348,Creature — Avatar,Alex Horley-Orlandelli
+Herald of Torment,3,2014,0.3,#000000,https://cards.scryfall.io/normal/front/6/b/6bb7e5ab-57d7-4a86-b7c2-262932ac3344.jpg?1783939556,Enchantment Creature — Demon,Vance Kovacs
+Hero's Demise,2,2005,1.23,#000000,https://cards.scryfall.io/normal/front/d/2/d22dd514-814f-4a62-926d-fef311896c02.jpg?1783944199,Instant,Jim Nelson
+Hero's Downfall,3,2013,0.28,#000000,https://cards.scryfall.io/normal/front/5/9/596822f6-dbd4-4cc8-aa50-9331ff42544e.jpg?1783939779,Instant,Ryan Pancoast
+He Who Hungers,5,2004,0.56,#000000,https://cards.scryfall.io/normal/front/1/c/1ccf0f8d-f988-45ec-b75b-d97206326cfb.jpg?1783944315,Legendary Creature — Spirit,Kev Walker
+Hex,6,2024,0.31,#000000,https://cards.scryfall.io/normal/front/d/8/d87e25fc-b173-4e9a-993d-c1e1053d2f4e.jpg?1783911930,Sorcery,Michael Sutfin
+Hidden Horror,3,1998,1.04,#000000,https://cards.scryfall.io/normal/front/6/4/64243f71-0941-47d5-816b-4548986726b4.jpg?1783946474,Creature — Horror,Brom
+Hidetsugu- Devouring Chaos,4,2022,0.25,#d78f42,https://cards.scryfall.io/normal/front/6/f/6f4142d3-f7ca-4613-a6e5-528cf1f22383.jpg?1783923885,Legendary Creature — Ogre Demon,Isis
+High-Society Hunter,5,2024,0.35,#000000,https://cards.scryfall.io/normal/front/5/1/51da4a4b-ea12-4169-a7cf-eb4427f13e84.jpg?1783909112,Creature — Vampire Noble,Daneen Wilkerson
+Hint of Insanity,3,2001,0.24,#000000,https://cards.scryfall.io/normal/front/d/6/d6abaca0-7ce1-4024-adf6-ef6cc0fbcb75.jpg?1783945244,Sorcery,Luca Zontini
+Hoarding Broodlord,8,2023,5.61,#000000,https://cards.scryfall.io/normal/front/3/8/386ce3c9-869d-461c-a3de-c8add3786f73.jpg?1783917006,Creature — Dragon,Filip Burburan
+Hollowborn Barghest,7,2008,0.32,#000000,https://cards.scryfall.io/normal/front/5/4/544fba3c-0db4-4ac3-ac70-ae9a5468ab5d.jpg?1783942754,Creature — Demon Dog,Eric Fortune
+Hollow Specter,3,2003,0.4,#000000,https://cards.scryfall.io/normal/front/2/d/2db779fd-0e01-417b-aee2-786db2c0b8c8.jpg?1783944913,Creature — Specter,rk post
+Homicide Investigator,2,2024,0.22,#000000,https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg?1783912896,Creature — Human Detective,Jodie Muir
+Hooded Blightfang,3,2020,0.98,#000000,https://cards.scryfall.io/normal/front/a/c/ac38a51f-9a3b-451c-b72d-6d4e0b296fbd.jpg?1783930706,Creature — Snake,Uriah Voth
+Horobi- Death's Wail,4,2004,1.2,#000000,https://cards.scryfall.io/normal/front/b/4/b41983cb-c4e4-4384-bd69-df3fc6e74cd0.jpg?1783944314,Legendary Creature — Spirit,John Bolton
+Hostile Hostel // Creeping Inn,0,2021,0.62,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Land // Artifact Creature — Horror Construct,Daniel Ljunggren
+Hostile Investigator,4,2024,0.41,#000000,https://cards.scryfall.io/normal/front/1/5/158c000e-7960-4518-b034-a529622b7bf1.jpg?1783912001,Creature — Ogre Rogue Detective,Andrew Mar
+Hostile Negotiations,4,2022,0.35,#000000,https://cards.scryfall.io/normal/front/f/8/f827a9a0-7b72-49e2-85fa-adcce1e8fdda.jpg?1783920085,Instant,David Auden Nash
+Hour of Glory,4,2017,0.1,#000000,https://cards.scryfall.io/normal/front/f/3/f35e66cb-af50-411a-b6f2-16fb7072eff5.jpg?1783936040,Instant,Svetlin Velinov
+Hunted Bonebrute,3,2024,0.24,#000000,https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg?1783912897,Creature — Skeleton Beast,Maxime Minard
+Hunted Horror,2,2022,4.4,#000000,https://cards.scryfall.io/normal/front/0/2/02f74866-d0ea-42ce-bc44-500219fb73d4.jpg?1783922444,Creature — Horror,Paolo Parente
+Hunted Nightmare,3,2020,0.14,#000000,https://cards.scryfall.io/normal/front/5/f/5f2dddce-583e-4af3-b144-a60dd268e84f.jpg?1783931060,Creature — Nightmare,Antonio José Manzanedo
+Hymn to Tourach,2,2025,0.58,#000000,https://cards.scryfall.io/normal/front/0/2/028a52c2-d641-49a5-a93b-4c5d01e67234.jpg?1783905114,Sorcery,Sophy Hollington
+Hypnotic Specter,3,2009,1.93,#000000,https://cards.scryfall.io/normal/front/9/6/9695f390-f791-4d64-90b2-731d6d37df1c.jpg?1783942383,Creature — Specter,Greg Staples
+Hypnox,11,2002,2.05,#000000,https://cards.scryfall.io/normal/front/0/e/0e0e53a1-11d5-4975-b698-8b5d72d241f0.jpg?1783945156,Creature — Nightmare Horror,Greg Staples
+Hythonia the Cruel,6,2013,0.36,#000000,https://cards.scryfall.io/normal/front/a/9/a9fbc814-4281-4ac6-a844-68bcd848f229.jpg?1783939778,Legendary Creature — Gorgon,Chris Rahn
+Ichorid,4,2016,0.61,#000000,https://cards.scryfall.io/normal/front/c/d/cd5bc1e4-eefb-4613-aa18-2bf2b9bdf415.jpg?1783937598,Creature — Horror,rk post
+Ill-Gotten Gains,4,2014,1.13,#000000,https://cards.scryfall.io/normal/front/c/f/cf569836-5ee7-4e5c-9ab7-f1004891ee15.jpg?1783939356,Sorcery,Greg Staples
+Illicit Masquerade,4,2024,0.2,#000000,https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg?1783912896,Enchantment,Valera Lutfullina
+Illuminor Szeras,3,2022,6.25,#000000,https://cards.scryfall.io/normal/front/d/1/d161a190-3c85-4207-9d88-7ff9213efea8.jpg?1783920924,Legendary Artifact Creature — Necron,Darren Tan
+Immortal Coil,4,2008,0.55,#000000,https://cards.scryfall.io/normal/front/0/b/0b79ec57-7c45-4ef9-9051-449d473b65ea.jpg?1783942566,Artifact,Dan Murayama Scott
+Imperial Seal,1,2022,163.39,#000000,https://cards.scryfall.io/normal/front/e/7/e71a6bd3-7478-4c3a-8ae0-98352ce28492.jpg?1783921904,Sorcery,Milivoj Ćeran
+Imp's Mischief,2,2023,6.64,#000000,https://cards.scryfall.io/normal/front/0/e/0eb0e8e7-266f-441e-b1cd-12b8ec3f7d71.jpg?1783915672,Instant,Thomas M. Baxa
+Iname- Death Aspect,6,2004,0.4,#000000,https://cards.scryfall.io/normal/front/2/d/2dd67e11-3dad-4e59-b15d-02911e53fbbf.jpg?1783944313,Legendary Creature — Spirit,Justin Sweet
+Incarnation Technique,5,2021,9.66,#000000,https://cards.scryfall.io/normal/front/9/6/9655deda-f02b-47a0-89a3-2904b11b84aa.jpg?1783927597,Sorcery,Alexander Mokhov
+Increasing Ambition,5,2012,2.28,#000000,https://cards.scryfall.io/normal/front/c/8/c8f508dc-7c7d-47e8-a4ef-0e8fd99cbd74.jpg?1783940827,Sorcery,Volkan Baǵa
+Indulgent Tormentor,5,2016,0.54,#000000,https://cards.scryfall.io/normal/front/a/0/a0bb89e2-0d28-4483-b5a7-fddf83d5eac3.jpg?1783937263,Creature — Demon,Wesley Burt
+Infernal Contract,3,2001,0.7,#000000,https://cards.scryfall.io/normal/front/f/4/f451a70f-1f1c-4fd6-ab0c-4b77a043c324.jpg?1783945498,Sorcery,Pete Venters
+Infernal Denizen,8,1995,0.83,#000000,https://cards.scryfall.io/normal/front/b/6/b63ac9a6-aaa5-4659-97d1-c5f6b0d5ccfe.jpg?1783947501,Creature — Demon,Drew Tucker
+Infernal Genesis,6,2000,5.45,#000000,https://cards.scryfall.io/normal/front/1/a/1a63d16e-319d-46f4-a28c-895b36605ee6.jpg?1783945783,Enchantment,Ron Spencer
+Infernal Grasp,2,2025,4.82,#000000,https://cards.scryfall.io/normal/front/8/2/82d69044-8d8c-4ae3-853e-de180f4706ca.jpg?1783905388,Instant,Erik Larsen & Randy Emberlin
+Infernal Kirin,4,2005,2.47,#000000,https://cards.scryfall.io/normal/front/c/7/c79e7a4c-e0e7-42ac-b125-1db2f3d9325c.jpg?1783944155,Legendary Creature — Kirin Spirit,Carl Critchlow
+Infernal Offering,5,2021,0.38,#000000,https://cards.scryfall.io/normal/front/8/a/8af751fd-bfac-43cb-af3b-6116fd643703.jpg?1783927552,Sorcery,Anthony Palumbo
+Infernal Reckoning,1,2018,0.3,#000000,https://cards.scryfall.io/normal/front/4/e/4e291f27-d74f-48e7-bcb4-ddcc558c2211.jpg?1783934570,Instant,Bram Sels
+Infernal Sovereign,6,2023,0.63,#000000,https://cards.scryfall.io/normal/front/f/4/f4fd9a21-a06f-491c-88fa-6e83b1e4c2e9.jpg?1783917248,Creature — Demon,Chris Rallis
+Infernal Spawn of Evil,9,2020,0.28,#000000,https://cards.scryfall.io/normal/front/4/c/4c28a60a-8b2b-45f5-b46e-c0c50218b239.jpg?1783931337,Creature — Beast,Ron Spencer
+Infernal Spawn of Infernal Spawn of Evil,10,2020,0.23,#000000,https://cards.scryfall.io/normal/front/d/f/df2c80d5-960b-4624-9b3e-96943d7b4144.jpg?1783931337,Creature — Demon Child,Ron Spencer
+Infernal Tribute,3,1997,2.86,#000000,https://cards.scryfall.io/normal/front/5/6/569739b2-f212-4cc9-84db-1be17b3f90fb.jpg?1783946733,Enchantment,Terese Nielsen
+Infernal Tutor,2,2024,0.5,#000000,https://cards.scryfall.io/normal/front/4/b/4b868126-f5f4-4541-8f02-9ac0f196d18c.jpg?1783913326,Sorcery,Kev Walker
+Infernius Spawnington III- Esq.,11,2020,0.16,#000000,https://cards.scryfall.io/normal/front/5/e/5e3b1317-f024-4e34-89ad-538fc148cd5c.jpg?1783931337,Creature — Demon Beast Grandchild,Ron Spencer
+Infest,3,2010,0.72,#000000,https://cards.scryfall.io/normal/front/9/3/9350a640-3f22-478f-b463-6b50cfe766e1.jpg?1783942074,Sorcery,Pete Venters
+Infinite Obliteration,3,2015,0.21,#000000,https://cards.scryfall.io/normal/front/7/1/71a6f6a0-3670-4b72-8c8e-668f47252fa0.jpg?1783938341,Sorcery,Yeong-Hao Han
+In Garruk's Wake,9,2022,3.04,#000000,https://cards.scryfall.io/normal/front/5/7/57a6f727-8239-45e6-9dbb-67d2d3c9239d.jpg?1783922445,Sorcery,Chase Stone
+Ink-Eyes- Servant of Oni,6,2016,12.73,#000000,https://cards.scryfall.io/normal/front/5/5/55ed38fc-dc1f-4a03-8869-147f7eb8646b.jpg?1783936836,Legendary Creature — Rat Ninja,Wayne Reynolds
+Inquisition of Kozilek,1,2016,0.5,#000000,https://cards.scryfall.io/normal/front/5/6/56995b84-2307-4955-9c7c-dc4f04acdc07.jpg?1783937313,Sorcery,Volkan Baǵa
+Insatiable Avarice,1,2024,5.13,#000000,https://cards.scryfall.io/normal/front/a/1/a108b0e4-1b43-4659-9e91-facb0bd57ebb.jpg?1783911830,Sorcery,Scott Murphy
+Insatiable Frugivore,4,2024,0.22,#000000,https://cards.scryfall.io/normal/front/2/e/2ef58a8f-ce72-40c2-b032-818cc16267ce.jpg?1783910731,Creature — Rat Berserker,Ben Wootten
+Inscription of Ruin,3,2020,0.17,#000000,https://cards.scryfall.io/normal/front/9/3/93612079-0b8d-489d-9ae1-3593414a8cee.jpg?1783929375,Sorcery,Zoltan Boros
+Insidious Dreams,4,2002,14.84,#000000,https://cards.scryfall.io/normal/front/e/8/e8a29622-23a6-42c7-8e56-690613572c94.jpg?1783945156,Instant,John Avon
+Instigator,2,1999,0.39,#000000,https://cards.scryfall.io/normal/front/2/e/2e3f57af-17d4-4a4c-ae46-fe37f97466fa.jpg?1783945950,Creature — Human Spellshaper,Fred Fields
+Intellect Devourer,4,2022,0.35,#000000,https://cards.scryfall.io/normal/front/a/5/a52d30a3-a436-4854-91e9-2c359c40457b.jpg?1783922758,Creature — Horror,Brian Valeza
+Interceptor- Shadow's Hound,4,2025,0.37,#000000,https://cards.scryfall.io/normal/front/3/0/30be9a07-5803-4bef-9313-391c926bfcec.jpg?1783906358,Legendary Creature — Dog,Sansyu
+Intermediate Chirography,2,2026,0.24,#000000,https://cards.scryfall.io/normal/front/d/6/d60c64aa-57a9-4082-82f4-af0d89c1a52d.jpg?1783903857,Enchantment — Class,Randy Gallegos
+Into the Pit,3,2024,0.44,#000000,https://cards.scryfall.io/normal/front/b/f/bf2fe1f5-0df5-4126-b760-8f3fef9c2ccc.jpg?1783909658,Enchantment,Greg Staples
+Invasion of Fiora // Marchesa- Resolute Monarch,6,2023,0.68,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Legendary Creature — Human Noble,Joshua Raphael
+Invasion of Innistrad // Deluge of the Dead,4,2025,0.33,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Enchantment,Alexey Kruglov
+Invoke Despair,5,2022,0.32,#000000,https://cards.scryfall.io/normal/front/3/5/35af9d5c-4449-4549-b549-c3ba4a67dee0.jpg?1783923885,Sorcery,Olivier Bernard
+Iridescent Vinelasher,1,2024,1.12,#000000,https://cards.scryfall.io/normal/front/b/2/b2bc854c-4e72-48e0-a098-e3451d6e511d.jpg?1783910833,Creature — Lizard Assassin,Aaron Miller
+Isareth the Awakener,3,2018,0.23,#000000,https://cards.scryfall.io/normal/front/7/4/74e49567-8ad6-4ce9-a55d-4db5e0fd9532.jpg?1783934568,Legendary Creature — Human Wizard,Jason Rainville
+Isildur's Fateful Strike,4,2023,0.26,#000000,https://cards.scryfall.io/normal/front/4/b/4bf08071-fbf8-463e-9a57-59dbf0280dd8.jpg?1783916301,Legendary Instant,John Di Giovanni
+Jacob Frye,3,2024,0.37,#000000,https://cards.scryfall.io/normal/front/2/3/23422e75-e1c7-484b-aa1f-155ef9a998ec.jpg?1783910980,Legendary Creature — Human Assassin,Lie Setiawan
+Jadar- Ghoulcaller of Nephalia,2,2026,1.05,#000000,https://cards.scryfall.io/normal/front/4/9/49d5d62b-72ed-446a-b280-ad04c38bdd0c.jpg?1783903786,Legendary Creature — Human Wizard,Yongjae Choi
+Jaws of Defeat,4,2025,0.62,#000000,https://cards.scryfall.io/normal/front/c/4/c495f3bf-86a4-4d2f-821f-c01515f084c9.jpg?1783907177,Enchantment,Andreas Zafiratos
+Jecht- Reluctant Guardian // Braska's Final Aeon,4,2025,0.4,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Warrior // Legendary Enchantment Creature — Saga Nightmare,Michael MacRae
+Jerren- Corrupted Bishop // Ormendahl- the Corrupter,3,2021,0.44,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Cleric // Legendary Creature — Demon,Yongjae Choi
+Josu Vess- Lich Knight,4,2023,0.24,#000000,https://cards.scryfall.io/normal/front/3/0/30553f61-6edf-4e7b-b60f-b8f62ca2bcad.jpg?1783917158,Legendary Creature — Zombie Knight,Tyler Jacobson
+Jovial Evil,3,1994,27.01,#000000,https://cards.scryfall.io/normal/front/c/9/c993c74c-a574-423b-81c8-96b0a7a6e529.jpg?1783948064,Sorcery,Christopher Rush
+Junji- the Midnight Sky,5,2025,0.52,#000000,https://cards.scryfall.io/normal/front/e/9/e9ff50c0-915e-4055-a595-3df6be8f1e1b.jpg?1783907091,Legendary Creature — Dragon Spirit,Chase Stone
+Junún Efreet,3,1993,52.22,#000000,https://cards.scryfall.io/normal/front/5/f/5f46783a-b91e-4829-a173-5515b09ca615.jpg?1783948387,Creature — Efreet,Christopher Rush
+Kaervek's Spite,3,1997,3.13,#000000,https://cards.scryfall.io/normal/front/d/3/d385b9e5-e13d-4098-ba74-ea55bde164d9.jpg?1783946993,Instant,Bryan Talbot
+Kaervek- the Punisher,3,2024,0.34,#000000,https://cards.scryfall.io/normal/front/7/f/7f3affc1-be42-48c7-89ff-b59550ff278c.jpg?1783911831,Legendary Creature — Human Warlock,Cristi Balanescu
+Kaervek- the Spiteful,4,2020,0.3,#000000,https://cards.scryfall.io/normal/front/b/0/b0fd1009-cd3d-4b53-b9f1-dbc47e8708ab.jpg?1783930706,Legendary Creature — Human Warlock,Daarken
+Kagemaro- First to Suffer,5,2005,2.48,#000000,https://cards.scryfall.io/normal/front/7/5/752f8672-1c37-4ab2-b290-fe3147784475.jpg?1783944155,Legendary Creature — Demon Spirit,Adam Rex
+Kain- Traitorous Dragoon,3,2025,0.25,#000000,https://cards.scryfall.io/normal/front/f/8/f8c86be0-e1b3-4a78-9254-238dd936914b.jpg?1783906617,Legendary Creature — Human Knight,Russell Dongjun Lu
+Kalitas- Bloodchief of Ghet,7,2009,6.57,#000000,https://cards.scryfall.io/normal/front/8/5/859aab70-8192-414c-839b-dd0fbcbd8bf1.jpg?1783942151,Legendary Creature — Vampire Warrior,Todd Lockwood
+Kalitas- Traitor of Ghet,4,2016,5.04,#000000,https://cards.scryfall.io/normal/front/1/7/17a278d0-f601-4d57-bc3d-2972f8602a69.jpg?1783937911,Legendary Creature — Vampire Warrior,Todd Lockwood
+Kamber- the Plunderer,4,2024,0.39,#000000,https://cards.scryfall.io/normal/front/f/c/fc7714b3-bcbd-4a63-b517-53166e3facb1.jpg?1783911929,Legendary Creature — Vampire Rogue,Andrey Kuzinskiy
+Karumonix- the Rat King,3,2023,1.21,#000000,https://cards.scryfall.io/normal/front/f/1/f16e282d-8941-46c7-a974-c05b6f73c964.jpg?1783918045,Legendary Creature — Phyrexian Rat,Helge C. Balzer
+Kazarov- Sengir Pureblood,7,2018,0.27,#d78f42,https://cards.scryfall.io/normal/front/2/a/2aff7077-496b-46ca-b9d7-a8c1772f9a91.jpg?1783935006,Legendary Creature — Vampire,Igor Kieryluk
+Kederekt Parasite,1,2024,8.38,#000000,https://cards.scryfall.io/normal/front/b/c/bc5da9e8-c070-4cf4-a21b-24ff2178d751.jpg?1783909618,Creature — Horror,Dan Murayama Scott
+Keen Duelist,2,2026,0.28,#000000,https://cards.scryfall.io/normal/front/0/4/0446a3df-6f77-4b86-b694-ce99feb3d9ab.jpg?1783903783,Creature — Human Wizard,Lindsey Look
+Keeper of Tresserhorn,6,1996,0.63,#000000,https://cards.scryfall.io/normal/front/a/a/aaf8b0ec-f81a-488c-850c-098a8a3119e5.jpg?1783947186,Creature — Avatar,Zak Plucinski & D. Alexander Gregory
+Kels- Fight Fixer,4,2020,0.32,#d78f42,https://cards.scryfall.io/normal/front/b/7/b70d445b-d3d6-4f7c-b9ea-bed6a26d4a2a.jpg?1783930505,Legendary Creature — Azra Warlock,Magali Villeneuve
+Kheru Mind-Eater,3,2017,0.69,#000000,https://cards.scryfall.io/normal/front/e/6/e6246cf3-76bd-476b-9cd9-789b6ad48887.jpg?1783935948,Creature — Vampire,Igor Kieryluk
+Kiku- Night's Flower,2,2004,5.75,#000000,https://cards.scryfall.io/normal/front/0/7/07e18994-d08b-4a8e-abfb-b5531fd6f816.jpg?1783944312,Legendary Creature — Human Assassin,Jim Murray
+Killing Wave,1,2012,0.54,#000000,https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg?1783940697,Sorcery,Steve Argyle
+Kindred Dominance,7,2026,3.31,#000000,https://cards.scryfall.io/normal/front/f/6/f6cd7c08-f5d4-4bdc-a254-809d900b0fc3.jpg?1783903243,Sorcery,Lordigan
+King Macar- the Gold-Cursed,4,2014,0.47,#000000,https://cards.scryfall.io/normal/front/f/f/ff5987ab-570a-426c-ae4a-a270fac6b346.jpg?1783939434,Legendary Creature — Human Noble,Greg Staples
+Kingpin- Wilson Fisk,4,2026,2.32,#000000,https://cards.scryfall.io/normal/front/f/4/f4f16314-d2eb-4117-8b28-4404c82e7343.jpg?1783903061,Legendary Creature — Human Villain,Jason Pastrana
+King's Assassin,3,1997,9.09,#000000,https://cards.scryfall.io/normal/front/6/7/670a3149-54fb-4fd2-bc66-3ee9bcc3519d.jpg?1783946827,Creature — Human Assassin,Zina Saunders
+Kinzu of the Bleak Coven,5,2023,0.35,#000000,https://cards.scryfall.io/normal/front/2/8/28934cf3-c1e0-49c9-93ce-fd60b1881884.jpg?1783917920,Legendary Creature — Phyrexian Vampire,Andreas Zafiratos
+Klaw- Master of Sound,3,2026,0.32,#000000,https://cards.scryfall.io/normal/front/5/c/5c589d94-7cea-4d4c-91a8-4d939634a5e5.jpg?1783903287,Legendary Creature — Elemental Rogue Villain,Ioannis Fiore
+Knife and Death,4,2022,0.12,#000000,https://cards.scryfall.io/normal/front/7/b/7b4b0c89-e811-426c-b185-6d51946c4235.jpg?1783920583,Sorcery,Caio Monteiro
+Knight of the Ebon Legion,1,2019,2.65,#000000,https://cards.scryfall.io/normal/front/2/9/29425426-7bf2-4872-aa35-c12c22801edd.jpg?1783932992,Creature — Vampire Knight,Alex Konstad
+Knucklebone Witch,1,2007,1.87,#000000,https://cards.scryfall.io/normal/front/7/d/7d66b355-9aff-4cce-ae4a-42b233475dcf.jpg?1783942889,Creature — Goblin Shaman,Jim Pavelec
+Koh- the Face Stealer,6,2025,0.41,#000000,https://cards.scryfall.io/normal/front/2/8/28f6fa32-5058-4c29-9ba8-9d8f2057eb6d.jpg?1783904969,Legendary Creature — Shapeshifter Spirit,Eduardo Francisco
+Kokusho- the Evening Star,6,2017,23.61,#000000,https://cards.scryfall.io/normal/front/a/b/ab56cedb-1bcd-48a5-8503-a8e324e236ad.jpg?1783935537,Legendary Creature — Dragon Spirit,Slawomir Maniak
+Korlash- Heir to Blackblade,4,2007,3.35,#000000,https://cards.scryfall.io/normal/front/3/2/32f1f022-da7f-49a4-881d-b3a2c54c38eb.jpg?1783943109,Legendary Creature — Zombie Warrior,Daarken
+Koskun Falls,4,1995,15.72,#000000,https://cards.scryfall.io/normal/front/0/4/04292a4e-8910-4911-a76d-4f2c3e15da33.jpg?1783947289,World Enchantment,Rob Alexander
+Kothophed- Soul Hoarder,6,2022,0.28,#000000,https://cards.scryfall.io/normal/front/a/1/a1070dd6-944f-44a0-8834-02eae93dabaa.jpg?1783921429,Legendary Creature — Demon,Jakub Kasper
+Krav- the Unredeemed,5,2018,3.17,#000000,https://cards.scryfall.io/normal/front/6/7/67bd3c49-ff73-4630-a4ee-c782f03e511d.jpg?1783934878,Legendary Creature — Demon,Randy Vargas
+K'rrik- Son of Yawgmoth,7,2024,0.78,#000000,https://cards.scryfall.io/normal/front/4/f/4f087b1c-97e0-4379-a94d-beac53685314.jpg?1783911216,Legendary Creature — Phyrexian Horror Minion,Chase Stone
+Kuon- Ogre Ascendant // Kuon's Essence,3,2005,1.15,#000000,https://cards.scryfall.io/normal/front/4/1/41004bdf-8e09-4b2c-9e9c-26c25eac9854.jpg?1783944153,Legendary Creature — Ogre Monk // Legendary Enchantment,Hideaki Takamura
+Kuro- Pitlord,9,2014,0.55,#000000,https://cards.scryfall.io/normal/front/e/1/e1f9531a-7201-4dfc-beb1-4128ec41728c.jpg?1783938779,Legendary Creature — Demon Spirit,Jon Foster
+Kyoki- Sanity's Eclipse,6,2005,1.22,#000000,https://cards.scryfall.io/normal/front/d/c/dc0969e6-f667-4e29-a038-8569022cce32.jpg?1783944198,Legendary Creature — Demon Spirit,Paolo Parente
+Lamentation,6,2026,0.27,#000000,https://cards.scryfall.io/normal/front/2/d/2dbc775a-ec2b-442f-a817-4108c05d7fab.jpg?1783904605,Creature — Elemental Incarnation,Lars Grant-West
+Languish,4,2020,0.37,#000000,https://cards.scryfall.io/normal/front/9/b/9b53ce1b-9353-42ad-89a0-36e907ba576a.jpg?1783930420,Sorcery,Jeff Simpson
+Laquatus's Champion,6,2018,0.23,#000000,https://cards.scryfall.io/normal/front/0/e/0e7ed355-894a-4592-9a64-ef061550d560.jpg?1783935163,Creature — Nightmare Horror,Greg Staples
+Larceny,5,2003,0.26,#000000,https://cards.scryfall.io/normal/front/1/c/1cb3eddb-cd89-4cec-92b4-4006dece36a8.jpg?1783944758,Enchantment,Dave Dorman
+Last Laugh,4,2002,2.72,#000000,https://cards.scryfall.io/normal/front/d/4/d4c05f2a-b844-42b3-af91-65694b4211dd.jpg?1783945155,Enchantment,John Matson
+Lazotep Sliver,4,2023,8.57,#000000,https://cards.scryfall.io/normal/front/5/1/517f7b4d-2997-412b-8e25-315d93d1603a.jpg?1783915481,Creature — Zombie Sliver,Maxime Minard
+Legion's End,2,2019,0.13,#000000,https://cards.scryfall.io/normal/front/4/9/49a1cd92-9d75-4e22-a934-a26d84967015.jpg?1783932991,Sorcery,David Palumbo
+Leshrac's Sigil,2,2022,1.67,#000000,https://cards.scryfall.io/normal/front/3/6/3672010d-7293-4906-b76d-759112c89c51.jpg?1783919209,Enchantment,Livia Prima
+Lethal Protection,4,2025,1.44,#000000,https://cards.scryfall.io/normal/front/d/9/d98f0e44-f5c7-4e08-8a4a-d0280f22d132.jpg?1783905372,Sorcery,Néstor Ossandón Leal
+Lethal Vapors,4,2003,8.99,#000000,https://cards.scryfall.io/normal/front/f/9/f96acfea-009a-4ac9-8746-64f65199024f.jpg?1783944879,Enchantment,John Avon
+Leyline of the Void,4,2024,0.56,#000000,https://cards.scryfall.io/normal/front/a/e/aeaa3aff-608d-4723-bb7c-8daedebe9f36.jpg?1783909479,Enchantment,Sergey Glushakov
+Liability,3,1999,1.15,#000000,https://cards.scryfall.io/normal/front/0/b/0b07c66d-5f37-4098-b7e6-03e6c684806b.jpg?1783945950,Enchantment,Christopher Moeller
+Lich-Knights' Conquest,5,2023,0.85,#000000,https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg?1783915106,Sorcery,Denis Zhbankov
+Lich's Mastery,6,2018,0.86,#000000,https://cards.scryfall.io/normal/front/7/7/77f4c9cb-f364-4556-8673-4b19d52a2cff.jpg?1783935005,Legendary Enchantment,Daarken
+Liege of the Pit,8,2006,0.7,#000000,https://cards.scryfall.io/normal/front/5/2/52e7c608-d224-472b-8736-273874211f24.jpg?1783943233,Creature — Demon,Jeremy Jarvis
+Lifebane Zombie,3,2013,0.33,#000000,https://cards.scryfall.io/normal/front/9/8/98370735-5303-40d4-9e80-cdb40dee18e2.jpg?1783939922,Creature — Zombie Warrior,Min Yum
+Life's Finale,6,2011,1.58,#000000,https://cards.scryfall.io/normal/front/f/f/ffd3fbd2-87c7-4f08-baaa-91d61c1114da.jpg?1783941312,Sorcery,Svetlin Velinov
+"Lifetime" Pass Holder,1,2022,0.31,#000000,https://cards.scryfall.io/normal/front/f/e/fede7f75-0dff-4f3e-816d-e52b43e8b33b.jpg?1783920578,Creature — Zombie Guest,Jeff Miracola
+Liliana- Death's Majesty,5,2021,0.53,#000000,https://cards.scryfall.io/normal/front/b/6/b63ae119-f91e-4d0d-8bbd-65350a4d47c4.jpg?1783925336,Legendary Planeswalker — Liliana,Chris Rallis
+Liliana- Death Wielder,7,2026,0.36,#000000,https://cards.scryfall.io/normal/front/6/f/6f874b0e-32e3-421f-8109-522638b3f38d.jpg?1783904559,Legendary Planeswalker — Liliana,Clint Cearley
+Liliana- Dreadhorde General,6,2024,6.59,#000000,https://cards.scryfall.io/normal/front/c/b/cb28d217-795e-4320-a032-cd713f7ecc8a.jpg?1783909073,Legendary Planeswalker — Liliana,Chris Rallis
+Liliana- Heretical Healer // Liliana- Defiant Necromancer,3,2022,6.59,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Cleric // Legendary Planeswalker — Liliana,Bastien L. Deharme
+Liliana of the Dark Realms,4,2013,9.13,#000000,https://cards.scryfall.io/normal/front/0/0/00cbe506-7332-4d29-9404-b7c6e1e791d8.jpg?1783939922,Legendary Planeswalker — Liliana,D. Alexander Gregory
+Liliana of the Veil,3,2025,7.12,#000000,https://cards.scryfall.io/normal/front/e/f/efbb7256-9337-4183-8bda-a419f3f2c501.jpg?1783907977,Legendary Planeswalker — Liliana,Steve Argyle
+Liliana's Contract,5,2018,4.13,#000000,https://cards.scryfall.io/normal/front/7/5/750e6246-c28d-46ed-9966-26706f6d3172.jpg?1783934567,Enchantment,Bastien L. Deharme
+Liliana's Influence,6,2017,0.35,#000000,https://cards.scryfall.io/normal/front/2/8/28cdf48e-e0d4-45ca-b48d-74ada54ba62e.jpg?1783936436,Sorcery,Winona Nelson
+Liliana's Mastery,5,2021,0.35,#000000,https://cards.scryfall.io/normal/front/a/9/a92ee6ec-eebf-40b4-9dd9-c0551e33f5ff.jpg?1783925336,Enchantment,Kieran Yanner
+Liliana's Reaver,4,2020,0.45,#000000,https://cards.scryfall.io/normal/front/f/a/fa9396f3-a93c-47ee-91da-78af864c86c3.jpg?1783930417,Creature — Zombie,Karl Kopinski
+Liliana's Scorn,5,2020,0.3,#000000,https://cards.scryfall.io/normal/front/b/2/b231f941-4acb-46f2-81ae-16e5a28e65af.jpg?1783930620,Sorcery,Josh Hass
+Liliana's Spoils,4,2018,0.38,#000000,https://cards.scryfall.io/normal/front/e/9/e960fb5a-70cc-490d-99cf-99bc65485cfb.jpg?1783934485,Sorcery,Tyler Jacobson
+Liliana's Standard Bearer,3,2023,0.28,#000000,https://cards.scryfall.io/normal/front/e/6/e60aaa4e-267c-4909-8abe-414a04d2c127.jpg?1783917158,Creature — Zombie Knight,Josh Hass
+Liliana's Talent,2,2023,0.65,#000000,https://cards.scryfall.io/normal/front/f/b/fb49be5e-142b-4077-87e3-a17584205f37.jpg?1783917246,Enchantment — Aura,A. M. Sartor
+Liliana- the Last Hope,3,2022,4.61,#000000,https://cards.scryfall.io/normal/front/f/7/f7ae5085-0d0d-4d7d-80a3-614315a07de5.jpg?1783921903,Legendary Planeswalker — Liliana,Jaime Jones
+Liliana- Untouched by Death,4,2018,1.61,#000000,https://cards.scryfall.io/normal/front/a/7/a7939170-f84e-44c6-b8bc-a180cf7f85d9.jpg?1783934566,Legendary Planeswalker — Liliana,Bastien L. Deharme
+Liliana Vess,5,2014,12.09,#000000,https://cards.scryfall.io/normal/front/6/0/6087f146-f468-472a-b248-fc7386ea3e63.jpg?1783939183,Legendary Planeswalker — Liliana,Aleksi Briclot
+Liliana- Waker of the Dead,4,2020,2.98,#000000,https://cards.scryfall.io/normal/front/e/3/e329a3e2-6702-4758-8aac-c3017e77b619.jpg?1783930705,Legendary Planeswalker — Liliana,Anna Steinbauer
+Lim-Dûl the Necromancer,7,2006,1.15,#000000,https://cards.scryfall.io/normal/front/b/8/b8a3cdfe-0289-474b-b9c4-07e8c6588ec5.jpg?1783943231,Legendary Creature — Human Wizard,Matt Cavotta
+Lion Vulture,4,2025,0.28,#000000,https://cards.scryfall.io/normal/front/a/e/ae735220-413d-4309-8e31-38ff27ead5ee.jpg?1783904781,Creature — Cat Bird,Nathaniel Himawan
+Living Death,5,2025,2.58,#000000,https://cards.scryfall.io/normal/front/4/a/4ac29c46-f8ee-42ba-a98c-d785ba65485e.jpg?1783907088,Sorcery,Mark Winters
+Living End,0,2021,5.35,#000000,https://cards.scryfall.io/normal/front/b/1/b1eede29-17a4-437f-a5c2-e24cccbc6a33.jpg?1783927818,Sorcery,Greg Staples
+Lo and Li- Royal Advisors,4,2025,0.21,#d78f42,https://cards.scryfall.io/normal/front/0/9/0992a8a7-e992-4fbd-bafd-e28761d2f677.jpg?1783904824,Legendary Creature — Human Advisor,Kieran Yanner
+Lobelia- Defender of Bag End,3,2023,0.31,#000000,https://cards.scryfall.io/normal/front/6/d/6d67a523-bda9-4f8b-bd50-dc015f9b4b7a.jpg?1783916031,Legendary Creature — Halfling Citizen,Caroline Gariba
+Lobelia Sackville-Baggins,3,2023,0.3,#000000,https://cards.scryfall.io/normal/front/8/7/87500b92-3d68-42f3-afa9-f8206b2ebcbb.jpg?1783916303,Legendary Creature — Halfling Citizen,Hristo D. Chukov
+Locthwain Lancer,5,2023,0.35,#000000,https://cards.scryfall.io/normal/front/7/4/7417067d-de28-404c-981e-e62b05d2bdf1.jpg?1783917285,Creature — Human Knight,Lars Grant-West
+Lokhust Heavy Destroyer,4,2022,0.42,#000000,https://cards.scryfall.io/normal/front/4/6/4665fa5d-37ea-4898-a4a4-7bc5311075de.jpg?1783920923,Artifact Creature — Necron,Adrián Rodríguez Pérez
+Lolth- Spider Queen,5,2021,5.62,#000000,https://cards.scryfall.io/normal/front/4/2/420a5689-d73e-4dda-82fd-8b8897ff5b55.jpg?1783926491,Legendary Planeswalker — Lolth,Tyler Jacobson
+Long Goodbye,2,2026,1.87,#000000,https://cards.scryfall.io/normal/front/b/8/b8f4205f-6a9e-4648-bb30-fb6edaaa50ff.jpg?1783903395,Instant,Gary Baseman
+Lorcan- Warlock Collector,7,2021,0.52,#000000,https://cards.scryfall.io/normal/front/5/f/5f6f90ae-340c-4eb7-b091-58db550be742.jpg?1783926248,Legendary Creature — Devil,Andrew Mar
+Lord of the Forsaken,6,2025,0.31,#000000,https://cards.scryfall.io/normal/front/0/f/0f87514c-cb45-443c-8768-891e2213950e.jpg?1783907088,Creature — Demon,Kekai Kotaki
+Lord of the Pit,7,2017,0.45,#000000,https://cards.scryfall.io/normal/front/5/b/5b626ab2-4cf6-42e8-a7e2-9c9f310d2f00.jpg?1783935537,Creature — Demon,Chippy
+Lord of the Undead,3,2007,12.01,#000000,https://cards.scryfall.io/normal/front/7/9/792e773b-5feb-407f-a162-f35d6e693cca.jpg?1783943034,Creature — Zombie,Brom
+Lord of the Void,7,2024,14.56,#000000,https://cards.scryfall.io/normal/front/2/e/2e014649-0d96-4bc9-8446-e57df50a2a4c.jpg?1783913325,Creature — Demon,Chris Rahn
+Lord Skitter's Blessing,2,2023,0.44,#000000,https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg?1783915106,Enchantment,Joseph Weston
+Lord Skitter- Sewer King,3,2023,4.98,#000000,https://cards.scryfall.io/normal/front/7/2/729877be-4894-4ef5-9e60-de8a8fb2bdc0.jpg?1783915106,Legendary Creature — Rat Noble,Jesper Ejsing
+Lost Legacy,3,2016,0.21,#000000,https://cards.scryfall.io/normal/front/d/5/d5d0e447-d98e-43d5-9b53-166221c34be2.jpg?1783937205,Sorcery,Greg Opalinski
+Lost Monarch of Ifnir,4,2025,0.62,#000000,https://cards.scryfall.io/normal/front/c/a/cae37ab0-9d60-45e9-98cb-e7427e508bc5.jpg?1783907751,Creature — Zombie Noble,Piotr Dura
+Lurking Evil,3,1998,0.44,#000000,https://cards.scryfall.io/normal/front/f/5/f5ef7201-4443-4a77-b9e1-6f1f39e8f993.jpg?1783946343,Enchantment,Scott Kirschner
+Lurking Skirge,2,1999,0.51,#000000,https://cards.scryfall.io/normal/front/9/0/9063cc12-a822-4488-856e-93d70ecfe37f.jpg?1783946241,Enchantment,Daren Bader
+Lychguard,3,2022,0.4,#000000,https://cards.scryfall.io/normal/front/6/7/6737a276-b5e9-4c55-b995-ada96eca4e6e.jpg?1783920922,Artifact Creature — Necron,Games Workshop
+Madame Hydra- Reanimated,4,2026,2.65,#000000,https://cards.scryfall.io/normal/front/c/8/c831bdda-06a9-465a-bec5-2b380d28d82a.jpg?1783903101,Legendary Creature — Human Horror Villain,Jennifer Hrabota Lesser
+Madame Null- Power Broker,3,2026,0.46,#000000,https://cards.scryfall.io/normal/front/4/e/4e712d5c-d6fe-40bb-b8e5-5f50c6ea8d4f.jpg?1783904106,Legendary Creature — Demon Advisor,Irina Nordsol
+Mad Auntie,3,2007,0.98,#000000,https://cards.scryfall.io/normal/front/3/9/39b1655b-ab0a-40d9-8d4d-55d13310ede1.jpg?1783942887,Creature — Goblin Shaman,Wayne Reynolds
+Maddening Imp,3,1997,1.33,#000000,https://cards.scryfall.io/normal/front/d/d/dda08eb5-c75c-4c21-bfd1-1f04a3575241.jpg?1783946637,Creature — Imp,Zina Saunders
+Maga- Traitor to Mortals,3,2005,3.42,#000000,https://cards.scryfall.io/normal/front/2/5/2563fd68-afdd-466f-8137-0769565674bf.jpg?1783944152,Legendary Creature — Human Wizard,Jim Murray
+Magus of the Abyss,4,2020,0.32,#000000,https://cards.scryfall.io/normal/front/9/9/9954157a-0c05-4788-8a0f-6093ebbb38c3.jpg?1783930178,Creature — Human Wizard,Kev Walker
+Magus of the Bridge,3,2021,0.21,#000000,https://cards.scryfall.io/normal/front/8/e/8ec4b7d1-16ed-4cc3-8db3-12fb8f25658c.jpg?1783926859,Creature — Human Wizard,Bryan Sola
+Magus of the Coffers,5,2014,4.98,#000000,https://cards.scryfall.io/normal/front/9/6/962a16bb-516c-4e74-b8dd-edd4c63c5fff.jpg?1783938843,Creature — Human Wizard,Don Hazeltine
+Magus of the Mirror,6,2014,0.62,#000000,https://cards.scryfall.io/normal/front/8/1/81357a2a-e436-469f-8610-3572c29fef15.jpg?1783939355,Creature — Human Wizard,Christopher Moeller
+Magus of the Will,3,2020,0.38,#000000,https://cards.scryfall.io/normal/front/2/4/24c41068-59d8-4ef4-aae4-a93b0a9ee19e.jpg?1783930177,Creature — Human Wizard,Vincent Proce
+Maha- Its Feathers Night,5,2024,23.22,#000000,https://cards.scryfall.io/normal/front/c/f/cf3320ec-c4e8-405a-982d-e009c58c9e21.jpg?1783910833,Legendary Creature — Elemental Bird,Alessandra Pisano
+Mai- Scornful Striker,2,2025,1.06,#000000,https://cards.scryfall.io/normal/front/7/4/74dd4c0e-27b8-4c47-b7a6-a281413cd6b4.jpg?1783904968,Legendary Creature — Human Noble Ally,Hori Airi
+Make an Example,4,2022,10.07,#000000,https://cards.scryfall.io/normal/front/b/4/b4ed0e64-c7d8-49a2-9d00-21076484da0a.jpg?1783923366,Sorcery,Igor Grechanyi
+Malakir Bloodwitch,5,2021,5.14,#000000,https://cards.scryfall.io/normal/front/b/9/b91ceead-5071-43e8-bf90-f379d683acdf.jpg?1783924954,Creature — Vampire Shaman,Shelly Wan
+Malevolent Witchkite,6,2023,0.35,#000000,https://cards.scryfall.io/normal/front/d/6/d6cb3c6d-560d-40ca-b5c0-27322863cead.jpg?1783915040,Creature — Dragon Warlock,Donato Giancola
+Malicious Affliction,2,2016,3.09,#000000,https://cards.scryfall.io/normal/front/1/2/127f3f4d-93f4-4e52-b3c1-325c3981e0e1.jpg?1783937596,Instant,Erica Yang
+Mandate of Abaddon,4,2022,4.65,#000000,https://cards.scryfall.io/normal/front/b/6/b63fa88b-a177-49b7-a583-a0a041313f77.jpg?1783920921,Sorcery,Games Workshop
+Maralen of the Mornsong,3,2008,33.8,#000000,https://cards.scryfall.io/normal/front/b/a/ba98d363-194b-4bc0-b9fe-987c498ab6fa.jpg?1783942792,Legendary Creature — Elf Wizard,Mark Zug
+Marauding Knight,4,2000,0.66,#000000,https://cards.scryfall.io/normal/front/c/e/cea2a7de-c67e-4541-be8c-e5ef7b64d94a.jpg?1783945695,Creature — Phyrexian Zombie Knight,Daren Bader
+March of Wretched Sorrow,1,2022,0.34,#000000,https://cards.scryfall.io/normal/front/0/5/050a604e-6146-4e2e-88a5-863ecb3dfa1f.jpg?1783923880,Instant,Tyler Jacobson
+Mardu Outrider,3,2024,0.25,#000000,https://cards.scryfall.io/normal/front/3/d/3d78478d-5bdb-4c29-aa3a-9de18a5fcd52.jpg?1783910622,Creature — Orc Warrior,Evan Shipard
+Mardu Strike Leader,3,2022,0.36,#000000,https://cards.scryfall.io/normal/front/6/2/626ed059-9bd1-4a18-ac85-7b00b8057426.jpg?1783922445,Creature — Human Warrior,Jason Rainville
+Marionette Master,6,2021,4.11,#000000,https://cards.scryfall.io/normal/front/d/d/dd21a925-c76f-4c1d-b5b8-8d3352730e5f.jpg?1783926217,Creature — Human Artificer,James Ryman
+Mari- the Killing Quill,3,2024,4.54,#000000,https://cards.scryfall.io/normal/front/6/b/6b4b3c1a-671c-422d-a98c-7d750760ca46.jpg?1783911928,Legendary Creature — Vampire Assassin,Rob Rey
+Markov Dreadknight,5,2016,0.2,#000000,https://cards.scryfall.io/normal/front/f/a/fa3ed9d2-9053-4583-a226-0ab49bbdab6e.jpg?1783937770,Creature — Vampire Knight,Darek Zabrocki
+Marrow-Gnawer,5,2004,28.71,#000000,https://cards.scryfall.io/normal/front/7/2/72e4548b-c171-4f10-b896-af37543dcf0f.jpg?1783944312,Legendary Creature — Rat Rogue,Wayne Reynolds
+Marshland Bloodcaster,5,2024,0.33,#000000,https://cards.scryfall.io/normal/front/4/d/4db8bd3e-2554-40eb-8e6d-d2eb589d9344.jpg?1783911927,Creature — Vampire Warlock,Jodie Muir
+Masked Gorgon,5,2002,0.42,#000000,https://cards.scryfall.io/normal/front/0/d/0d62728b-b834-4fa8-aed5-6348033ee69c.jpg?1783945122,Creature — Gorgon,Matthew D. Wilson
+Mask of Griselbrand,3,2024,0.73,#000000,https://cards.scryfall.io/normal/front/a/8/a8c36e65-395c-4800-bd0a-c444940a9b36.jpg?1783909617,Legendary Artifact — Equipment,Jason Felix
+Massacre,4,2024,5.74,#000000,https://cards.scryfall.io/normal/front/c/4/c4472b2e-b47a-4bc3-992b-9f8a218594f6.jpg?1783911475,Sorcery,Andrey Kuzinskiy
+Massacre Girl,5,2024,0.46,#000000,https://cards.scryfall.io/normal/front/5/9/59957c45-4672-4650-80b1-70e4a60b429e.jpg?1783909617,Legendary Creature — Human Assassin,Chris Rallis
+Massacre Girl- Known Killer,4,2026,0.72,#000000,https://cards.scryfall.io/normal/front/8/e/8ef53e5e-709c-4613-a5ab-6bf12961b2e1.jpg?1783904559,Legendary Creature — Human Assassin,Billy Christian
+Massacre Wurm,6,2026,1.26,#000000,https://cards.scryfall.io/normal/front/6/7/670a36cc-34e1-4d11-808e-1b6bc88eb5d8.jpg?1783903950,Creature — Phyrexian Wurm,Jason Chan
+Masterful Ninja,3,2017,0.29,#000000,https://cards.scryfall.io/normal/front/f/7/f7f0b8b2-0202-4e68-970d-cd006f63de61.jpg?1783935434,Creature — Troll Ninja,Matt Gaser
+Mastermind Plum,3,2024,1.82,#000000,https://cards.scryfall.io/normal/front/d/f/df81568b-c66a-49c6-bd48-7df98ea00117.jpg?1783912584,Legendary Creature — Human Wizard,Bryan Sola
+Mastermind's Acquisition,4,2018,1.95,#000000,https://cards.scryfall.io/normal/front/2/f/2f00f09b-a113-460e-ac2f-d3988a83179e.jpg?1783935310,Sorcery,Svetlin Velinov
+Master of Dark Rites,1,2023,3.34,#000000,https://cards.scryfall.io/normal/front/6/3/6394a522-37bb-4cf3-b434-5121c8000ac6.jpg?1783913910,Creature — Vampire Cleric,Igor Kieryluk
+Master of the Feast,3,2014,6.73,#000000,https://cards.scryfall.io/normal/front/d/5/d528f7a3-0a7b-42e3-8e4f-f1eeab02e23a.jpg?1783939433,Enchantment Creature — Demon,Chris Rahn
+Mausoleum Secrets,2,2018,0.78,#000000,https://cards.scryfall.io/normal/front/2/6/26f7cf38-78cc-4139-9f2a-4dd0be7d9da8.jpg?1783934174,Instant,Adam Paquette
+Meathook Massacre II,4,2024,2.45,#000000,https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg?1783909478,Legendary Enchantment,Tiffany Turrill
+Memoricide,4,2010,0.2,#000000,https://cards.scryfall.io/normal/front/a/c/acc5b944-a9fe-4a64-bf11-51817a26f22b.jpg?1783941730,Sorcery,James Ryman
+Mephidross Vampire,6,2004,2.49,#000000,https://cards.scryfall.io/normal/front/7/5/754f202f-4f08-4c39-9219-1114d8508788.jpg?1783944398,Creature — Vampire,Matthew D. Wilson
+Mephitic Ooze,5,2004,0.54,#000000,https://cards.scryfall.io/normal/front/5/4/5465de95-1249-4f14-a2e3-2b2861dfe058.jpg?1783944442,Creature — Ooze,Alex Horley-Orlandelli
+Mercenary Knight,3,1997,3.2,#000000,https://cards.scryfall.io/normal/front/e/c/ec9f97a2-b04e-418b-89c7-1c019288f27a.jpg?1783946826,Creature — Human Mercenary Knight,Adrian Smith
+Merchant of Venom,4,2026,0.27,#000000,https://cards.scryfall.io/normal/front/d/6/d60cf719-d5ce-46c3-bf92-24682b1c53bd.jpg?1783903858,Creature — Cat Warlock,Diana Franco
+Merciless Executioner,3,2022,10.18,#000000,https://cards.scryfall.io/normal/front/f/5/f5d054f9-ef77-4552-aa49-e9dfd840d8f6.jpg?1783919222,Creature — Orc Warrior,Paolo Parente
+Metamorphosis Fanatic,6,2024,5.98,#000000,https://cards.scryfall.io/normal/front/1/6/16448d95-ee21-4def-b880-26f6f159c213.jpg?1783909658,Creature — Human Cleric,Andreas Zafiratos
+Midnight Banshee,6,2026,0.33,#000000,https://cards.scryfall.io/normal/front/f/0/f0a38737-22e6-469f-94d8-12b9a62f4495.jpg?1783904557,Creature — Spirit,Daarken
+Midnight Entourage,4,2017,0.12,#000000,https://cards.scryfall.io/normal/front/2/8/2838c6dd-d816-4363-a861-f2f8052d1430.jpg?1783936761,Creature — Aetherborn Rogue,Lius Lasahido
+Midnight Oil,4,2016,0.23,#000000,https://cards.scryfall.io/normal/front/1/4/14875840-044d-482f-845e-79240cad66f3.jpg?1783937203,Enchantment,Daniel Ljunggren
+Midnight Reaper,3,2024,0.2,#000000,https://cards.scryfall.io/normal/front/f/2/f229b0e6-1ffd-410e-b04b-a0afc179c58c.jpg?1783908929,Creature — Zombie Knight,Sidharth Chaturvedi
+Midnight Ritual,3,2007,0.23,#000000,https://cards.scryfall.io/normal/front/4/2/4239c4e8-41f3-47fd-bd01-fa0b28976e29.jpg?1783943033,Sorcery,Jeff Easley
+Mikaeus- the Unhallowed,6,2023,24.44,#000000,https://cards.scryfall.io/normal/front/b/c/bc1f42a2-fe11-45da-9552-069803b4068a.jpg?1783915670,Legendary Creature — Zombie Cleric,Chris Rahn
+Mindblade Render,2,2025,0.28,#000000,https://cards.scryfall.io/normal/front/2/7/27e43b25-9a9e-4bfc-9589-77d1f53a3c4b.jpg?1783907086,Creature — Azra Warrior,Mitchell Malloy
+Mindleecher,6,2020,0.46,#000000,https://cards.scryfall.io/normal/front/2/b/2bf6b21a-8e18-400c-a39c-d693e487e47b.jpg?1783931218,Creature — Nightmare,Antonio José Manzanedo
+Mind Shatter,2,2017,0.31,#000000,https://cards.scryfall.io/normal/front/2/8/28c44782-a12f-4ecc-a6e8-d569e2942a9a.jpg?1783936654,Sorcery,Michael Sutfin
+Mindslicer,4,2023,0.57,#000000,https://cards.scryfall.io/normal/front/a/f/afc86134-8af6-4355-b1ad-96917c99ff3c.jpg?1783918474,Creature — Horror,Kev Walker
+Mindwarper,4,1998,0.25,#000000,https://cards.scryfall.io/normal/front/e/b/ebe796e1-97f9-469a-a6b6-a09161058e12.jpg?1783946561,Creature — Spirit,Paolo Parente
+Mind Whip,4,1995,0.44,#000000,https://cards.scryfall.io/normal/front/3/f/3f3ff5fb-4126-4a18-b540-2beaae382e59.jpg?1783947498,Enchantment — Aura,Drew Tucker
+Mindwrack Demon,4,2016,0.38,#000000,https://cards.scryfall.io/normal/front/b/8/b804cb9c-349e-4143-a372-cf65470d5b46.jpg?1783937768,Creature — Demon,Matt Stewart
+Minion of the Wastes,6,1997,0.97,#000000,https://cards.scryfall.io/normal/front/d/9/d9f120fc-c681-47b6-827e-1cc7ead47a0f.jpg?1783946637,Creature — Minion,Scott Kirschner
+Minotaur- Roxxon CEO,6,2026,2.76,#000000,https://cards.scryfall.io/normal/front/7/a/7a40c996-7b64-4d56-a21f-b68ac64c1e99.jpg?1783903103,Legendary Creature — Minotaur Villain,David Palumbo
+Mirri the Cursed,4,2021,0.46,#000000,https://cards.scryfall.io/normal/front/2/4/24c1706d-2faa-452b-a192-204386df29f6.jpg?1783927815,Legendary Creature — Vampire Cat,Filip Burburan
+Misery's Shadow,2,2022,0.33,#000000,https://cards.scryfall.io/normal/front/5/1/514c5e77-9ecc-41c9-b104-76343601fafb.jpg?1783920084,Creature — Shade,Igor Kieryluk
+Misfortune Teller,4,2024,0.19,#000000,https://cards.scryfall.io/normal/front/7/c/7c9e6ca9-14cf-4476-8c55-b98a6ebe6101.jpg?1783911927,Creature — Human Warlock,Nils Hamm
+M.O.D.O.K.,5,2026,4.91,#000000,https://cards.scryfall.io/normal/front/3/8/38e87542-50f7-4812-9338-84e4b9b7bb44.jpg?1783902940,Legendary Artifact Creature — Villain,Simon Dominic
+M.O.D.O.K.- Evil Intellect,5,2026,4.62,#000000,https://cards.scryfall.io/normal/front/d/e/de490be1-4b62-4dc8-ad00-55de74d501dd.jpg?1783903108,Legendary Artifact Creature — Villain,Kieran Yanner
+Moira- Urborg Haunt,3,2022,0.36,#000000,https://cards.scryfall.io/normal/front/0/a/0a5c9d99-8fbc-4a74-99a5-32ba71eb2b62.jpg?1783921478,Legendary Creature — Spirit Wizard,Marta Nael
+Mold Demon,7,1994,17.58,#000000,https://cards.scryfall.io/normal/front/6/4/649a33aa-7eac-4161-ae1a-fcbc758abccf.jpg?1783948064,Creature — Fungus Demon,Jesper Myrfors
+Monomania,5,2011,0.27,#000000,https://cards.scryfall.io/normal/front/6/a/6af53d7f-7f02-4c35-b6f4-7365d121ba54.jpg?1783941080,Sorcery,James Ryman
+Monumental Corruption,5,2023,0.35,#000000,https://cards.scryfall.io/normal/front/2/d/2da97319-de80-4d71-82fc-715109cf8e2c.jpg?1783918155,Sorcery,Sergey Glushakov
+Moonlight Bargain,5,2018,0.33,#000000,https://cards.scryfall.io/normal/front/6/6/662097e6-355f-4192-9fa7-4b8c22346a64.jpg?1783934299,Instant,Nick Percival
+Moonshadow,1,2026,10.8,#000000,https://cards.scryfall.io/normal/front/2/5/2573e694-eaa0-42ca-b470-2ab507cbcec1.jpg?1783904461,Creature — Elemental,Olivier Bernard
+Moonstone Eulogist,5,2024,0.27,#000000,https://cards.scryfall.io/normal/front/1/3/13158f3b-9d85-4689-9afa-7d9a8a2d1b09.jpg?1783910733,Creature — Bat Warlock,Yohann Schepacz
+Morality Shift,7,2002,5.66,#000000,https://cards.scryfall.io/normal/front/b/5/b5c83e4d-ccc1-4ebf-9e74-2cc1ff9a7b07.jpg?1783945122,Sorcery,Jerry Tiritilli
+Morbid Opportunist,3,2024,17.07,#000000,https://cards.scryfall.io/normal/front/7/5/75ce7a2a-95c3-4854-ab70-15d144d44714.jpg?1783911691,Creature — Human Rogue,Chris Seaman
+Morinfen,5,1997,0.74,#000000,https://cards.scryfall.io/normal/front/b/5/b5006ad3-16ca-4be3-8d56-d4fe4e9e0a44.jpg?1783946732,Legendary Creature — Phyrexian Horror,Carl Critchlow
+Moriok Rigger,3,2004,0.55,#000000,https://cards.scryfall.io/normal/front/4/7/47ffdeb8-52d2-4059-b9c6-0ad71b96516a.jpg?1783944398,Creature — Human Rogue Rigger,Wayne England
+Morlun- Devourer of Spiders,2,2025,0.45,#000000,https://cards.scryfall.io/normal/front/1/b/1beb2eb9-90b5-43ba-8b04-cfce7dcb744b.jpg?1783905345,Legendary Creature — Vampire Villain,Randy Gallegos
+Mornsong Aria,3,2026,0.32,#000000,https://cards.scryfall.io/normal/front/9/9/9985c554-8338-46b1-ac36-526d2eb61570.jpg?1783904462,Legendary Enchantment,Scott M. Fischer
+Mortal Combat,4,2007,6.07,#000000,https://cards.scryfall.io/normal/front/f/1/f1d9cfce-1507-4cdf-9d58-6ebaf44e72e3.jpg?1783943032,Enchantment,Mike Ploog
+Mortarion- Daemon Primarch,6,2022,0.59,#000000,https://cards.scryfall.io/normal/front/3/b/3b6b1bcf-10a4-4643-9db0-b2a4fee340a2.jpg?1783920921,Legendary Creature — Demon Primarch,Helge C. Balzer
+Mortician Beetle,1,2010,3.03,#000000,https://cards.scryfall.io/normal/front/a/1/a19ee3e4-5f76-4c28-bee6-f1c063ec0cb3.jpg?1783941983,Creature — Insect,Lars Grant-West
+Mortivore,4,2018,0.45,#000000,https://cards.scryfall.io/normal/front/b/e/beeaaef1-5cd9-402a-982e-2cb4e69cfaca.jpg?1783934754,Creature — Lhurgoyf,Anthony S. Waters
+Mortuary,4,1998,21.71,#000000,https://cards.scryfall.io/normal/front/8/6/860f46ea-6fd0-456d-971d-8d1eccc7fa60.jpg?1783946561,Enchantment,Robert Bliss
+Moseo- Vein's New Dean,3,2026,0.95,#000000,https://cards.scryfall.io/normal/front/6/8/6877180c-22a1-4c4d-9178-316f4c34661b.jpg?1783903677,Legendary Creature — Bird Skeleton Warlock,Abz J Harding
+Mukotai Soulripper,2,2022,0.14,#000000,https://cards.scryfall.io/normal/front/1/6/166775be-c3b7-4a17-9376-aa4229b147f9.jpg?1783923879,Artifact — Vehicle,Eddie Mendoza
+Murderous Betrayal,3,2003,0.37,#000000,https://cards.scryfall.io/normal/front/0/0/0063ed19-494b-4199-9120-d479bfcb625a.jpg?1783944753,Enchantment,Randy Gallegos
+Murderous Rider // Swift End,3,2023,0.36,#000000,https://cards.scryfall.io/normal/front/8/0/80fffad3-2486-4350-8dff-54a215ebfc28.jpg?1783917156,Creature — Zombie Knight // Instant — Adventure,Josh Hass
+Mutilate,4,2014,1.97,#000000,https://cards.scryfall.io/normal/front/0/4/04587192-e5a6-46f6-98b5-3b349d618880.jpg?1783938750,Sorcery,Zoltan Boros & Gabor Szikszai
+Myojin of Grim Betrayal,8,2022,0.31,#000000,https://cards.scryfall.io/normal/front/3/f/3fa18695-e10f-4dd5-b116-8a9891e58c20.jpg?1783923987,Legendary Creature — Spirit,Jason A. Engle
+Myojin of Night's Reach,8,2024,0.16,#000000,https://cards.scryfall.io/normal/front/7/3/73bc5505-7fa0-4ebf-a691-b4ca5f52b019.jpg?1783908928,Legendary Creature — Spirit,Kev Walker
+Mythos of Nethroi,3,2020,0.36,#d78f42,https://cards.scryfall.io/normal/front/6/a/6abc24e1-e721-471a-9efd-547f320675b0.jpg?1783931058,Instant,Seb McKinnon
+Nameless Inversion,2,2009,4.94,#000000,https://cards.scryfall.io/normal/front/b/1/b1ea60ba-11ac-4112-92af-db0aa420dd8c.jpg?1783942499,Kindred Instant — Shapeshifter,Jesper Ejsing
+Nameless Race,4,1994,3.76,#000000,https://cards.scryfall.io/normal/front/3/4/348a467a-4661-4fdb-af1d-9171a1a930d9.jpg?1783947938,Creature,Quinton Hoover
+Nantuko Shade,2,2023,0.26,#000000,https://cards.scryfall.io/normal/front/f/b/fb4c5dd4-79dc-4bd2-8c18-897924a4a959.jpg?1783918476,Creature — Insect Shade,Brian Snõddy
+Nashi- Moon Sage's Scion,3,2024,3.73,#000000,https://cards.scryfall.io/normal/front/1/e/1e62de3b-6a41-43e3-93ad-9a1e3894be3b.jpg?1783911927,Legendary Creature — Rat Ninja,Valera Lutfullina
+Necravolver,3,2001,0.45,#d78f42,https://cards.scryfall.io/normal/front/2/3/232c32d9-9b0c-458d-b1b3-e4219bd34c82.jpg?1783945348,Creature — Volver,Dave Dorman
+Necrodominance,3,2024,2.5,#000000,https://cards.scryfall.io/normal/front/f/f/ffc0109c-f939-4424-820e-d6e60cacd794.jpg?1783911278,Legendary Enchantment,Robin Olausson
+Necrogen Mists,3,2003,10.71,#000000,https://cards.scryfall.io/normal/front/1/8/18291514-9ffb-4032-9c77-cec0200bf1b6.jpg?1783944546,Enchantment,Alex Horley-Orlandelli
+Necrogoyf,5,2021,0.3,#000000,https://cards.scryfall.io/normal/front/f/2/f200ea9a-198b-4ba2-ad2b-ea4a133b7f40.jpg?1783926858,Creature — Lhurgoyf,Nicholas Gregory
+Necro-Impotence,3,2004,2.16,#000000,https://cards.scryfall.io/normal/front/e/a/ead51a23-db13-4424-9191-dc992c510921.jpg?1783944250,Enchantment,Mark Tedin
+Necromancer's Stockpile,2,2014,0.25,#000000,https://cards.scryfall.io/normal/front/2/b/2ba07e86-fdef-4f51-808e-7780883eefe3.jpg?1783939181,Enchantment,Seb McKinnon
+Necromantic Selection,7,2025,0.34,#000000,https://cards.scryfall.io/normal/front/2/0/2002d779-9ea2-432b-8c15-d61995b8adda.jpg?1783907085,Sorcery,Dave Kendall
+Necromentia,3,2020,0.3,#000000,https://cards.scryfall.io/normal/front/3/2/32c5252e-ff15-4f86-ad63-d8286427e70f.jpg?1783930700,Sorcery,Mila Pesic
+Necron Deathmark,5,2022,5.8,#000000,https://cards.scryfall.io/normal/front/4/1/4129cb0d-eefe-4971-9db8-1196201ef353.jpg?1783920921,Artifact Creature — Necron,Games Workshop
+Necron Overlord,4,2022,0.48,#000000,https://cards.scryfall.io/normal/front/6/2/62d70fd2-de4e-41c6-b3e5-147fffca8a20.jpg?1783920919,Artifact Creature — Necron Noble,David Sondered
+Necroplasm,3,2018,0.89,#000000,https://cards.scryfall.io/normal/front/1/f/1f5f3202-fee4-4336-998f-f6710984f6d2.jpg?1783934755,Creature — Ooze,rk post
+Necropolis Fiend,9,2025,0.15,#000000,https://cards.scryfall.io/normal/front/7/d/7de44851-ce9b-4979-afed-87f50e8d99b8.jpg?1783907085,Creature — Demon,Seb McKinnon
+Necropolis Regent,6,2021,0.56,#000000,https://cards.scryfall.io/normal/front/9/c/9cd548d5-6162-4eff-adfc-69b7e3b45712.jpg?1783924954,Creature — Vampire,Winona Nelson
+Necropotence,3,2017,37.65,#000000,https://cards.scryfall.io/normal/front/c/8/c89c6895-b0f8-444a-9c89-c6b4fd027b3e.jpg?1783935537,Enchantment,Dave Kendall
+Necrosavant,6,1999,0.41,#000000,https://cards.scryfall.io/normal/front/1/6/164a9755-f003-456d-a827-d6ef6cc29a86.jpg?1783946181,Creature — Zombie Giant,John Coulthart
+Necroskitter,3,2026,0.67,#000000,https://cards.scryfall.io/normal/front/1/7/1743ff46-7bfe-46f7-a2cf-170dd92bf28f.jpg?1783911525,Creature — Elemental,Thomas M. Baxa
+Necrotic Hex,7,2020,0.41,#000000,https://cards.scryfall.io/normal/front/0/0/009d2fb8-6144-46d9-9085-26232c174109.jpg?1783928832,Sorcery,Nils Hamm
+Necrotic Ooze,4,2022,3.09,#000000,https://cards.scryfall.io/normal/front/a/c/acc3557d-49c6-49cd-a540-1b24897f4e86.jpg?1783921901,Creature — Ooze,James Ryman
+Necrotic Plague,4,2010,0.36,#000000,https://cards.scryfall.io/normal/front/2/e/2e7573a8-be2b-46a5-8862-db0980968088.jpg?1783941813,Enchantment — Aura,Jaime Jones
+Needle Specter,3,2008,1.15,#000000,https://cards.scryfall.io/normal/front/2/1/21af9e72-fbaf-460a-a2eb-a09b925ebd9a.jpg?1783942687,Creature — Specter,Christopher Moeller
+Nefarious Lich,4,2001,3.77,#000000,https://cards.scryfall.io/normal/front/d/9/d90f5a4e-8c3a-4803-bb59-d3d7c23761db.jpg?1783945242,Enchantment,Jerry Tiritilli
+Nefarox- Overlord of Grixis,6,2012,0.41,#000000,https://cards.scryfall.io/normal/front/a/b/abc382f3-fdb9-4987-acf4-bf1ac4fd2ef7.jpg?1783940497,Legendary Creature — Demon,Aleksi Briclot
+Nefashu,6,2009,0.31,#000000,https://cards.scryfall.io/normal/front/2/9/29b206a3-829f-421e-b8bf-0bcc0d9845c1.jpg?1783942328,Creature — Zombie Mutant,rk post
+Netherborn Altar,2,2020,0.62,#000000,https://cards.scryfall.io/normal/front/5/4/541151af-f1a3-494f-858e-2c3fe447e036.jpg?1783931216,Artifact,Titus Lunter
+Nethergoyf,1,2024,3.18,#000000,https://cards.scryfall.io/normal/front/3/e/3ee3945e-5089-4751-b7b3-5961c39d2a33.jpg?1783911277,Creature — Lhurgoyf,Xavier Ribeiro
+Nether Shadow,2,1997,1.2,#000000,https://cards.scryfall.io/normal/front/b/0/b0877527-6dbe-49f2-862f-5c79e66a92e9.jpg?1783946923,Creature — Spirit,DiTerlizzi
+Nether Spirit,3,2019,0.24,#000000,https://cards.scryfall.io/normal/front/8/2/82f1f3e1-d986-4c0b-850e-5e8f2eaa0642.jpg?1783933125,Creature — Spirit,Deruchenko Alexander
+Nether Traitor,2,2026,0.8,#000000,https://cards.scryfall.io/normal/front/f/a/fae5d1cb-ead9-41e1-84ce-2f06dc8cf6ba.jpg?1783903785,Creature — Spirit,Vance Kovacs
+Nettlevine Blight,6,2007,1.15,#000000,https://cards.scryfall.io/normal/front/d/d/dd6b1240-0bc3-401a-9cc3-3acaea871a3d.jpg?1783942885,Enchantment — Aura,Michael Sutfin
+Nettling Nuisance,3,2023,2.17,#000000,https://cards.scryfall.io/normal/front/5/8/5826d347-9160-4471-af6f-ae6712048301.jpg?1783914986,Creature — Faerie Rogue,Kevin Sidharta
+Neverending Torment,6,2005,0.72,#000000,https://cards.scryfall.io/normal/front/3/f/3f91f678-9d3a-4502-81a6-3e1676aa447a.jpg?1783944151,Sorcery,Thomas Gianni
+Never // Return,7,2017,0.19,#000000,https://cards.scryfall.io/normal/front/a/4/a4b32135-7061-4278-a01a-4fcbaadc9706.jpg?1783936458,Sorcery // Sorcery,Daarken
+New Blood,4,2023,0.33,#000000,https://cards.scryfall.io/normal/front/6/e/6ee669ab-0ae6-43e5-86fd-f0dcb621e478.jpg?1783913872,Sorcery,Howard Lyon
+Nezumi Shortfang // Stabwhisker the Odious,2,2004,2.29,#000000,https://cards.scryfall.io/normal/front/c/8/c8265c39-d287-4c5a-baba-f2f09dd80a1c.jpg?1783944311,Creature — Rat Rogue // Legendary Creature — Rat Shaman,Daren Bader
+Night Dealings,4,2004,1.19,#000000,https://cards.scryfall.io/normal/front/5/8/58d012ee-9523-469f-8ddb-f4b664093c13.jpg?1783944310,Enchantment,Darrell Riche
+Nighthawk Scavenger,3,2024,0.39,#000000,https://cards.scryfall.io/normal/front/4/7/47433ce9-1ac6-4359-a5e4-4ec68490cb0c.jpg?1783911927,Creature — Vampire Rogue,Heonhwa
+Nighthowler,3,2022,0.31,#000000,https://cards.scryfall.io/normal/front/b/7/b76dab3d-1788-4ab7-8d2b-70f7787cf935.jpg?1783922442,Enchantment Creature — Horror,Nils Hamm
+Night Incarnate,5,2018,0.53,#000000,https://cards.scryfall.io/normal/front/c/6/c665b8b7-166f-4651-9a76-9e89695343ee.jpg?1783934339,Creature — Elemental,Anthony Palumbo
+Nightmare,6,2017,0.25,#000000,https://cards.scryfall.io/normal/front/0/5/052022ff-795f-4f50-a45c-91cf8be9fbe9.jpg?1783936547,Creature — Nightmare Horse,Vance Kovacs
+Nightmare Incursion,6,2008,1.03,#000000,https://cards.scryfall.io/normal/front/7/c/7cccd244-9fd4-4f58-85da-af6d235ef7bb.jpg?1783942686,Sorcery,Chuck Lukacs
+Nightmare Shepherd,4,2024,0.38,#000000,https://cards.scryfall.io/normal/front/c/0/c03c1ad6-3122-4267-80d6-94ecf1ff3884.jpg?1783909617,Enchantment Creature — Demon,Tyler Jacobson
+Nightmare Unmaking,5,2022,0.29,#000000,https://cards.scryfall.io/normal/front/4/4/44dc5937-4186-4ebf-a3cb-053c270370f3.jpg?1783923267,Sorcery,Izzy
+Night of Souls' Betrayal,4,2017,1.74,#000000,https://cards.scryfall.io/normal/front/e/4/e42c5234-7395-4c9f-a885-8b63cf02c5e8.jpg?1783935536,Legendary Enchantment,Greg Staples
+Nightscape Familiar,2,2024,13.83,#000000,https://cards.scryfall.io/normal/front/c/f/cf313ba7-d031-4dd3-aee0-36f2c4533da5.jpg?1783913077,Creature — Zombie,Graham Yarrington
+Nightscape Master,4,2000,0.45,#d78f42,https://cards.scryfall.io/normal/front/d/8/d86174b8-dd9e-4ece-bc23-4f9ac50bccd3.jpg?1783945694,Creature — Zombie Wizard,Andrew Goldhawk
+Nightshade Harvester,4,2024,0.35,#000000,https://cards.scryfall.io/normal/front/f/a/fac55604-3635-4af1-b9ca-10d1f89db504.jpg?1783909617,Creature — Elf Shaman,PINDURSKI
+Nightstalker Engine,5,1998,0.81,#000000,https://cards.scryfall.io/normal/front/6/1/61e440ad-462f-4c7e-a646-8c5123a9f6b2.jpg?1783946473,Creature — Nightstalker,Mark Tedin
+Night's Whisper,2,2026,5.5,#000000,https://cards.scryfall.io/normal/front/4/6/467ccbbb-146c-4411-90a3-0b9f44e5724c.jpg?1783903499,Sorcery,John Thacker
+Nihilistic Glee,4,2006,0.25,#000000,https://cards.scryfall.io/normal/front/f/6/f603486d-c8d7-4a02-bdb3-c25d2bc62ba6.jpg?1783943427,Enchantment,Ron Spears & Wayne Reynolds
+Nihilith,6,2022,0.3,#000000,https://cards.scryfall.io/normal/front/5/9/598900a0-e244-45e3-a04a-685837fb1867.jpg?1783922440,Creature — Horror,Dave Allsop
+Nikara- Lair Scavenger,3,2020,0.92,#000000,https://cards.scryfall.io/normal/front/0/0/00b9ac91-51e4-4653-ac2a-da166a894f2a.jpg?1783931234,Legendary Creature — Human Cleric,Grzegorz Rutkowski
+Nim Devourer,5,2003,0.32,#000000,https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg?1783944547,Creature — Zombie,Adam Rex
+Nine-Lives Familiar,3,2024,1.31,#000000,https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg?1783909109,Creature — Cat,Bram Sels
+Ninja's Blades,3,2025,0.53,#000000,https://cards.scryfall.io/normal/front/a/6/a6b5af82-3646-44f9-ac12-1d7fa698f037.jpg?1783906616,Artifact — Equipment,Immanuela Crovius
+Ninja Teen,3,2026,1.44,#000000,https://cards.scryfall.io/normal/front/0/8/0825a28f-f60b-4f80-83e3-cad6f9b266ce.jpg?1783904106,Enchantment — Class,Justyna Dura
+Nirkana Revenant,6,2021,7.29,#000000,https://cards.scryfall.io/normal/front/9/6/96da0a4c-2865-4383-875a-9f5d6503baee.jpg?1783924955,Creature — Vampire Shade,Livia Prima
+Nocturno of Myra's Marvels,4,2022,0.14,#000000,https://cards.scryfall.io/normal/front/a/f/af1d19cd-e51d-4cee-97ca-1aa646d5bf30.jpg?1783920579,Legendary Creature — Vampire Performer,Gaboleps
+No Mercy,4,2023,26.42,#000000,https://cards.scryfall.io/normal/front/6/3/63c5e1dd-2fe6-4734-8406-7bcdf17aa60c.jpg?1783918474,Enchantment,Mark Tedin
+Noosegraf Mob,6,2018,0.4,#000000,https://cards.scryfall.io/normal/front/b/8/b8320434-70d6-48c6-a4cd-1cecc6a21ad4.jpg?1783934821,Creature — Zombie,Seb McKinnon
+Notorious Assassin,4,1999,1.01,#000000,https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg?1783945949,Creature — Human Spellshaper Assassin,Heather Hudson
+Nowhere to Run,2,2026,0.87,#000000,https://cards.scryfall.io/normal/front/d/e/ded0147d-220f-411d-8950-fd8a47786f6f.jpg?1783904340,Enchantment,Jodie Muir
+Noxious Gearhulk,6,2025,0.39,#000000,https://cards.scryfall.io/normal/front/2/8/289c11b7-a460-4a2f-b11a-e1ba54bd1f34.jpg?1783907084,Artifact Creature — Construct,Lius Lasahido
+Nuclear Fallout,2,2024,3.27,#000000,https://cards.scryfall.io/normal/front/e/7/e717e4b0-a8c1-4411-b18a-1d17e7225503.jpg?1783912408,Sorcery,Jason Rainville
+Nullpriest of Oblivion,2,2024,0.21,#000000,https://cards.scryfall.io/normal/front/b/2/b2c7613c-38fc-49c3-93ee-1df93136455a.jpg?1783908928,Creature — Vampire Cleric,Yongjae Choi
+Null Profusion,6,2007,0.61,#000000,https://cards.scryfall.io/normal/front/c/9/c996792c-0846-4b78-bce5-1c6ad29640f6.jpg?1783943150,Enchantment,Kev Walker
+Nurgle's Conscription,5,2022,0.4,#000000,https://cards.scryfall.io/normal/front/9/e/9e663ce3-1871-4cde-82ba-4f009d582b77.jpg?1783920918,Instant,Ørjan Ruttenborg Svendsen
+Nyla- Shirshu Sleuth,5,2025,0.18,#000000,https://cards.scryfall.io/normal/front/e/4/e4760b87-b109-496a-98d1-353f67c265b8.jpg?1783904823,Legendary Creature — Mole Beast,Douzen
+Nyxathid,3,2020,0.39,#000000,https://cards.scryfall.io/normal/front/a/9/a9843f26-83ed-4517-8ad6-0e288833d140.jpg?1783930414,Creature — Elemental,Raymond Swanland
+Oath of Ghouls,2,1998,7.26,#000000,https://cards.scryfall.io/normal/front/1/1/1102f35a-ae62-479d-b61c-31a82978aedd.jpg?1783946515,Enchantment,Brom
+Oath of Liliana,3,2016,0.45,#000000,https://cards.scryfall.io/normal/front/2/0/2028f577-e0fb-48dd-89c6-f4a000b0a881.jpg?1783937481,Legendary Enchantment,Wesley Burt
+Oath of Lim-Dûl,4,1995,0.54,#000000,https://cards.scryfall.io/normal/front/f/1/f16df768-06de-43a0-b548-44fb0887490b.jpg?1783947496,Enchantment,Douglas Shuler
+Oathsworn Knight,3,2019,0.33,#000000,https://cards.scryfall.io/normal/front/9/1/9173ffda-1d3b-4dab-8dcb-de44717de464.jpg?1783932637,Creature — Human Knight,Svetlin Velinov
+Ob Nixilis of the Black Oath,5,2023,0.92,#000000,https://cards.scryfall.io/normal/front/f/b/fb4e4509-ffd8-4fd0-a678-19c9975d571b.jpg?1783915669,Legendary Planeswalker — Nixilis,Daarken
+Ob Nixilis Reignited,5,2024,0.34,#000000,https://cards.scryfall.io/normal/front/5/a/5af237ad-9294-47f5-a338-f9ca4fce3e70.jpg?1783909616,Legendary Planeswalker — Nixilis,Chris Rahn
+Ob Nixilis- the Fallen,5,2025,1.15,#000000,https://cards.scryfall.io/normal/front/d/c/dc9d3ada-9d0d-489a-89b7-08f53f6601e1.jpg?1783907081,Legendary Creature — Demon,Jason Felix
+Ob Nixilis- Unshackled,6,2022,5.33,#000000,https://cards.scryfall.io/normal/front/6/c/6c727f49-833a-4b79-9946-bfbc6b06999c.jpg?1783921902,Legendary Creature — Demon,Karl Kopinski
+Obsessive Pursuit,2,2025,0.3,#000000,https://cards.scryfall.io/normal/front/e/8/e837e29c-d241-43c8-8f45-05056e082b60.jpg?1783904967,Enchantment,Ichiko Milk Tei
+Oft-Nabbed Goat,2,2026,0.29,#000000,https://cards.scryfall.io/normal/front/4/0/4030bfab-867c-4724-904e-3e8b631f075e.jpg?1783904605,Creature — Goat,Mariah Tekulve
+Ogre Slumlord,5,2024,0.38,#000000,https://cards.scryfall.io/normal/front/7/6/76995067-81a3-41c5-bc95-bfa5a953700d.jpg?1783911926,Creature — Ogre Rogue,Trevor Claxton
+Olivia's Wrath,5,2023,0.43,#000000,https://cards.scryfall.io/normal/front/3/e/3eb5cc8d-a198-43cd-a2bd-9c9414d815b2.jpg?1783913871,Sorcery,Néstor Ossandón Leal
+Ominous Harvest,3,2026,0.44,#000000,https://cards.scryfall.io/normal/front/2/2/2271184b-08eb-4d2a-8ebf-a1807d51dd2a.jpg?1783903860,Sorcery,Fajareka Setiawan
+One Ring to Rule Them All,4,2023,2.6,#000000,https://cards.scryfall.io/normal/front/b/b/bb2dc2e0-f393-4442-818b-d3b860bfffd0.jpg?1783916298,Enchantment — Saga,L J Koh
+One with Nothing,1,2005,2.59,#000000,https://cards.scryfall.io/normal/front/5/a/5a5841fa-4f30-495a-b840-3ef5a2af8fad.jpg?1783944151,Instant,Jim Nelson
+Oona's Prowler,2,2022,0.31,#000000,https://cards.scryfall.io/normal/front/c/d/cd79780e-ddad-4ef4-a94d-ab191d118882.jpg?1783921901,Creature — Faerie Rogue,Wayne Reynolds
+Open the Graves,5,2021,0.43,#000000,https://cards.scryfall.io/normal/front/1/3/130978d1-0b20-4dfa-85f5-3ff2bc2cfda3.jpg?1783925336,Enchantment,Vincent Proce
+Ophiomancer,3,2026,0.8,#000000,https://cards.scryfall.io/normal/front/b/a/baf793b6-9612-43f3-9f1b-2e53e81cb89f.jpg?1783903820,Creature — Human Shaman,Flavio Greco Paglia
+Opposition Agent,3,2020,18.07,#000000,https://cards.scryfall.io/normal/front/0/8/086f97e9-8b62-44f3-b467-149c2ac5ca78.jpg?1783928831,Creature — Human Rogue,Scott Murphy
+Oppression,3,2001,4.12,#000000,https://cards.scryfall.io/normal/front/a/c/ac327f80-983e-4e28-96e8-91ff5377f5a3.jpg?1783945491,Enchantment,Alex Horley-Orlandelli
+Oriq Loremage,4,2021,0.59,#000000,https://cards.scryfall.io/normal/front/2/5/25214a91-2f64-46ee-9834-7fbf684800f7.jpg?1783927363,Creature — Human Warlock,JiHun Lee
+Orochi Soul-Reaver,6,2024,10.98,#000000,https://cards.scryfall.io/normal/front/e/c/ec8f372a-d8c7-4f5d-a91d-ec7e5eb17104.jpg?1783911966,Creature — Snake Ninja Rogue,Bram Sels
+Osteomancer Adept,2,2024,0.32,#000000,https://cards.scryfall.io/normal/front/7/d/7d8238dd-858f-466c-96de-986bd66861d7.jpg?1783910831,Creature — Squirrel Warlock,Daniel Zrom
+Oubliette,3,2024,4.32,#000000,https://cards.scryfall.io/normal/front/8/7/87149eb8-7935-4e45-8092-6baa2a6fb8d2.jpg?1783909709,Enchantment,Will Sweeney
+Out of the Tombs,3,2022,14.33,#000000,https://cards.scryfall.io/normal/front/f/1/f1170bfa-9623-44c3-a15e-bd8c2627fe6e.jpg?1783920916,Enchantment,Games Workshop
+Outrageous Robbery,2,2024,0.38,#000000,https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg?1783912894,Instant,Kai Carpenter
+Overlord of the Balemurk,5,2024,20.01,#000000,https://cards.scryfall.io/normal/front/9/b/9b911653-7b96-4cf3-a907-13c5c53a14f7.jpg?1783909475,Enchantment Creature — Avatar Horror,Babs Webb
+Over My Dead Bodies,6,2017,0.31,#000000,https://cards.scryfall.io/normal/front/c/5/c5279543-3678-40f2-9bea-0a75c2044017.jpg?1783935434,Enchantment,Even Amundsen
+Overseer of the Damned,7,2024,0.37,#000000,https://cards.scryfall.io/normal/front/0/a/0a1a06a4-af73-43e3-a2cd-3a2f0f9b18f0.jpg?1783913005,Creature — Demon,rk post
+Oversold Cemetery,2,2023,3.12,#000000,https://cards.scryfall.io/normal/front/0/6/06b7312a-c775-4fa8-ba62-c84ff38459e8.jpg?1783918473,Enchantment,Jarel Threat
+Ow,1,1998,0.69,#000000,https://cards.scryfall.io/normal/front/d/d/dd26c2a6-7b08-4de6-afbf-e34d321995ab.jpg?1783946429,Enchantment,Edward P. Beard, Jr.
+Pack Rat,2,2012,2.38,#000000,https://cards.scryfall.io/normal/front/1/7/170693f5-13db-4191-99b1-e527ffb5b88e.jpg?1783940361,Creature — Rat,Kev Walker
+Pact of the Serpent,3,2023,0.75,#000000,https://cards.scryfall.io/normal/front/4/8/481d268a-848c-4ccd-95ff-eed77dc20776.jpg?1783913870,Sorcery,Donato Giancola
+Pact Weapon,4,2022,2.24,#000000,https://cards.scryfall.io/normal/front/2/0/20b0cf66-c6ec-4ff6-96a5-334e2c9c7818.jpg?1783922757,Artifact — Equipment,Volkan Baǵa
+Painful Quandary,5,2024,1.32,#000000,https://cards.scryfall.io/normal/front/0/5/05757669-e8a6-4a2f-8479-d4e2ade822ca.jpg?1783909073,Enchantment,David Palumbo
+Painful Truths,3,2026,0.34,#000000,https://cards.scryfall.io/normal/front/f/a/faa82f09-0693-4cc6-8770-8c6a35aa627b.jpg?1783904558,Sorcery,Winona Nelson
+Pain Seer,2,2014,0.23,#000000,https://cards.scryfall.io/normal/front/8/c/8ce8891f-b44c-4be4-878e-9fc45a9dc9cb.jpg?1783939553,Creature — Human Wizard,Tyler Jacobson
+Pain's Reward,3,2005,11.03,#000000,https://cards.scryfall.io/normal/front/6/d/6d16da68-85f6-4d54-9751-9cf046f5e99a.jpg?1783944152,Sorcery,Matt Cavotta
+Palace Siege,5,2017,1.05,#000000,https://cards.scryfall.io/normal/front/d/a/da855bb6-adc2-484c-a084-83aff2b267f1.jpg?1783935904,Enchantment,Slawomir Maniak
+Parallax Nexus,3,2000,0.6,#000000,https://cards.scryfall.io/normal/front/8/6/862c50c7-0840-46e0-a653-5b660fdfd4bd.jpg?1783945827,Enchantment,Greg Staples
+Parker Luck,3,2025,0.25,#000000,https://cards.scryfall.io/normal/front/e/3/e375bcf0-7fcb-4fe4-a7e8-a4cbf9b23e3c.jpg?1783905343,Enchantment,Raoul Vitale
+Path of Peril,3,2021,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/0/f0c5449a-d63b-4b22-9432-8f0365c3c4d9.jpg?1783924854,Sorcery,Kasia 'Kafis' Zielińska
+Path of the Schemer,5,2023,0.29,#000000,https://cards.scryfall.io/normal/front/5/8/5832df72-99dc-4c9e-b8e6-90b666abf08d.jpg?1783917285,Sorcery,Josu Hernaiz
+Patriarch's Bidding,5,2021,4.01,#000000,https://cards.scryfall.io/normal/front/3/1/317686d8-b762-4598-b74a-8b1fa6b899ba.jpg?1783926786,Sorcery,Ilse Gort
+Patron of the Nezumi,7,2018,0.49,#000000,https://cards.scryfall.io/normal/front/6/1/61740668-9f85-43ed-aaa0-33ce7101da6e.jpg?1783934754,Legendary Creature — Spirit,Kev Walker
+Patron of the Vein,6,2023,0.34,#000000,https://cards.scryfall.io/normal/front/a/7/a70d7b65-77d0-41d3-9735-d64b9288fde1.jpg?1783913870,Creature — Vampire Shaman,Tommy Arnold
+Peer into the Abyss,7,2020,3.33,#000000,https://cards.scryfall.io/normal/front/a/a/aac00055-640e-4749-8d23-d242e6d0b23a.jpg?1783930701,Sorcery,Izzy
+Persecute,4,2005,0.5,#000000,https://cards.scryfall.io/normal/front/5/4/54af13f6-7a7b-431d-9dda-6492d135563f.jpg?1783943991,Sorcery,D. Alexander Gregory
+Persist,2,2026,1.27,#000000,https://cards.scryfall.io/normal/front/b/7/b7a56356-91bf-42f5-ab21-af2c48e78fc3.jpg?1783904558,Sorcery,Milivoj Ćeran
+Persistent Constrictor,5,2024,13.43,#000000,https://cards.scryfall.io/normal/front/0/a/0a25d478-84fd-4e4b-abb7-f5f6becf6eb0.jpg?1783909658,Creature — Zombie Snake,Steve Ellis
+Pestilence Demon,8,2016,0.59,#000000,https://cards.scryfall.io/normal/front/0/5/058eb32f-2ae2-4276-ae1a-242bbb150418.jpg?1783937260,Creature — Demon,Justin Sweet
+Pestilent Cauldron // Restorative Burst,3,2021,0.31,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact // Sorcery,Dan Murayama Scott
+Pestilent Spirit,3,2019,0.35,#000000,https://cards.scryfall.io/normal/front/5/f/5f9a0387-5116-484b-bb2b-064bd42e7fff.jpg?1783933691,Creature — Spirit,Anastasia Ovchinnikova
+Phage the Untouchable,7,2014,14.17,#000000,https://cards.scryfall.io/normal/front/d/4/d497a5a3-65fb-4c12-b3f2-8ce4cf4e0f6f.jpg?1783939355,Legendary Creature — Avatar Minion,Ron Spears
+Phoenix Fleet Airship,4,2025,1.16,#000000,https://cards.scryfall.io/normal/front/b/5/b51d3259-c41c-4f64-9666-0a9e676c812f.jpg?1783904968,Artifact — Vehicle,Thanh Tuấn
+Photo Op,1,2022,0.14,#000000,https://cards.scryfall.io/normal/front/5/8/58eb480e-c7e7-4177-83b7-ebd4334b15f0.jpg?1783920578,Sorcery,Setor Fiadzigbey
+Phylactery Lich,3,2018,0.32,#000000,https://cards.scryfall.io/normal/front/a/6/a6e359c3-2a18-4240-b38a-216372161cd8.jpg?1783934564,Creature — Zombie,Michael Komarck
+Phyresis Outbreak,3,2023,12.71,#000000,https://cards.scryfall.io/normal/front/8/1/812498c8-974c-460c-b782-506f5f735346.jpg?1783918160,Sorcery,Matthew G. Lewis
+Phyrexian Arena,3,2024,4.52,#000000,https://cards.scryfall.io/normal/front/0/7/0784b6f0-9ebf-43d2-ba0f-a6bc93ba0c48.jpg?1783909072,Enchantment,Svetlin Velinov
+Phyrexian Crusader,3,2011,4.71,#000000,https://cards.scryfall.io/normal/front/3/2/32aaa8b9-987b-4809-8a54-aa29bdc18805.jpg?1783941382,Creature — Phyrexian Zombie Knight,Eric Deschamps
+Phyrexian Delver,5,2023,0.57,#000000,https://cards.scryfall.io/normal/front/8/6/86f6f3e9-b594-49da-b0af-75a672590da1.jpg?1783917153,Creature — Phyrexian Zombie,Igor Kieryluk
+Phyrexian Etchings,3,2006,0.27,#000000,https://cards.scryfall.io/normal/front/9/7/978dbf63-0842-4abd-9950-a33aa080971c.jpg?1783943346,Enchantment,Ron Spears
+Phyrexian Infiltrator,3,2000,0.34,#d78f42,https://cards.scryfall.io/normal/front/2/2/224b8254-553d-4d88-8163-1f15e1244bd2.jpg?1783945693,Creature — Phyrexian Minion,Darrell Riche
+Phyrexian Obliterator,4,2023,9.98,#000000,https://cards.scryfall.io/normal/front/6/7/67a9c38b-6b3a-4056-a87c-fc48446f854f.jpg?1783918042,Creature — Phyrexian Horror,Maxim Kostin
+Phyrexian Plaguelord,5,2017,0.2,#000000,https://cards.scryfall.io/normal/front/d/0/d0894a99-13e0-406c-8ca3-5552c64e3154.jpg?1783936286,Creature — Phyrexian Carrier,Kev Walker
+Phyrexian Reclamation,1,2024,5.21,#000000,https://cards.scryfall.io/normal/front/3/4/3490d482-535a-4080-bc36-941e2536282b.jpg?1783909208,Enchantment,Justine Cruz
+Phyrexian Scriptures,4,2023,0.82,#000000,https://cards.scryfall.io/normal/front/0/9/09bb74d7-dd61-4cce-b88c-ee4d656a97f4.jpg?1783917153,Enchantment — Saga,Joseph Meehan
+Phyrexian Scuta,4,2001,0.73,#000000,https://cards.scryfall.io/normal/front/e/b/eb57e656-c94e-4cc2-ae8d-9300f51f941f.jpg?1783945619,Creature — Phyrexian Zombie,Scott M. Fischer
+Phyrexian Tribute,3,1996,2.41,#000000,https://cards.scryfall.io/normal/front/b/f/bfc55d48-6d6f-429d-8281-e66a9996d574.jpg?1783947090,Sorcery,John Matson
+Phyrexian Vatmother,4,2011,0.37,#000000,https://cards.scryfall.io/normal/front/f/0/f0024556-0317-4c28-83c3-0a6020d72a2b.jpg?1783941382,Creature — Phyrexian Horror,Stephan Martiniere
+Pile On,4,2024,0.33,#000000,https://cards.scryfall.io/normal/front/5/7/570b56ff-b25a-43e4-927b-99dba542be5e.jpg?1783913004,Instant,Javier Charro
+Pillar Tombs of Aku,4,1997,1.05,#000000,https://cards.scryfall.io/normal/front/1/5/153f93fd-4f2c-4dce-a774-4483031ed532.jpg?1783946992,World Enchantment,Terese Nielsen
+Piper of the Swarm,2,2021,2.14,#000000,https://cards.scryfall.io/normal/front/b/4/b4810704-beb8-499c-a921-26f672fd33b2.jpg?1783926215,Creature — Human Warlock,Irina Nordsol
+Pitiless Carnage,4,2024,0.29,#000000,https://cards.scryfall.io/normal/front/f/a/fa76fc45-a106-4dc9-9d44-a005eaa2784d.jpg?1783911830,Sorcery,Richard Kane Ferguson
+Pitiless Horde,3,2015,0.14,#000000,https://cards.scryfall.io/normal/front/8/6/86263073-b585-4744-829d-5725e6a06cf2.jpg?1783938595,Creature — Orc Berserker,Viktor Titov
+Pitiless Plunderer,4,2025,19.34,#000000,https://cards.scryfall.io/normal/front/8/c/8cbd3935-f02e-4508-895e-4ca86b6f8723.jpg?1783907471,Creature — Human Pirate,Rian Gonzales
+Pit Spawn,7,1998,0.53,#000000,https://cards.scryfall.io/normal/front/6/6/669ad60b-4053-4f07-9072-52e6ff65b4e3.jpg?1783946515,Creature — Demon,Thomas M. Baxa
+Plaguebearer,2,1998,40.23,#000000,https://cards.scryfall.io/normal/front/a/8/a8493df6-9954-4e33-867c-ca4bcf3953b2.jpg?1783946515,Creature — Zombie,Ron Spencer
+Plague Belcher,3,2017,0.43,#000000,https://cards.scryfall.io/normal/front/2/8/280ae211-f025-4971-83e6-118ca08a1911.jpg?1783936500,Creature — Zombie Beast,Izzy
+Plaguecrafter,3,2022,31.41,#000000,https://cards.scryfall.io/normal/front/6/3/63a10efc-4b8d-4e32-90fb-50ab73810b59.jpg?1783919209,Creature — Human Shaman,Junji Ito
+Plague Drone,4,2022,2.12,#000000,https://cards.scryfall.io/normal/front/9/5/95df49ae-e75f-4d97-8323-ebb62ff1df33.jpg?1783920915,Creature — Demon,Games Workshop
+Plague Engineer,3,2019,0.44,#000000,https://cards.scryfall.io/normal/front/8/f/8f32b0e9-5eb2-4b26-8c06-5d4561f0295d.jpg?1783933124,Creature — Phyrexian Carrier,Nicholas Gregory
+Plague of Vermin,7,2008,21.63,#000000,https://cards.scryfall.io/normal/front/2/3/231613d6-d3b8-4b41-bc93-4d5da3fec5d0.jpg?1783942753,Sorcery,Carl Critchlow
+Plague Reaver,3,2020,0.39,#000000,https://cards.scryfall.io/normal/front/2/3/230b9bc8-29c8-49cb-b4f5-1aceeda8bf45.jpg?1783928829,Creature — Beast,Nicholas Gregory
+Plague Sliver,4,2006,0.65,#000000,https://cards.scryfall.io/normal/front/7/0/703d491e-b25f-44fa-8b76-b955a4e75ba5.jpg?1783943230,Creature — Sliver,Dave Allsop
+Plague Wind,9,2018,5.75,#000000,https://cards.scryfall.io/normal/front/7/2/72d21d0d-7de7-4f03-8663-002c9290512f.jpg?1783935158,Sorcery,Alan Pollack
+Planar Despair,5,2001,0.18,#000000,https://cards.scryfall.io/normal/front/3/a/3a92d454-3f23-45bf-921f-25b0da4ce138.jpg?1783945346,Sorcery,Mike Sass
+Planeswalker's Scorn,3,2001,0.3,#000000,https://cards.scryfall.io/normal/front/8/e/8ed08376-836f-4313-83d0-481895ead9da.jpg?1783945619,Enchantment,Glen Angus
+Plunge into Darkness,2,2004,10.06,#000000,https://cards.scryfall.io/normal/front/d/2/d21c74b4-dd9e-43d6-ad0a-06e026a8d672.jpg?1783944397,Instant,Justin Sweet
+Poet's Quill,2,2021,0.28,#000000,https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg?1783927363,Artifact — Equipment,Anna Fehr
+Polluted Bonds,5,2008,9.24,#000000,https://cards.scryfall.io/normal/front/c/6/c6439222-de30-44cd-a53f-a7de0cb00b8f.jpg?1783942752,Enchantment,Michael Sutfin
+Polluted Cistern // Dim Oubliette,7,2024,0.4,#000000,https://cards.scryfall.io/normal/front/6/a/6a7c3370-6f79-417e-a98e-4341307e151b.jpg?1783909656,Enchantment — Room // Enchantment — Room,Arthur Yuan
+Pontiff of Blight,6,2022,0.33,#000000,https://cards.scryfall.io/normal/front/f/a/fa04c8f5-e174-4055-a98c-efec2f064d69.jpg?1783922442,Creature — Zombie Cleric,Seb McKinnon
+Postmortem Professor,2,2026,0.21,#000000,https://cards.scryfall.io/normal/front/1/7/174f5d7e-5d36-4d13-96bf-9b12cd644716.jpg?1783903677,Creature — Zombie Warlock,Nino Vecia
+Power Word Kill,2,2022,0.36,#000000,https://cards.scryfall.io/normal/front/3/6/36c71043-1c11-4377-ab33-41d19927143a.jpg?1783923554,Instant,Andreas Zafiratos
+Pox Plague,5,2026,0.32,#000000,https://cards.scryfall.io/normal/front/9/c/9c99c17b-ad3a-4859-97e8-469718b81cd9.jpg?1783903677,Sorcery,Camille Alquier
+Poxwalkers,3,2022,8.13,#000000,https://cards.scryfall.io/normal/front/c/a/ca79cd21-daaa-4a1c-bab5-cc4c783994ae.jpg?1783920914,Creature — Zombie,Games Workshop
+Praetor's Grasp,3,2011,11.03,#000000,https://cards.scryfall.io/normal/front/9/5/9588be49-d9b5-4491-a5a0-10bcadc9f8b3.jpg?1783941311,Sorcery,Steve Argyle
+Preacher of the Schism,3,2023,1.27,#000000,https://cards.scryfall.io/normal/front/8/9/89345f55-2b32-4356-945a-d56dded39909.jpg?1783913774,Creature — Vampire Cleric,Donato Giancola
+Predators' Hour,2,2024,0.37,#000000,https://cards.scryfall.io/normal/front/5/5/55ddf977-de2c-4850-8ad1-b8adab1d24ee.jpg?1783911927,Sorcery,Tomas Duchek
+Price of Knowledge,7,2013,2.12,#000000,https://cards.scryfall.io/normal/front/9/7/97f536be-7836-4c9a-befc-94590e602f26.jpg?1783939673,Enchantment,Dan Murayama Scott
+Pride of the Perfect,4,2026,6.8,#000000,https://cards.scryfall.io/normal/front/f/5/f5b3ed42-ef06-4e44-8a76-fc367bcb5ee5.jpg?1783904228,Enchantment,Justyna Dura
+Priest of Forgotten Gods,2,2026,0.48,#000000,https://cards.scryfall.io/normal/front/3/6/363f8761-91a7-47e8-9e15-3b73d59bc020.jpg?1783903781,Creature — Human Cleric,Zack Stella
+Priest of the Blood Rite,5,2016,0.3,#000000,https://cards.scryfall.io/normal/front/1/a/1a0df50f-59b8-46b6-8bac-6e3f93b9c979.jpg?1783937260,Creature — Human Cleric,David Palumbo
+Primaris Eliminator,5,2022,3.35,#000000,https://cards.scryfall.io/normal/front/d/b/db7ab081-d6cd-4323-98bf-536e4df95115.jpg?1783920912,Creature — Astartes Warrior,Logan Feliciano
+Profane Command,2,2022,0.36,#000000,https://cards.scryfall.io/normal/front/7/0/7005bb21-0cec-4c19-a95b-99a1bac25aa4.jpg?1783923265,Sorcery,Wayne England
+Profane Transfusion,9,2020,1.29,#000000,https://cards.scryfall.io/normal/front/c/0/c04d8edb-7350-4ab5-b721-390784c66329.jpg?1783928829,Sorcery,Vincent Proce
+Profane Tutor,0,2021,4.21,#000000,https://cards.scryfall.io/normal/front/2/a/2afc6f7d-ab59-4d64-bd11-6bd0fd4bfcd2.jpg?1783926857,Sorcery,Richard Kane Ferguson
+Professor Onyx,6,2024,5.54,#000000,https://cards.scryfall.io/normal/front/b/8/b8d8e608-6de4-4b90-aeb7-d060d1f44844.jpg?1783909616,Legendary Planeswalker — Liliana,Kieran Yanner
+Promise of Aclazotz // Foul Rebirth,2,2023,0.33,#000000,https://cards.scryfall.io/normal/front/b/8/b88a3b40-bf04-4017-be97-08ab86e331d1.jpg?1783913909,Enchantment // Sorcery — Adventure,Lixin Yin
+Promise of Power,5,2014,0.64,#000000,https://cards.scryfall.io/normal/front/b/1/b1b54b37-69f4-46bd-8ee7-216e65507478.jpg?1783938777,Sorcery,Kev Walker
+Protection Racket,3,2022,3.51,#000000,https://cards.scryfall.io/normal/front/7/7/7723cf0b-de49-44f6-a52e-6e339a080457.jpg?1783923364,Enchantment,Ernanda Souza
+Prowling Geistcatcher,4,2021,0.49,#000000,https://cards.scryfall.io/normal/front/8/4/84ed5b16-273a-432b-895b-791ffaa5148d.jpg?1783925376,Creature — Human Rogue,Lie Setiawan
+Pulse of the Dross,3,2004,0.33,#000000,https://cards.scryfall.io/normal/front/b/b/bb8b1d0a-2c78-4173-b7ed-d7f3a0502fe7.jpg?1783944442,Sorcery,Paolo Parente
+Puppeteer Clique,5,2026,0.32,#000000,https://cards.scryfall.io/normal/front/f/f/ffb08d08-9936-4525-bd72-3c2b77783d7d.jpg?1783904556,Creature — Faerie Wizard,Daren Bader
+Purraj of Urborg,5,1996,0.88,#000000,https://cards.scryfall.io/normal/front/4/7/4704bf02-c6be-4983-9bc7-a1d464d21b31.jpg?1783947089,Legendary Creature — Cat Warrior,John Matson
+Qarsi Revenant,3,2025,2.24,#000000,https://cards.scryfall.io/normal/front/8/c/8c93a0f6-5e50-4dda-9ff6-da741fb839ff.jpg?1783907373,Creature — Vampire,Lorenzo Mastroianni
+Quag Feast,2,2025,0.29,#000000,https://cards.scryfall.io/normal/front/d/d/dd8b6033-63e6-484e-8efb-a4eb9ca59fbf.jpg?1783907891,Sorcery,Loïc Canavaggia
+Queen's Bay Paladin,5,2023,0.24,#000000,https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg?1783913773,Creature — Vampire Knight,Slawomir Maniak
+Quest for the Nihil Stone,1,2010,1.52,#000000,https://cards.scryfall.io/normal/front/c/6/c604a567-71dd-47d9-ae5d-b87b4db98df4.jpg?1783942055,Enchantment,Mike Bierek
+Rag Man,4,2001,0.22,#000000,https://cards.scryfall.io/normal/front/8/e/8e3809e6-41ac-47e8-80dc-9e9c8be1ed7a.jpg?1783945488,Creature — Human Minion,Scott M. Fischer
+Rain of Filth,1,2024,28.91,#000000,https://cards.scryfall.io/normal/front/c/d/cd39e21d-89cf-4211-8b03-c53e7c48311b.jpg?1783913076,Instant,Graham Yarrington
+Rakshasa Debaser,6,2020,0.39,#000000,https://cards.scryfall.io/normal/front/e/3/e31fd23d-e6b2-412b-b2ff-c99812365001.jpg?1783928828,Creature — Demon,Yigit Koroglu
+Ral Zarek- Guest Lecturer,3,2026,1.74,#000000,https://cards.scryfall.io/normal/front/8/f/8fbad757-4081-42f7-a460-68ac03e77510.jpg?1783903675,Legendary Planeswalker — Ral,Billy Christian
+Rankle- Master of Pranks,4,2024,3.19,#000000,https://cards.scryfall.io/normal/front/4/8/4821d865-2a46-4611-ab93-1a9fdde08302.jpg?1783911926,Legendary Creature — Faerie Rogue,Dmitry Burmak
+Rankle's Prank,4,2023,0.44,#000000,https://cards.scryfall.io/normal/front/e/8/e8a9bdcf-160a-48c9-9750-778c910b805d.jpg?1783915104,Sorcery,Tyler Walpole
+Rapacious Guest,3,2023,0.47,#000000,https://cards.scryfall.io/normal/front/f/f/ff9dfba4-07d2-4407-a441-88acc7284d43.jpg?1783916032,Creature — Halfling Citizen,Bartłomiej Gaweł
+Rapid Decay,2,1999,0.41,#000000,https://cards.scryfall.io/normal/front/1/6/1678d911-1456-4631-a2f4-d7de4906644b.jpg?1783946072,Instant,Chippy
+Ratcatcher,6,2018,9.67,#000000,https://cards.scryfall.io/normal/front/e/9/e9cb08a7-cfcf-49ee-948b-4be859c1d256.jpg?1783935161,Creature — Ogre Rogue,Dan Murayama Scott
+Rat Colony,2,2024,17.04,#000000,https://cards.scryfall.io/normal/front/9/a/9a75d005-cd2c-4131-b3ed-ceec7842b165.jpg?1783909913,Creature — Rat,Mark Zug
+Rathi Assassin,4,2000,0.31,#000000,https://cards.scryfall.io/normal/front/3/e/3e3597c3-3053-49f8-ab7e-a774e2fb082f.jpg?1783945826,Creature — Phyrexian Zombie Mercenary Assassin,Dana Knutson
+Rat King- Pale Piper,4,2026,0.37,#000000,https://cards.scryfall.io/normal/front/9/b/9b215ce4-a085-4627-99b1-f4f1344ad41b.jpg?1783904169,Legendary Creature — Rat Avatar,Andrey Kuzinskiy
+Rat King- Verminister,2,2026,0.87,#000000,https://cards.scryfall.io/normal/front/b/e/be464d88-8933-46e8-97b0-3be05f1976a3.jpg?1783904102,Legendary Creature — Rat Avatar,Miklós Ligeti
+Raven Eagle,3,2025,0.19,#000000,https://cards.scryfall.io/normal/front/2/2/2262f24b-db6b-4f86-96d0-47a20fc015ab.jpg?1783904964,Creature — Bird Assassin,Robin Olausson
+Ravenloft Adventurer,4,2022,0.36,#000000,https://cards.scryfall.io/normal/front/a/5/a5e27c36-d883-4681-8430-b4d0ad7f1df0.jpg?1783922756,Creature — Human Rogue Assassin,Jodie Muir
+Ravenous Chupacabra,4,2024,4.77,#000000,https://cards.scryfall.io/normal/front/f/9/f9a7f2f0-3c12-4dba-975e-26d01f3f9c0d.jpg?1783909213,Creature — Beast Horror,Ed Repka
+Ravenous Demon // Archdemon of Greed,5,2012,0.21,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Demon // Creature — Demon,Igor Kieryluk
+Ravenous Rotbelly,5,2021,0.7,#000000,https://cards.scryfall.io/normal/front/d/5/d58d8968-825b-453d-b109-8f975cd99322.jpg?1783925376,Creature — Zombie Horror,Nils Hamm
+Ravenous Trap,4,2020,0.34,#000000,https://cards.scryfall.io/normal/front/c/e/ce0fae06-1a93-43ac-a349-f3719e60076e.jpg?1783930176,Instant — Trap,Cyril Van Der Haegen
+Raving Dead,5,2014,1.19,#000000,https://cards.scryfall.io/normal/front/5/d/5d24d153-a014-4524-a496-9fe1c41cbc2b.jpg?1783938869,Creature — Zombie,Daarken
+Razaketh- the Foulblooded,8,2023,13.86,#000000,https://cards.scryfall.io/normal/front/d/6/d6bb956d-0df6-4910-9320-55f2c5674d98.jpg?1783915666,Legendary Creature — Demon,Chris Rallis
+Read the Bones,3,2025,5.33,#000000,https://cards.scryfall.io/normal/front/6/b/6b497f60-0f2c-429d-a87a-6ee65940af83.jpg?1783905145,Sorcery,Nicholas Gregory
+Reanimate,1,2024,9.25,#000000,https://cards.scryfall.io/normal/front/3/6/368b6903-5fc4-43e7-bd44-46b8107c8bb4.jpg?1783909614,Sorcery,Johann Bodin
+Reaper from the Abyss,6,2014,0.96,#000000,https://cards.scryfall.io/normal/front/0/8/0831a574-33c5-4ab2-b7f6-17db2829df51.jpg?1783938840,Creature — Demon,Matt Stewart
+Reaper's Scythe,3,2025,0.28,#000000,https://cards.scryfall.io/normal/front/e/1/e1e53ff2-c321-4fc8-b4d7-eb253d670c5b.jpg?1783906360,Artifact — Equipment,Colin Boyer
+Reassembling Skeleton,2,2023,24.9,#000000,https://cards.scryfall.io/normal/front/b/e/bea44c06-900d-41b8-88fa-c1bede6ce757.jpg?1783915169,Creature — Skeleton Warrior,Ryan Roadkill
+Rebel Informer,3,2000,0.34,#000000,https://cards.scryfall.io/normal/front/c/9/c98a71a8-291f-4d94-ada0-5f50f354cca7.jpg?1783945781,Creature — Human Mercenary Rebel,Scott M. Fischer
+Reign of the Pit,6,2022,0.19,#000000,https://cards.scryfall.io/normal/front/3/0/3074a8e8-765c-4f32-9bc1-a3f865448ef9.jpg?1783923265,Sorcery,Evan Shipard
+Reiver Demon,8,2017,0.76,#000000,https://cards.scryfall.io/normal/front/3/e/3e0de032-a107-4095-b475-28f3f13b2c6e.jpg?1783936286,Creature — Demon,Brom
+Rejoin the Fight,6,2025,0.2,#000000,https://cards.scryfall.io/normal/front/f/3/f3140950-1ce2-41b8-91f9-da53bfbee963.jpg?1783906358,Sorcery,YASUNARI HIRASAKA
+Relentless Dead,2,2016,11.68,#000000,https://cards.scryfall.io/normal/front/2/a/2a0d7998-2f3d-43b8-a0be-6ff7e5c83223.jpg?1783937766,Creature — Zombie,Ryan Yee
+Remorseless Punishment,5,2016,0.11,#000000,https://cards.scryfall.io/normal/front/1/d/1dde9379-b335-400f-9748-a7ca3e293ee0.jpg?1783937911,Sorcery,Ryan Barger
+Repay in Kind,7,2010,3.95,#000000,https://cards.scryfall.io/normal/front/9/0/90d1db4c-1e79-410a-92ab-c9d58c5e58a6.jpg?1783941981,Sorcery,Vance Kovacs
+Repentant Vampire,5,2001,0.58,#000000,https://cards.scryfall.io/normal/front/2/c/2c1dbad4-1105-4426-8d4d-a30f6fa95ce8.jpg?1783945240,Creature — Vampire,Mark Tedin
+Requiem Monolith,3,2025,0.29,#000000,https://cards.scryfall.io/normal/front/8/3/837d710a-652f-4c60-a52d-d786231160a4.jpg?1783905963,Artifact,Warren Mahy
+Retribution of the Ancients,1,2014,0.53,#000000,https://cards.scryfall.io/normal/front/0/d/0d3ee29d-b374-471d-80c3-bcad7a4226e6.jpg?1783939078,Enchantment,Svetlin Velinov
+Return of the Nightstalkers,7,1998,0.81,#000000,https://cards.scryfall.io/normal/front/e/8/e85d85c2-9f34-4375-adcd-a1c5b487cacc.jpg?1783946471,Sorcery,Randy Gallegos
+Revel in Riches,5,2017,15.75,#000000,https://cards.scryfall.io/normal/front/7/9/79b0e035-8716-469d-99ae-a530cd96ef09.jpg?1783935756,Enchantment,Eric Deschamps
+Revenant,5,2001,0.3,#000000,https://cards.scryfall.io/normal/front/9/0/90c75244-68b3-463d-aad3-2b22f1eaf717.jpg?1783945485,Creature — Spirit,Andrew Goldhawk
+Rev- Tithe Extractor,4,2024,20.55,#000000,https://cards.scryfall.io/normal/front/8/b/8bf88010-799d-4217-8e79-308bec7ad2ff.jpg?1783908857,Legendary Creature — Human Rogue,M.Matsumoto
+Rhystic Tutor,3,2000,5.11,#000000,https://cards.scryfall.io/normal/front/e/0/e02c1609-9cac-460f-8504-a84e28c340c1.jpg?1783945781,Sorcery,Dan Frazier
+Ringwraiths,6,2023,1.64,#000000,https://cards.scryfall.io/normal/front/2/a/2a8495c3-96cf-40ab-b68a-1b5711b7659e.jpg?1783916220,Creature — Wraith Knight,Warren Mahy
+Ripples of Undeath,2,2024,6.75,#000000,https://cards.scryfall.io/normal/front/a/2/a201d1bc-e3fe-4f59-bd48-3683996ac308.jpg?1783911276,Enchantment,Ben Wootten
+Risen Executioner,4,2015,1.82,#000000,https://cards.scryfall.io/normal/front/9/5/95ff5e62-b73e-4b85-b65f-5226e75c7f97.jpg?1783938594,Creature — Zombie Warrior,Craig J Spearing
+Rise of the Dark Realms,9,2024,6.34,#000000,https://cards.scryfall.io/normal/front/8/6/8645bf0c-631f-4003-bd24-3e069ae23513.jpg?1783909071,Sorcery,Michael Komarck
+Rise of the Dread Marn,3,2021,0.49,#000000,https://cards.scryfall.io/normal/front/9/d/9d3a1ec1-f362-494d-a23b-6a963ce44fdd.jpg?1783928240,Instant,Titus Lunter
+Rite of Belzenlok,4,2018,0.26,#000000,https://cards.scryfall.io/normal/front/1/e/1ed7cca3-79be-44ca-bf10-2ae1c0835ed1.jpg?1783935004,Enchantment — Saga,Seb McKinnon
+Ritual of Soot,4,2018,0.23,#000000,https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg?1783934172,Sorcery,Dimitar Marinski
+Rodolf Duskbringer,6,2024,3.65,#d78f42,https://cards.scryfall.io/normal/front/0/b/0bfb808d-46a7-4711-b237-f7f5321ea142.jpg?1783908714,Legendary Creature — Vampire Angel,Billy Christian
+Roiling Horror,5,2007,0.35,#000000,https://cards.scryfall.io/normal/front/f/8/f83006a5-c42b-4083-a246-f46b25412150.jpg?1783943153,Creature — Horror,John Avon
+Rot-Curse Rakshasa,2,2025,2.21,#000000,https://cards.scryfall.io/normal/front/3/1/31276460-fa9d-47da-85c5-c4baa8074d0d.jpg?1783907372,Creature — Demon,Chris Rahn
+Rot Hulk,7,2018,3.36,#000000,https://cards.scryfall.io/normal/front/c/e/ce9cf26d-f214-4e76-b000-8dd895cce8d9.jpg?1783933994,Creature — Zombie,Grzegorz Rutkowski
+Rotlung Reanimator,3,2002,17.77,#000000,https://cards.scryfall.io/normal/front/8/7/87b29d1e-9c06-4ad1-8178-b3eaa212f6f1.jpg?1783945065,Creature — Zombie Cleric,Thomas M. Baxa
+Rottenmouth Viper,6,2024,4.72,#000000,https://cards.scryfall.io/normal/front/7/3/735e79b1-a3a9-4ddf-8bbc-f756c8a0452b.jpg?1783910830,Creature — Elemental Snake,Andrea Piparo
+Rotting Regisaur,3,2019,1.93,#000000,https://cards.scryfall.io/normal/front/d/8/d88c61cb-dbf9-46c3-8795-8896ba1208d5.jpg?1783932989,Creature — Zombie Dinosaur,Randy Vargas
+Royal Assassin,3,2023,0.38,#000000,https://cards.scryfall.io/normal/front/6/7/67ef9842-7142-4c63-8aea-fa73f02722a5.jpg?1783918471,Creature — Human Assassin,Mark Zug
+Royal Warden,5,2022,0.52,#000000,https://cards.scryfall.io/normal/front/0/a/0a968eac-2840-41ba-b7de-3182964d4913.jpg?1783920911,Artifact Creature — Necron,Artur Nakhodkin
+Ruinous Path,3,2018,0.22,#000000,https://cards.scryfall.io/normal/front/7/7/771305ca-f33d-4498-8e21-152ced7317ef.jpg?1783934298,Sorcery,Jaime Jones
+Ruin Raider,3,2017,0.18,#000000,https://cards.scryfall.io/normal/front/4/5/457ba695-3637-40de-a8a8-e3a43a71674f.jpg?1783935755,Creature — Orc Pirate,Kieran Yanner
+Rune-Scarred Demon,7,2024,0.77,#000000,https://cards.scryfall.io/normal/front/1/e/1eae3165-554d-4759-8f18-794e2a7d8464.jpg?1783909071,Creature — Demon,Michael Komarck
+Rush of Dread,3,2024,0.39,#000000,https://cards.scryfall.io/normal/front/7/2/721c7122-91b6-45ea-ba28-de0246a2fc1b.jpg?1783911826,Sorcery,Chris Seaman
+Ruthless Technomancer,4,2022,3.52,#000000,https://cards.scryfall.io/normal/front/d/d/dddeb5cc-b535-4484-8a0e-ce32c4c09000.jpg?1783923986,Creature — Human Wizard,PINDURSKI
+Ruthless Winnower,5,2021,1.88,#000000,https://cards.scryfall.io/normal/front/8/8/886ef13a-4f9d-425b-a071-6366cdb637c8.jpg?1783928337,Creature — Elf Rogue,Zoltan Boros
+Sacrifice,1,2024,16.22,#000000,https://cards.scryfall.io/normal/front/6/0/60af9b16-3e0b-432b-b01f-c009630a1d74.jpg?1783909279,Instant,David Palumbo
+Sadistic Sacrament,3,2009,0.82,#000000,https://cards.scryfall.io/normal/front/f/3/f3d82fd7-6af1-4a97-9d51-486a41224b35.jpg?1783942149,Sorcery,Dan Murayama Scott
+Sadistic Shell Game,5,2024,0.34,#000000,https://cards.scryfall.io/normal/front/4/c/4c5c8eb3-c866-4974-90eb-be99c07af1a1.jpg?1783909657,Sorcery,Karl Kopinski
+Salvage Titan,6,2020,0.37,#000000,https://cards.scryfall.io/normal/front/7/1/7175febd-ae8e-4945-91ab-b6c67c40f04b.jpg?1783930176,Artifact Creature — Golem,Anthony Francisco
+Sanctum Seeker,4,2023,0.31,#000000,https://cards.scryfall.io/normal/front/8/9/893279fb-6f51-4d1e-b2fd-a0cdb603785f.jpg?1783913869,Creature — Vampire Knight,Volkan Baǵa
+Sangromancer,4,2021,0.82,#000000,https://cards.scryfall.io/normal/front/5/9/59f7f84c-d0a8-4204-a68e-93075f2a96b0.jpg?1783927552,Creature — Vampire Shaman,Igor Kieryluk
+Sanguine Bond,5,2021,5.64,#000000,https://cards.scryfall.io/normal/front/a/d/ad4de9f1-7a39-45af-828e-c59234d9e9b9.jpg?1783927550,Enchantment,Jaime Jones
+Sanguine Praetor,8,2006,0.35,#000000,https://cards.scryfall.io/normal/front/8/2/8291b1a9-2d04-4dd7-b8c5-3b1018aa0d2f.jpg?1783943507,Creature — Avatar Praetor,rk post
+Sanguine Spy,3,2022,0.3,#000000,https://cards.scryfall.io/normal/front/2/d/2d52ea1e-5b66-47c7-9a6d-95f5996565d8.jpg?1783923124,Creature — Vampire Rogue,David Palumbo
+Sarcomancy,1,1997,16.33,#000000,https://cards.scryfall.io/normal/front/e/b/eb5730f5-a44c-4f75-a26f-90815cfcd31e.jpg?1783946635,Enchantment,Daren Bader
+Sauron- the Necromancer,5,2023,0.45,#000000,https://cards.scryfall.io/normal/front/3/7/377d65d8-21c8-4292-97db-610e0173ba59.jpg?1783916297,Legendary Creature — Avatar Horror,Yongjae Choi
+Savanti Romero- Time's Exile,5,2026,0.28,#000000,https://cards.scryfall.io/normal/front/0/1/01cb8ded-7f77-4b75-b799-23e9f5efb513.jpg?1783904105,Legendary Creature — Demon Wizard,Michele Giorgi
+Saw in Half,3,2022,5.09,#000000,https://cards.scryfall.io/normal/front/0/5/05e6a7bc-a35a-4e68-99a0-be264553b5de.jpg?1783920577,Instant,Sebastian Giacobino
+Scarblade Elite,2,2008,3.39,#000000,https://cards.scryfall.io/normal/front/1/b/1bd5c2b6-fcb2-4865-a0e5-9af59d94ae5a.jpg?1783942791,Creature — Elf Assassin,Greg Staples
+Scavenger Regent // Exude Toxin,4,2025,0.58,#000000,https://cards.scryfall.io/normal/front/0/d/0d4b46a3-847a-44a7-9f68-2cb4657cad61.jpg?1783907372,Creature — Dragon // Sorcery — Omen,John Tedrick
+Scavenger's Talent,1,2024,0.73,#000000,https://cards.scryfall.io/normal/front/9/a/9a52b7fe-87ae-425b-85fd-b24e6e0395f1.jpg?1783910829,Enchantment — Class,Chris Seaman
+Scepter of Fugue,2,2009,0.36,#000000,https://cards.scryfall.io/normal/front/2/1/21f7e17c-45df-45e9-8dcf-7fc90fa4d65d.jpg?1783942481,Artifact,Franz Vohwinkel
+Scheming Silvertongue // Sign in Blood,2,2026,1.42,#000000,https://cards.scryfall.io/normal/front/f/e/fe85a124-0d8b-4a29-8df1-65888a39147f.jpg?1783903675,Creature — Vampire Warlock // Sorcery,Anna Steinbauer
+Scheming Symmetry,1,2019,8.03,#000000,https://cards.scryfall.io/normal/front/0/1/01acc50b-856d-442d-9880-1a892b40643b.jpg?1783932988,Sorcery,Seb McKinnon
+Scion of Darkness,8,2010,0.9,#000000,https://cards.scryfall.io/normal/front/f/e/fe179672-87c0-4ca9-88f8-d432542b3289.jpg?1783941912,Creature — Avatar,Mark Zug
+Scourge of Nel Toth,7,2020,0.5,#000000,https://cards.scryfall.io/normal/front/8/b/8b39ee60-c467-4145-8ca7-123eef01791e.jpg?1783930409,Creature — Zombie Dragon,Mark Winters
+Scourge of the Skyclaves,2,2020,0.53,#000000,https://cards.scryfall.io/normal/front/4/d/4dea7bcc-3ff8-40b0-8264-0cd678d6ff31.jpg?1783929370,Creature — Demon,Chase Stone
+Screeching Scorchbeast,6,2024,2.07,#000000,https://cards.scryfall.io/normal/front/9/6/967dbb24-3073-4c33-bfdf-b3eb9e8fe443.jpg?1783912407,Creature — Bat Mutant,Nino Is
+Scythe Specter,6,2018,0.44,#000000,https://cards.scryfall.io/normal/front/5/9/590bd3e6-3bef-4c2d-9d4f-4b4bd5ff06d0.jpg?1783934753,Creature — Specter,Vincent Proce
+Season of Loss,5,2024,1.68,#000000,https://cards.scryfall.io/normal/front/c/c/cc540652-916b-45c5-ae5a-0a0bc557cee1.jpg?1783910829,Sorcery,Dominik Mayer
+Season of the Witch,3,1994,24.21,#000000,https://cards.scryfall.io/normal/front/0/6/06900a71-34ca-48c6-94ac-fca744356829.jpg?1783947938,Enchantment,Jesper Myrfors
+Secret Salvage,5,2017,0.48,#000000,https://cards.scryfall.io/normal/front/d/9/d9b9f3e2-b5e8-4234-aaf3-5f1938a20c78.jpg?1783936758,Sorcery,Tommy Arnold
+Sedgemoor Witch,3,2021,5.47,#000000,https://cards.scryfall.io/normal/front/e/9/e900c1eb-968b-4046-b824-c167a7a5b682.jpg?1783927362,Creature — Human Warlock,Igor Kieryluk
+Seizan- Perverter of Truth,5,2004,2.06,#000000,https://cards.scryfall.io/normal/front/e/1/e1e61750-f7d7-4e6d-9d68-e1e357868a8d.jpg?1783944308,Legendary Creature — Demon Spirit,Kev Walker
+Seize the Soul,4,2006,0.22,#000000,https://cards.scryfall.io/normal/front/2/9/29bf245f-e8e0-4d32-8cd7-06d832609910.jpg?1783943505,Instant,Aleksi Briclot
+Selfless Glyphweaver // Deadly Vanity,3,2021,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Cleric // Sorcery,Johannes Voss
+Sengir Autocrat,4,1999,0.44,#000000,https://cards.scryfall.io/normal/front/2/3/234a5401-bbe4-40ab-9204-12d944fbd2b1.jpg?1783946179,Creature — Human,David A. Cherry
+Sengir Nosferatu,5,2021,0.14,#000000,https://cards.scryfall.io/normal/front/7/1/71dc9f1e-b889-402d-a5a1-fa0d7d493246.jpg?1783927810,Creature — Vampire,Scott M. Fischer
+Sengir- the Dark Baron,6,2020,0.34,#000000,https://cards.scryfall.io/normal/front/4/d/4d51a22e-74fc-442e-945a-56d02ca12713.jpg?1783928828,Legendary Creature — Vampire Noble,Bastien L. Deharme
+Sengir Vampire,5,2007,0.29,#000000,https://cards.scryfall.io/normal/front/a/1/a1570397-0efa-4b31-a7fd-bdf4dcf690a1.jpg?1783943028,Creature — Vampire,Kev Walker
+Sephiroth- Fabled SOLDIER // Sephiroth- One-Winged Angel,3,2025,33.82,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Avatar Soldier // Legendary Creature — Angel Nightmare Avatar,Wisnu Tan
+Sepulchral Primordial,7,2020,0.43,#000000,https://cards.scryfall.io/normal/front/2/e/2ed2b1d9-3c23-4f2e-b816-6f2bea74b797.jpg?1783929474,Creature — Avatar,Stephan Martiniere
+Serpent Assassin,5,1997,2.07,#000000,https://cards.scryfall.io/normal/front/1/0/1018f6ff-5eaa-4fe1-ba20-544df799f5b2.jpg?1783946823,Creature — Snake Assassin,Roger Raupp
+Serpent's Soul-Jar,3,2021,0.31,#000000,https://cards.scryfall.io/normal/front/0/8/08ae371f-ce62-475f-89a2-1f8a17cf950f.jpg?1783928336,Artifact,Dan Murayama Scott
+Sever the Bloodline,4,2022,0.19,#000000,https://cards.scryfall.io/normal/front/2/2/22bfced7-8fbf-44d2-a439-7ac7c8c7e365.jpg?1783923265,Sorcery,Clint Cearley
+Sewer Nemesis,4,2022,1.21,#000000,https://cards.scryfall.io/normal/front/c/d/cdb8d320-fecc-42c2-b9d8-a9f6dd44b36d.jpg?1783922445,Creature — Horror,Uriah Voth
+Sewers of Estark,4,1994,1.36,#000000,https://cards.scryfall.io/normal/front/b/0/b0da11d4-3603-4f59-8f61-7204bf04e165.jpg?1783947876,Instant,Melissa A. Benson
+Seymour Flux,5,2025,0.29,#000000,https://cards.scryfall.io/normal/front/c/5/c5fdc78e-0815-443c-8c26-35387b6f4f37.jpg?1783906434,Legendary Creature — Spirit Avatar,K-SUWABE
+Shadowborn Demon,5,2013,0.46,#000000,https://cards.scryfall.io/normal/front/3/8/3884c05b-c10e-4f1d-a8bd-8b5118657972.jpg?1783939920,Creature — Demon,Lucas Graciano
+Shadowgrange Archfiend,7,2021,5.64,#000000,https://cards.scryfall.io/normal/front/d/e/de4e445f-4d54-44a8-a5f5-ef02b3d57251.jpg?1783925001,Creature — Demon,Oleksandr Kozachenko
+Shadowheart- Dark Justiciar,4,2022,0.91,#000000,https://cards.scryfall.io/normal/front/1/3/13a0913d-776b-4ef8-adef-8861349df2b5.jpg?1783922752,Legendary Creature — Human Elf Cleric,Cristi Balanescu
+Shadow- Mysterious Assassin,3,2025,0.39,#000000,https://cards.scryfall.io/normal/front/f/8/f88d81d9-8ded-4c20-8237-2218046595fb.jpg?1783906358,Legendary Creature — Human Assassin,Wisnu Tan
+Shadow of Mortality,15,2022,0.61,#000000,https://cards.scryfall.io/normal/front/4/0/40cbb0db-94e9-4988-b900-ced4f9e6d4ed.jpg?1783923125,Creature — Avatar,Robin Olausson
+Shadow of the Enemy,6,2023,1.08,#000000,https://cards.scryfall.io/normal/front/e/4/e47cab70-55cb-481c-b4cd-32a41251f210.jpg?1783916298,Sorcery,Shahab Alizadeh
+Shadow of the Grave,2,2017,0.5,#000000,https://cards.scryfall.io/normal/front/9/b/9b0205cb-c163-4332-9624-394e1024bf6a.jpg?1783936499,Instant,Darek Zabrocki
+Shadow-Rite Priest,2,2022,0.34,#000000,https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg?1783921326,Creature — Human Cleric,Michael C. Hayes
+Shadows' Verdict,5,2020,0.2,#000000,https://cards.scryfall.io/normal/front/5/2/52470883-b44d-415b-9324-8074e66f79ae.jpg?1783929366,Sorcery,Lius Lasahido
+Shaile- Dean of Radiance // Embrose- Dean of Shadow,2,2021,0.38,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Bird Cleric // Legendary Creature — Human Warlock,Yongjae Choi
+Shakedown Heavy,3,2022,0.33,#000000,https://cards.scryfall.io/normal/front/c/e/ce418184-a672-46bc-a17d-c559614defb5.jpg?1783923123,Creature — Ogre Warrior,Randy Vargas
+Shallow Grave,2,1996,99.75,#000000,https://cards.scryfall.io/normal/front/d/5/d5c782cc-c951-4c6f-a93f-774ae6c1c214.jpg?1783947088,Instant,John Coulthart
+Shambling Swarm,4,2002,0.54,#000000,https://cards.scryfall.io/normal/front/b/5/b5b93715-985f-4719-a3c3-044c2a150e96.jpg?1783945152,Creature — Horror,Arnie Swekel
+Shard of the Nightbringer,8,2022,6.23,#000000,https://cards.scryfall.io/normal/front/2/1/21e4140e-22b3-479f-a259-0f56ed02b8ad.jpg?1783920909,Creature — C'tan,Pierre Loyvet
+Shard of the Void Dragon,7,2022,2.53,#000000,https://cards.scryfall.io/normal/front/4/1/41dd0b55-3dbb-4b65-a949-20c2a12f7edd.jpg?1783920909,Creature — C'tan,Alex Konstad
+Shared Trauma,1,2018,0.43,#000000,https://cards.scryfall.io/normal/front/5/8/58f562e0-6a7f-4795-9cca-1ce5f9c9ee18.jpg?1783934753,Sorcery,Clint Cearley
+Shark Shredder- Killer Clone,4,2026,0.33,#000000,https://cards.scryfall.io/normal/front/8/f/8f946b3d-7d2a-4210-a909-d16078757e3b.jpg?1783904104,Legendary Creature — Shark Octopus Ninja,Nicholas Gregory
+Shauku- Endbringer,7,1996,2.32,#000000,https://cards.scryfall.io/normal/front/0/6/06d94b21-7568-4e5c-a8ec-ff5bb48a4f36.jpg?1783947088,Legendary Creature — Vampire,Pete Venters
+Shelob- Dread Weaver,4,2023,0.37,#000000,https://cards.scryfall.io/normal/front/8/3/83944c19-6f9b-4043-9eeb-1a4ca452f698.jpg?1783916030,Legendary Creature — Spider Demon,Warren Mahy
+Sheoldred's Edict,2,2026,2.13,#000000,https://cards.scryfall.io/normal/front/d/c/dca66a1b-0acd-4b79-b5fe-16f2930f9c1b.jpg?1783903924,Instant,Lorenzo Gaggiotti
+Sheoldred- the Apocalypse,4,2022,96.41,#000000,https://cards.scryfall.io/normal/front/d/6/d67be074-cdd4-41d9-ac89-0a0456c4e4b2.jpg?1783921327,Legendary Creature — Phyrexian Praetor,Chris Rahn
+Sheoldred // The True Scriptures,5,2023,18.32,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Phyrexian Praetor // Enchantment — Saga,Ryan Pancoast
+Sheoldred- Whispering One,7,2020,20.48,#000000,https://cards.scryfall.io/normal/front/8/b/8b207a4a-47d1-4905-81d3-455c59bfd7da.jpg?1783930409,Legendary Creature — Phyrexian Praetor,Jana Schirmer & Johannes Voss
+Shilgengar- Sire of Famine,5,2024,0.32,#d78f42,https://cards.scryfall.io/normal/front/9/e/9e6aba35-bee5-4058-a2df-d73506d225c2.jpg?1783911275,Legendary Creature — Elder Demon,Chris Rallis
+Shimian Specter,4,2012,0.18,#000000,https://cards.scryfall.io/normal/front/1/c/1ca9e99b-e46c-4f7a-9c51-e2cfe8810450.jpg?1783940489,Creature — Specter,Anthony S. Waters
+Shirei- Shizo's Caretaker,5,2005,0.94,#000000,https://cards.scryfall.io/normal/front/7/d/7db7ced3-08b8-4599-9f44-3c6c8f905c9b.jpg?1783944195,Legendary Creature — Spirit,Wayne Reynolds
+Shoot the Sheriff,2,2026,2.87,#000000,https://cards.scryfall.io/normal/front/0/d/0d4c4b20-8cab-43fe-9f77-dd35eaf56e57.jpg?1783995433,Instant,Marcuscus
+Shredder- Shadow Master,5,2026,0.87,#000000,https://cards.scryfall.io/normal/front/d/d/ddf4d3c9-bef9-4796-91ef-3d5beebae571.jpg?1783904169,Legendary Creature — Human Ninja,Miklós Ligeti
+Shriveling Rot,4,2004,0.47,#000000,https://cards.scryfall.io/normal/front/2/5/25c255d5-9246-4a93-8750-0da8871fb12d.jpg?1783944441,Instant,Alex Horley-Orlandelli
+Sickening Shoal,2,2005,12.73,#000000,https://cards.scryfall.io/normal/front/d/9/d92f4129-19fc-4ee9-9e3d-77fcf1563e4b.jpg?1783944196,Instant — Arcane,Dan Murayama Scott
+Sidisi- Regent of the Mire,2,2025,0.37,#000000,https://cards.scryfall.io/normal/front/4/7/47374d23-662b-4ba7-a94f-37c9bc759cc6.jpg?1783907370,Legendary Creature — Zombie Snake Warlock,Diana Franco
+Sidisi- Undead Vizier,5,2015,7.92,#000000,https://cards.scryfall.io/normal/front/6/e/6ea5dbba-6114-4d97-9363-817ab9e896d3.jpg?1783938593,Legendary Creature — Zombie Snake,Min Yum
+Siegfried- Famed Swordsman,4,2025,0.23,#000000,https://cards.scryfall.io/normal/front/6/9/69dadb0c-413e-4658-9cdc-23a65df7a800.jpg?1783906357,Legendary Creature — Human Warrior Rogue,Crystal Fae
+Sign in Blood,2,2021,5.46,#000000,https://cards.scryfall.io/normal/front/e/3/e3fcd51a-77d2-41bc-b1ca-02f23c95a74e.jpg?1783925034,Sorcery,Alan Pollack
+Silence the Believers,4,2014,0.17,#000000,https://cards.scryfall.io/normal/front/d/6/d6dc2bd1-a980-4eab-8bb3-1ce28c3f9ef4.jpg?1783939430,Instant,Slawomir Maniak
+Silent Assassin,2,1999,0.52,#000000,https://cards.scryfall.io/normal/front/b/a/ba34034a-1150-41c8-a340-543f529ae07f.jpg?1783945947,Creature — Human Mercenary Assassin,rk post
+Silent Specter,6,2002,0.53,#000000,https://cards.scryfall.io/normal/front/b/f/bfd891ba-cf6a-4b83-a421-3a7c346ada31.jpg?1783945063,Creature — Specter,Daren Bader
+Silumgar Assassin,2,2019,0.31,#000000,https://cards.scryfall.io/normal/front/8/1/818034cf-8b55-4c9b-b265-b08c23fb0aef.jpg?1783932761,Creature — Human Assassin,Yohann Schepacz
+Sima Yi- Wei Field Marshal,6,1999,29.66,#000000,https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg?1783946115,Legendary Creature — Human Soldier,Gao Yan
+Sinister Gnarlbark,3,2026,0.42,#000000,https://cards.scryfall.io/normal/front/9/3/939a4eaa-4d9b-47d1-94a4-fb1e9a95e539.jpg?1783904604,Creature — Treefolk Warlock,Olivier Bernard
+Sinkhole,2,2016,8.04,#000000,https://cards.scryfall.io/normal/front/a/0/a084d0fb-8db2-4873-a2f9-e6e5fecdd38c.jpg?1783937591,Sorcery,Jonas De Ro
+Sinkhole Surveyor,2,2025,0.31,#000000,https://cards.scryfall.io/normal/front/3/7/37cb5599-7d2c-48e9-978b-902a01a74bde.jpg?1783907369,Creature — Bird Scout,Warren Mahy
+Sins of the Past,6,2005,0.42,#000000,https://cards.scryfall.io/normal/front/5/c/5c518792-a50f-40b1-b6fb-674432093b6a.jpg?1783943661,Sorcery,Jeremy Jarvis
+Skeletal Vampire,6,2017,0.39,#000000,https://cards.scryfall.io/normal/front/3/2/327096bb-78d3-444f-a017-4c504d18203a.jpg?1783935900,Creature — Vampire Skeleton,Wayne Reynolds
+Skeleton Crew,4,2023,0.3,#000000,https://cards.scryfall.io/normal/front/d/d/dd9f52d6-da6d-4f68-aafb-6bd3d022f616.jpg?1783913909,Creature — Skeleton Pirate,Camille Alquier
+Skeleton Scavengers,3,1998,0.52,#000000,https://cards.scryfall.io/normal/front/5/7/57af1b3f-661a-4b02-be08-0ec721d7cab8.jpg?1783946559,Creature — Skeleton,Brian Snõddy
+Skemfar Avenger,2,2021,0.4,#000000,https://cards.scryfall.io/normal/front/f/a/fad2c6d4-03dd-4dab-861c-77c55bda0db7.jpg?1783928240,Creature — Elf Berserker,Randy Vargas
+Skirsdag High Priest,2,2025,0.41,#000000,https://cards.scryfall.io/normal/front/7/a/7a329b20-4e6e-45c9-aee0-51fe81dce543.jpg?1783908131,Creature — Human Cleric,Jason A. Engle
+Skithiryx- the Blight Dragon,5,2020,12.48,#000000,https://cards.scryfall.io/normal/front/c/a/cab61c7e-e00a-413b-a0b5-7718b479582f.jpg?1783930175,Legendary Creature — Phyrexian Dragon Skeleton,Chippy
+Skorpekh Lord,3,2022,2.65,#000000,https://cards.scryfall.io/normal/front/b/7/b768ec5f-771a-4acd-b3dd-85dea914689e.jpg?1783920906,Artifact Creature — Necron Noble,Adrián Rodríguez Pérez
+Skull Storm,9,2018,0.87,#000000,https://cards.scryfall.io/normal/front/0/5/05e95b4c-1b59-4eec-8392-794b35202aad.jpg?1783934338,Sorcery,Mark Poole
+Skyclave Shade,2,2022,0.3,#000000,https://cards.scryfall.io/normal/front/b/4/b4bdcf1d-3387-4e21-9159-9294af1ab0b4.jpg?1783923263,Creature — Shade,Daarken
+Slaughter Pact,0,2021,1.54,#000000,https://cards.scryfall.io/normal/front/8/1/81e00341-030f-433e-b22b-aca42e0a88d2.jpg?1783927810,Instant,Kev Walker
+Slaughter Specialist,2,2021,0.9,#000000,https://cards.scryfall.io/normal/front/c/b/cb83e33c-810e-4de3-800d-2038f38a1eda.jpg?1783925610,Creature — Vampire Warrior,Kari Christensen
+Sleeper Agent,1,2007,1.72,#000000,https://cards.scryfall.io/normal/front/6/0/60096938-d520-424a-afe4-0c5ee8b90aa1.jpg?1783943028,Creature — Phyrexian Minion,Randy Gallegos
+Sloppity Bilepiper,4,2022,0.34,#000000,https://cards.scryfall.io/normal/front/7/e/7eadbe1b-12a2-4791-b51d-e5eebf652af6.jpg?1783920905,Creature — Demon,Ørjan Ruttenborg Svendsen
+Smallpox,2,2026,0.77,#000000,https://cards.scryfall.io/normal/front/0/f/0f6f64b9-145c-4ed2-b90c-cbcf021b353d.jpg?1783903924,Sorcery,Lorenzo Gaggiotti
+Snuff Out,4,2024,11.18,#000000,https://cards.scryfall.io/normal/front/9/e/9eba002c-3562-4295-81e4-5f408f1556c6.jpg?1783909710,Instant,Ed Repka
+Solemn Doomguide,5,2022,0.23,#000000,https://cards.scryfall.io/normal/front/b/4/b467929d-5fc3-4104-8a29-a8157835f274.jpg?1783922505,Creature — Tiefling Cleric,Micah Epstein
+Sorceress Queen,3,1997,1.3,#000000,https://cards.scryfall.io/normal/front/6/5/657979b3-6e4f-41a8-a518-4bd329307770.jpg?1783946921,Creature — Human Wizard Sorcerer,Kaja Foglio
+Sorin- Imperious Bloodlord,3,2025,5.83,#000000,https://cards.scryfall.io/normal/front/2/1/219d3e48-e0b1-472d-ac45-11c14b292c9e.jpg?1783908130,Legendary Planeswalker — Sorin,Chase Stone
+Sorin Markov,6,2011,9.72,#000000,https://cards.scryfall.io/normal/front/e/2/e25b3a89-3a99-4e02-bf0c-a3cf450da1a1.jpg?1783941077,Legendary Planeswalker — Sorin,Michael Komarck
+Sorin of House Markov // Sorin- Ravenous Neonate,2,2024,2.88,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Noble // Legendary Planeswalker — Sorin,Matt Stewart
+Sorin's Guide,5,2019,0.24,#000000,https://cards.scryfall.io/normal/front/4/1/416b000d-77d0-4c83-bbbd-d1107f746dde.jpg?1783932920,Creature — Vampire,Jason Rainville
+Sorin's Vengeance,7,2011,1.17,#000000,https://cards.scryfall.io/normal/front/2/c/2cb62846-c5da-4c7c-b0d7-9b677dce68d1.jpg?1783941077,Sorcery,Jana Schirmer & Johannes Voss
+Sorin the Mirthless,4,2021,2.26,#000000,https://cards.scryfall.io/normal/front/c/c/cc7ff5f4-a7cc-41a1-a22b-8cf67ad18707.jpg?1783924850,Legendary Planeswalker — Sorin,Martina Fačková
+Sothera- the Supervoid,4,2025,1.79,#000000,https://cards.scryfall.io/normal/front/e/9/e99d6fc0-dcf2-4b25-81c2-02c230a36246.jpg?1783905962,Legendary Enchantment,Dominik Mayer
+Soul Collector,5,2003,0.55,#000000,https://cards.scryfall.io/normal/front/e/c/ec78c0e8-a354-46d2-95ad-012f120c3df8.jpg?1783944878,Creature — Vampire,Matthew D. Wilson
+Soulflayer,6,2020,0.33,#000000,https://cards.scryfall.io/normal/front/e/2/e249a406-6783-4502-952a-27ec744a38b3.jpg?1783931177,Creature — Demon,Seb McKinnon
+Soul of Innistrad,6,2020,0.36,#000000,https://cards.scryfall.io/normal/front/3/1/31155467-5444-4a9b-a602-ec7cdad89e8b.jpg?1783931179,Creature — Avatar,Adam Paquette
+Soul Shatter,3,2020,3.7,#000000,https://cards.scryfall.io/normal/front/2/c/2c2fb07b-0f70-403b-be8b-b5217f12e671.jpg?1783929366,Instant,Wylie Beckert
+Souls of the Lost,2,2023,0.31,#000000,https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg?1783913771,Creature — Spirit,Nils Hamm
+Soul Spike,7,2006,16.62,#000000,https://cards.scryfall.io/normal/front/4/b/4b14b97d-122b-453a-9e5f-129404f96440.jpg?1783943346,Instant,Wayne England
+Soul Transfer,3,2022,0.25,#000000,https://cards.scryfall.io/normal/front/1/e/1e5aba90-c8c7-4f06-b7b3-1b4758d2791a.jpg?1783923876,Sorcery,Lorenzo Mastroianni
+South Wind Avatar,4,2026,2.4,#000000,https://cards.scryfall.io/normal/front/c/1/c17bc07c-7147-4c84-aa0b-8a0865fba94e.jpg?1783904101,Creature — Snake Spirit Avatar,InHyuk Lee
+Sower of Discord,6,2023,5.31,#000000,https://cards.scryfall.io/normal/front/f/5/f532301e-9005-4770-9e04-868f69f6becf.jpg?1783915666,Creature — Demon,Wisnu Tan
+Spawn of Mayhem,4,2024,0.53,#000000,https://cards.scryfall.io/normal/front/c/7/c78aa786-a6ea-429f-a9e1-48f848578af3.jpg?1783912544,Creature — Demon,Victor Adame Minguez
+Species Specialist,4,2020,10.34,#000000,https://cards.scryfall.io/normal/front/b/b/bb2cbf12-7f35-4162-b1a0-89a1632728c7.jpg?1783931217,Creature — Human Warrior,Paul Scott Canavan
+Specter of Mortality,5,2023,0.22,#000000,https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg?1783915102,Creature — Specter,Daarken
+Sphere of Annihilation,1,2021,0.28,#000000,https://cards.scryfall.io/normal/front/3/d/3d2315a9-584b-4c59-af43-dd38bcb6c322.jpg?1783926488,Artifact,Jason Felix
+Spike- Tournament Grinder,4,2017,0.3,#000000,https://cards.scryfall.io/normal/front/b/0/b0e90b22-6f43-4e9a-a236-f33191768813.jpg?1783935429,Legendary Creature — Human Gamer,Zoltan Boros
+Spirit of the Night,9,1996,7.24,#000000,https://cards.scryfall.io/normal/front/8/4/845c4b06-090f-4217-acb2-8900b7dab37c.jpg?1783947085,Legendary Creature — Demon Spirit,Cliff Nielsen
+Spiteful Hexmage,1,2023,0.16,#000000,https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1783915102,Creature — Human Warlock,Anna Steinbauer
+Spitting Dilophosaurus,3,2023,29.54,#000000,https://cards.scryfall.io/normal/front/f/4/f4f0c479-5fd1-45c2-af3f-15b6e5811b0f.jpg?1783913640,Creature — Dinosaur,Francisco Badilla
+Splinter's Technique,4,2026,2.15,#000000,https://cards.scryfall.io/normal/front/f/d/fd3a5465-074a-4688-b79b-68e232076581.jpg?1783904100,Sorcery,Jo Cordisco
+Splinter- the Mentor,2,2026,2.15,#000000,https://cards.scryfall.io/normal/front/0/6/06c595fa-55ff-46f3-afaf-17edae465864.jpg?1783904174,Legendary Creature — Mutant Ninja Rat,Andrea Tentori Montalto
+Spoils of Blood,1,2014,2.04,#000000,https://cards.scryfall.io/normal/front/d/9/d9df391c-eb76-45b1-a58d-8211538a22ac.jpg?1783938867,Instant,Erica Yang
+Spoils of Evil,3,1995,6.06,#000000,https://cards.scryfall.io/normal/front/f/d/fd368eb6-72f0-42d4-afa5-3daa7de949ff.jpg?1783947494,Instant,Quinton Hoover
+Spoils of the Vault,1,2018,0.56,#000000,https://cards.scryfall.io/normal/front/6/e/6eb97a96-2c56-4638-b971-00cdf1eafd43.jpg?1783933812,Instant,Steven Belledin
+Spoils of War,1,1995,2.62,#000000,https://cards.scryfall.io/normal/front/b/3/b38af8bd-d927-46d0-a1b1-fb437ea9ea66.jpg?1783947494,Sorcery,Pete Venters
+Spreading Plague,5,2000,11.95,#000000,https://cards.scryfall.io/normal/front/a/c/ac86055d-ce08-4b05-a92c-45e007ca0ba4.jpg?1783945691,Enchantment,Scott Bailey
+Stain the Mind,5,2014,0.21,#000000,https://cards.scryfall.io/normal/front/c/7/c7d2b046-59bc-4e39-94ce-981179307bd3.jpg?1783939180,Sorcery,Jason Rainville
+Stalactite Stalker,1,2023,0.27,#000000,https://cards.scryfall.io/normal/front/5/3/5319c0b1-de54-492a-bdea-85a5a75d693e.jpg?1783913771,Creature — Goblin Rogue,Olivier Bernard
+Stalking Bloodsucker,6,2001,0.27,#000000,https://cards.scryfall.io/normal/front/1/6/16705695-1ba8-4169-974f-d8c683ab2652.jpg?1783945241,Creature — Vampire,Greg Staples
+Starscream- Power Hungry // Starscream- Seeker Leader,4,2022,3.8,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact Creature — Robot // Legendary Artifact — Vehicle,Volta Creation
+Starving Revenant,4,2023,0.3,#000000,https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg?1783913770,Creature — Spirit Horror,Fesbra
+Stenchskipper,4,2008,0.31,#000000,https://cards.scryfall.io/normal/front/c/3/c376fd5f-596a-4208-b173-0b2e5165f2e9.jpg?1783942788,Creature — Elemental,Howard Lyon
+Stensian Sanguinist // Exsanguinate,2,2026,4.14,#000000,https://cards.scryfall.io/normal/front/9/0/909a52bc-53f6-4654-9db7-e8f48333d765.jpg?1783903860,Creature — Vampire Cleric // Sorcery,Cristi Balanescu
+Stinging Study,5,2021,16.03,#000000,https://cards.scryfall.io/normal/front/b/8/b8840226-1693-44bc-a067-e50198c5e17e.jpg?1783927597,Instant,Kieran Yanner
+Stinkweed Imp,3,2026,6.31,#000000,https://cards.scryfall.io/normal/front/6/a/6a601d71-04e0-48f1-8011-a77186c1dd97.jpg?1783904233,Creature — Imp,Austin DuRivage
+Stone Catapult,5,1999,45.49,#000000,https://cards.scryfall.io/normal/front/6/0/60303bfe-9158-4e25-a905-6522883ab671.jpg?1783946113,Creature — Human Soldier,Shang Huitong
+Stromkirk Condemned,2,2021,0.33,#000000,https://cards.scryfall.io/normal/front/b/0/b0e0cecb-4f14-438e-a9d0-c6b19a4126c5.jpg?1783924953,Creature — Vampire Horror,Magali Villeneuve
+Strongarm Tactics,2,2002,0.38,#000000,https://cards.scryfall.io/normal/front/5/7/57dcf434-5c67-440a-8b67-2df7307e92bd.jpg?1783945062,Sorcery,Greg Hildebrandt & Tim Hildebrandt
+Stronghold Arena,2,2022,0.29,#d78f42,https://cards.scryfall.io/normal/front/f/b/fb64b0a7-3e9a-490f-bf02-c62fc8cf750d.jpg?1783921324,Enchantment,Alexander Mokhov
+Stronghold Overseer,6,2006,0.62,#000000,https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg?1783943227,Creature — Demon,Puddnhead
+Stunning Reversal,4,2018,5.43,#000000,https://cards.scryfall.io/normal/front/6/7/6714197d-7420-43a1-8b08-4e1fd6355b54.jpg?1783934859,Instant,Zoltan Boros
+Subversion,5,1999,2.41,#000000,https://cards.scryfall.io/normal/front/5/0/50f1bca9-5831-4e8b-8920-f28ebb3ffb27.jpg?1783946238,Enchantment,Rob Alexander
+Sudden Edict,2,2025,12.64,#000000,https://cards.scryfall.io/normal/front/a/4/a4630fe2-f1d2-4ae5-9840-886a95c42aab.jpg?1783907529,Instant,Sadboi
+Sudden Spoiling,3,2021,7.48,#000000,https://cards.scryfall.io/normal/front/7/3/73514b51-6c19-4b3c-9cf9-2cf5028d7708.jpg?1783927806,Instant,Alan Pollack
+Summon: Primal Odin,6,2025,1.42,#000000,https://cards.scryfall.io/normal/front/8/b/8b1b5f06-e34d-44a3-976e-5157c4b7a0f4.jpg?1783906611,Enchantment Creature — Saga Knight,Nino Is
+Summon the Pack,8,2017,0.71,#000000,https://cards.scryfall.io/normal/front/c/d/cd66d5bb-a0cc-48fa-9d98-4195debc188a.jpg?1783935427,Sorcery,Matt Cavotta
+Sunset Saboteur,2,2025,0.25,#000000,https://cards.scryfall.io/normal/front/3/9/396bca07-82ba-49b7-b79e-7784b3a06d48.jpg?1783905960,Creature — Human Rogue,Mirko Failoni
+Super Shredder,2,2026,18.22,#000000,https://cards.scryfall.io/normal/front/3/7/37a497b8-e908-4ddc-996e-a8470df72afb.jpg?1783904099,Legendary Creature — Mutant Ninja Human,Néstor Ossandón Leal
+Super-Skrull,4,2026,0.35,#d78f42,https://cards.scryfall.io/normal/front/1/1/11fc8221-756a-4919-9272-38793e9c1ad9.jpg?1783902936,Legendary Creature — Skrull Shapeshifter Villain,Zoltan Boros
+Supper for Spiders,2,2026,19.99,#000000,https://cards.scryfall.io/normal/front/5/b/5b25e454-06bb-43ca-9a9f-57164f7a70c4.jpg?1784376962,Instant,Michele Giorgi
+Surgical Extraction,1,2022,2.77,#000000,https://cards.scryfall.io/normal/front/e/1/e15d76ac-1c23-4503-8225-375ac2bf2fb6.jpg?1783921896,Instant,Steven Belledin
+Suspended Sentence,4,2024,0.87,#000000,https://cards.scryfall.io/normal/front/3/8/38c98aa0-bfa1-42f4-b035-a48dac86f0ce.jpg?1783909657,Instant,L.A. Draws
+Sutured Ghoul,7,2011,0.24,#000000,https://cards.scryfall.io/normal/front/8/3/8390d9b7-5adf-4039-8682-02bfba421ff9.jpg?1783941077,Creature — Zombie,Carl Critchlow
+Swarmyard Massacre,5,2024,4.09,#000000,https://cards.scryfall.io/normal/front/8/4/8486f472-afad-4fdd-a57a-d20d8871b543.jpg?1783910732,Sorcery,Michael Phillippi
+Swift Demise,3,2026,0.28,#000000,https://cards.scryfall.io/normal/front/4/4/442feb65-9c0f-4962-8518-78e6d314c916.jpg?1783904168,Instant,Anna Pavleeva
+Sword-Point Diplomacy,3,2017,0.22,#000000,https://cards.scryfall.io/normal/front/2/5/25750098-02a1-48e4-917d-187c41e111b6.jpg?1783935754,Sorcery,Eric Deschamps
+Syndicate Trafficker,2,2016,0.24,#000000,https://cards.scryfall.io/normal/front/d/8/d89427f0-08d5-49a1-9684-ebe8769430f6.jpg?1783937200,Creature — Aetherborn Rogue,Tony Foti
+Syphon Sliver,3,2023,7.83,#000000,https://cards.scryfall.io/normal/front/3/d/3d222985-759c-4fdc-82ba-d970ef789b35.jpg?1783915433,Creature — Sliver,Johann Bodin
+Syr Konrad- the Grim,5,2023,2.38,#000000,https://cards.scryfall.io/normal/front/e/9/e9d7e6fe-ed8b-442c-86f0-c84e9d333f62.jpg?1783914805,Legendary Creature — Human Knight,Anna Steinbauer
+Szat's Will,5,2020,1.21,#000000,https://cards.scryfall.io/normal/front/9/8/9828be7b-1eae-4718-9e71-2f625121b00b.jpg?1783928826,Instant,Sidharth Chaturvedi
+Taborax- Hope's Demise,3,2020,0.26,#000000,https://cards.scryfall.io/normal/front/3/3/331bf97d-f447-4c68-bfc7-2bb593106d66.jpg?1783929365,Legendary Creature — Demon Cleric,G-host Lee
+Tainted Adversary,2,2021,1.24,#000000,https://cards.scryfall.io/normal/front/e/6/e6b9b8fc-c30d-49e7-bb6c-219380d73a82.jpg?1783925608,Creature — Zombie,Tuan Duong Chu
+Tainted Aether,4,2001,8.15,#000000,https://cards.scryfall.io/normal/front/8/3/838cffb6-8099-44d7-a127-b2ab3b53ea44.jpg?1783945479,Enchantment,Ciruelo
+Tainted Pact,2,2001,39.7,#000000,https://cards.scryfall.io/normal/front/c/5/c513f51b-a0db-4c08-8acc-1e91060b93b7.jpg?1783945239,Instant,Adam Rex
+Tainted Remedy,3,2015,8.06,#000000,https://cards.scryfall.io/normal/front/c/b/cbb8edd0-4573-4b52-a3ea-83ed19dbf58d.jpg?1783938337,Enchantment,Izzy
+Tainted Specter,4,1996,0.52,#000000,https://cards.scryfall.io/normal/front/7/4/74feb223-784a-4540-8a8e-6007d10a9505.jpg?1783947085,Creature — Specter,Chippy
+Tallyman of Nurgle,3,2022,0.41,#000000,https://cards.scryfall.io/normal/front/7/2/72ce155e-af65-47f9-8967-6608bd69ee55.jpg?1783920905,Creature — Astartes Warrior,Games Workshop
+Tangled Colony,2,2023,0.78,#000000,https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg?1783915099,Creature — Rat,Filip Burburan
+Tar Fiend,6,2008,0.32,#000000,https://cards.scryfall.io/normal/front/f/a/fa1903f8-2863-4203-9552-a75759fa8c94.jpg?1783942563,Creature — Elemental,Anthony S. Waters
+Tarrian's Journal // The Tomb of Aclazotz,2,2023,0.52,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact — Book // Legendary Land — Cave,Randy Gallegos
+Tasigur- the Golden Fang,6,2025,0.26,#d78f42,https://cards.scryfall.io/normal/front/1/7/175ad810-3cdd-43c7-99a9-8a2e8ad6dbae.jpg?1783907079,Legendary Creature — Human Shaman,Chris Rahn
+Taste of Death,6,2021,0.38,#000000,https://cards.scryfall.io/normal/front/a/4/a4e52634-8502-4b72-950d-eb4c2f6b3bc4.jpg?1783927548,Sorcery,Chris Rallis
+Taster of Wares,3,2026,0.25,#000000,https://cards.scryfall.io/normal/front/b/c/bc0b64b6-8984-431c-8a2f-84402b429e2b.jpg?1783904460,Creature — Goblin Warlock,Edgar Sánchez Hidalgo
+Tatsunari- Toad Rider,3,2022,0.34,#d78f42,https://cards.scryfall.io/normal/front/a/b/abf42833-43d0-4b05-b499-d13b2c577ee8.jpg?1783923876,Legendary Creature — Human Ninja,Justine Cruz
+Technomancer,7,2022,0.59,#000000,https://cards.scryfall.io/normal/front/c/1/c160c1f7-714e-444a-ab74-c64c3a099a48.jpg?1783920903,Artifact Creature — Necron Wizard,David Álvarez
+Tegwyll's Scouring,6,2023,1.11,#000000,https://cards.scryfall.io/normal/front/8/c/8c50b2f9-036d-424c-9661-5cb56b8cddfd.jpg?1783914986,Sorcery,Campbell White
+Temporal Extortion,4,2007,29.56,#000000,https://cards.scryfall.io/normal/front/8/8/883a1afb-423d-4f12-93e1-75cc336553b8.jpg?1783943152,Sorcery,Steven Belledin
+Tempt with Immortality,5,2013,1.49,#000000,https://cards.scryfall.io/normal/front/c/8/c87ff489-2d9c-4f04-a169-9eafb046dd7e.jpg?1783939672,Sorcery,Philip Straub
+Tenacious Underdog,2,2022,0.39,#000000,https://cards.scryfall.io/normal/front/9/b/9b6a6d00-3e00-4827-8420-13343ac3d0fd.jpg?1783923123,Creature — Human Warrior,Zara Alfonso
+Tergrid- God of Fright // Tergrid's Lantern,5,2021,22.64,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact,Yongjae Choi
+Terisiare's Devastation,4,2022,0.37,#000000,https://cards.scryfall.io/normal/front/4/9/494a9b67-cfd8-44cd-adbb-8e8a9eeca0d4.jpg?1783919721,Sorcery,Bram Sels
+Termination Facilitator,2,2022,2.9,#000000,https://cards.scryfall.io/normal/front/5/d/5db59164-f0b1-4b5a-b821-ad0b2e1612d1.jpg?1783919185,Creature — Human Assassin,Justine Cruz
+Terror,2,2005,7.58,#000000,https://cards.scryfall.io/normal/front/b/a/ba9d4863-75f2-4894-8033-e4ffebe0547a.jpg?1783944221,Instant,Ron Spencer
+Terror of Towashi,4,2023,0.32,#000000,https://cards.scryfall.io/normal/front/9/a/9a759d44-5496-437e-a714-acc398988b84.jpg?1783916902,Creature — Phyrexian Ogre,Lius Lasahido
+Terror Tide,4,2023,0.28,#000000,https://cards.scryfall.io/normal/front/0/a/0a281d2c-20b9-4887-a924-9be6c07b7629.jpg?1783913768,Sorcery,Brock Grossman
+Tetzimoc- Primal Death,6,2018,0.85,#000000,https://cards.scryfall.io/normal/front/c/6/c6a0b40e-7a43-4722-b787-a5d7ec6453ac.jpg?1783935305,Legendary Creature — Elder Dinosaur,Zack Stella
+Teval's Judgment,3,2025,7.45,#000000,https://cards.scryfall.io/normal/front/4/0/40ed0cef-8ff6-4169-a9f3-7dd5cf56b79f.jpg?1783907175,Enchantment,Alix Branwyn
+Tevesh Szat- Doom of Fools,5,2020,7.26,#000000,https://cards.scryfall.io/normal/front/8/f/8f244716-78ab-46f5-b6e9-fc1e6db28052.jpg?1783928825,Legendary Planeswalker — Szat,Livia Prima
+Thanos- Death's Consort,4,2026,3.84,#000000,https://cards.scryfall.io/normal/front/4/8/4842d520-8bce-4b95-bcb6-bd9eb9374f90.jpg?1783903109,Legendary Creature — Eternal Villain,Kieran Yanner
+The Book of Vile Darkness,3,2021,0.5,#000000,https://cards.scryfall.io/normal/front/0/5/05dcff61-8c48-401f-a31f-5fc53a298356.jpg?1783926499,Legendary Artifact — Book,Daniel Ljunggren
+The Cauldron of Eternity,12,2019,1.39,#000000,https://cards.scryfall.io/normal/front/e/b/eb69473f-de99-43a7-b094-429465ae735c.jpg?1783932642,Legendary Artifact,Tomasz Jedruszek
+The Cloning of Shredder,6,2026,1.36,#000000,https://cards.scryfall.io/normal/front/9/4/94449d88-2df4-4850-8ffa-d6d193835dda.jpg?1783904107,Enchantment — Saga,Chris Seaman
+The Cruelty of Gix,5,2022,1.32,#000000,https://cards.scryfall.io/normal/front/3/d/3d6e5eb3-25ab-4e9e-96e8-655e0ce74675.jpg?1783921334,Enchantment — Saga,Volkan Baǵa
+The Darkness Crystal,4,2025,5.42,#000000,https://cards.scryfall.io/normal/front/0/f/0f93b6ac-54ce-45d0-8549-19307406e6e5.jpg?1783906621,Legendary Artifact,Pablo Mendoza
+The Death of Gwen Stacy,3,2025,0.37,#000000,https://cards.scryfall.io/normal/front/6/9/690f1f31-f8c5-4336-9ec9-72ff761e3adc.jpg?1783905346,Enchantment — Saga,Bill Sienkiewicz
+The Destined Black Mage,3,2025,17.82,#000000,https://cards.scryfall.io/normal/front/c/b/cbba90d0-c45e-4ef1-ba0e-a2160533e27f.jpg?1783904654,Legendary Creature — Human Wizard,David Rapoza
+The Elderspell,2,2019,0.35,#000000,https://cards.scryfall.io/normal/front/a/3/a3b16625-7faf-4de6-abf7-d397988e32fb.jpg?1783933446,Sorcery,Daarken
+The End,4,2023,0.32,#000000,https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg?1783915109,Instant,Donato Giancola
+The Falcon- Airship Restored,3,2025,0.21,#000000,https://cards.scryfall.io/normal/front/0/8/080fc2be-d463-4e8e-ba42-8f3cb0c95ed3.jpg?1783906359,Legendary Artifact — Vehicle,Kotakan
+The Fire Nation Drill,4,2025,0.27,#000000,https://cards.scryfall.io/normal/front/5/4/54d762f6-e131-480f-b294-10f5a63d9c98.jpg?1783904973,Legendary Artifact — Vehicle,Brandon L. Hunt
+The Frightful Four,4,2026,0.87,#000000,https://cards.scryfall.io/normal/front/3/e/3e792132-de96-47aa-bcd5-58f1e9be5932.jpg?1783903286,Legendary Creature — Villain,Björn Barends
+The Ghoul- Gunslinger,3,2026,10.41,#000000,https://cards.scryfall.io/normal/front/e/7/e7ed7d2c-c49b-4786-86eb-125863e874a2.jpg?1783904271,Legendary Creature — Zombie Mutant Rogue,Josh Newton
+The Grim Captain's Locker,4,2023,0.25,#000000,https://cards.scryfall.io/normal/front/3/f/3f10a61b-d48b-4519-8c7d-d8bbf70091b2.jpg?1783913910,Legendary Artifact,Bruce Brenneise
+The Haunt of Hightower,6,2024,2.89,#000000,https://cards.scryfall.io/normal/front/4/9/49b1bdff-a039-4dae-acda-7371ef6aec9d.jpg?1783910012,Legendary Creature — Vampire,Lius Lasahido
+Their Name Is Death,6,2022,10.1,#000000,https://cards.scryfall.io/normal/front/e/a/ea5ddc28-dfc1-4b96-b6e2-590fcb1f83ef.jpg?1783920903,Sorcery,Evan Shipard
+Their Number Is Legion,4,2022,1.12,#000000,https://cards.scryfall.io/normal/front/f/0/f03c1eb4-1f47-4b65-8d8d-4057fb6997e1.jpg?1783920902,Sorcery,Games Workshop
+The Last Ride,1,2025,0.36,#000000,https://cards.scryfall.io/normal/front/9/c/9cbb7b4e-bd32-44a0-9396-16738c5e4381.jpg?1783907893,Legendary Artifact — Vehicle,Michele Giorgi
+The Meathook Massacre,2,2025,27.45,#000000,https://cards.scryfall.io/normal/front/7/0/70d0540f-93c6-4af5-ab2d-65e6c03001c7.jpg?1783908137,Legendary Enchantment,Chris Seaman
+The Meep,3,2023,29.71,#000000,https://cards.scryfall.io/normal/front/3/6/366c4cdb-c6f2-4ee8-b5fb-acb59a9931bf.jpg?1783913392,Legendary Creature — Alien,Billy Christian
+The Raven Man,2,2022,0.48,#000000,https://cards.scryfall.io/normal/front/6/e/6e761fb2-ae4f-4d72-a142-f7e9bd681303.jpg?1783921327,Legendary Creature — Human Wizard,Chris Rahn
+The Rise of Sozin // Fire Lord Sozin,6,2025,1.44,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Legendary Creature — Human Noble,Mitori
+The Sibsig Ceremony,3,2025,0.33,#000000,https://cards.scryfall.io/normal/front/5/a/5a9f2a62-1c61-4d2e-86d9-18cd84c31748.jpg?1783907369,Legendary Enchantment,Eli Minaya
+The Soul Stone,2,2025,121.36,#000000,https://cards.scryfall.io/normal/front/1/9/1982f910-a9bd-4e94-a187-84381b22aacc.jpg?1783905342,Legendary Artifact — Infinity Stone,Volkan Baǵa
+The Speed Demon,5,2025,0.89,#000000,https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg?1783907890,Legendary Creature — Demon,Helge C. Balzer
+The Toymaker's Trap,3,2023,0.3,#000000,https://cards.scryfall.io/normal/front/3/8/381de078-6eac-462c-b6d9-095779279d42.jpg?1783914656,Enchantment,Eric Wilkerson
+The War in Heaven,6,2022,0.58,#000000,https://cards.scryfall.io/normal/front/c/d/cd556cd1-e33a-433d-ac18-4a4fd195c3ab.jpg?1783920897,Enchantment — Saga,Darren Tan
+The Wretched,5,1997,0.75,#000000,https://cards.scryfall.io/normal/front/7/2/729f4543-79f3-4fe2-973f-fb2598045877.jpg?1783946922,Creature — Demon,Christopher Rush
+Thieves' Guild Enforcer,1,2020,0.42,#000000,https://cards.scryfall.io/normal/front/d/f/df99f770-2c39-4025-a8a2-a5890f61eb53.jpg?1783930698,Creature — Human Rogue,Evyn Fong
+Thieving Amalgam,7,2024,0.74,#000000,https://cards.scryfall.io/normal/front/c/6/c6225b97-396f-4969-954c-f2885da70c1b.jpg?1783911925,Creature — Ape Snake,Johan Grenier
+Thieving Varmint,2,2024,3.35,#000000,https://cards.scryfall.io/normal/front/8/e/8e66d567-9f06-47c1-aa9f-f29ba5e9906a.jpg?1783911966,Creature — Varmint,Néstor Ossandón Leal
+This Is How It Ends,4,2023,0.34,#000000,https://cards.scryfall.io/normal/front/2/5/250f6265-c0c8-4f51-bea8-408caf0a58d8.jpg?1783914657,Instant,Eliz Roxs
+Thought Gorger,4,2010,0.34,#000000,https://cards.scryfall.io/normal/front/f/9/f9b6b512-6252-4899-bb9c-5c304f37d10a.jpg?1783941980,Creature — Horror,Jason Felix
+Thoughtseize,1,2020,8.98,#000000,https://cards.scryfall.io/normal/front/b/2/b281a308-ab6b-47b6-bec7-632c9aaecede.jpg?1783930173,Sorcery,Aleksi Briclot
+Thrashing Wumpus,5,1999,0.89,#000000,https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg?1783945945,Creature — Beast,Jeff Miracola
+Thrilling Encore,5,2018,1.36,#000000,https://cards.scryfall.io/normal/front/2/0/20b4d2f6-c49c-45d7-b172-2628d336e843.jpg?1783934860,Instant,Alex Konstad
+Throat Slitter,5,2026,4.84,#000000,https://cards.scryfall.io/normal/front/6/2/62a351c1-4541-4b67-a441-8c0db213652e.jpg?1783904220,Creature — Rat Ninja,Kevin Eastman
+Throne of the Grim Captain // The Grim Captain,2,2023,0.23,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact // Legendary Creature — Skeleton Spirit Pirate,Tiffany Turrill
+Thunderbolts Conspiracy,4,2026,0.2,#000000,https://cards.scryfall.io/normal/front/f/4/f498c1a4-54d2-4e87-952f-8cf7e408930c.jpg?1783902936,Enchantment,Lucio Parrillo
+Time Reaper,5,2023,0.25,#000000,https://cards.scryfall.io/normal/front/d/a/da05bca9-a756-4492-b085-221daa384a93.jpg?1783914656,Creature — Alien Horror,Helge C. Balzer
+Timmerian Fiends,3,1995,0.67,#000000,https://cards.scryfall.io/normal/front/9/0/90643766-c92f-4a25-bd02-227f3c91f391.jpg?1783947288,Creature — Horror,Mike Kimble
+Timothar- Baron of Bats,6,2023,0.29,#000000,https://cards.scryfall.io/normal/front/7/b/7b01ecb8-02e2-4da2-8bf3-9c3753b23ba4.jpg?1783913869,Legendary Creature — Vampire Noble,Jason A. Engle
+Tinybones- Bauble Burglar,2,2024,0.94,#000000,https://cards.scryfall.io/normal/front/f/f/ff3d85bc-ef2d-4251-baf4-a14bd0cee61e.jpg?1783909107,Legendary Creature — Skeleton Rogue,Leonardo Santanna
+Tinybones Joins Up,1,2024,0.49,#000000,https://cards.scryfall.io/normal/front/5/7/5724a15f-0ba0-421a-9cd4-a2b701e6141f.jpg?1783911826,Legendary Enchantment,Wylie Beckert
+Tinybones- the Pickpocket,1,2024,6.23,#000000,https://cards.scryfall.io/normal/front/3/d/3d3025a2-4a17-4137-ba0b-bd676c6f5f88.jpg?1783911826,Legendary Creature — Skeleton Rogue,Ekaterina Burmak
+Tinybones- Trinket Thief,2,2020,17.28,#000000,https://cards.scryfall.io/normal/front/4/0/4063be5b-bfd9-43c5-bc39-09a40bc793bf.jpg?1783930505,Legendary Creature — Skeleton Rogue,Jason Rainville
+Tip the Scales,3,2025,0.23,#000000,https://cards.scryfall.io/normal/front/0/0/00b492ca-9cba-4d51-91b9-41430c6933a1.jpg?1783907175,Sorcery,Volkan Baǵa
+Titan Hunter,5,2020,0.25,#000000,https://cards.scryfall.io/normal/front/e/b/eb564473-7416-4cf7-971a-e6dc5eb10445.jpg?1783931216,Creature — Human Warrior,Matt Stewart
+Tivash- Gloom Summoner,5,2021,0.51,#000000,https://cards.scryfall.io/normal/front/e/3/e3b2a152-7bb9-495d-ac84-516097754137.jpg?1783927596,Legendary Creature — Human Warlock,Kieran Yanner
+Tomb Blade,6,2022,0.37,#000000,https://cards.scryfall.io/normal/front/2/f/2f5f2e19-41ce-40c6-9732-d0f88ad6735f.jpg?1783920902,Artifact Creature — Necron,Darren Tan
+Tombfire,1,2001,0.36,#000000,https://cards.scryfall.io/normal/front/b/b/bb08a4a7-941b-4b54-a89b-a4145a6fc14e.jpg?1783945238,Sorcery,Arnie Swekel
+Tomb Robber,3,2018,0.19,#000000,https://cards.scryfall.io/normal/front/6/8/68132a28-b33b-48cb-acf8-42245312934e.jpg?1783935306,Creature — Human Pirate,Xi Zhang
+Tombstalker,8,2021,0.28,#000000,https://cards.scryfall.io/normal/front/7/8/78f02d59-0786-41c8-940b-4ef6ef01c646.jpg?1783927805,Creature — Demon,Aleksi Briclot
+Tombstone Stairwell,4,1996,64.15,#000000,https://cards.scryfall.io/normal/front/f/8/f8fe2f99-7ec2-490c-8ec3-aa2fb4680826.jpg?1783947085,World Enchantment,Dom!
+Tomb Tyrant,4,2021,2.42,#000000,https://cards.scryfall.io/normal/front/7/3/73315f75-252e-4db2-b48c-a60eafaf25e3.jpg?1783925375,Creature — Zombie Noble,Chris Cold
+Torgaar- Famine Incarnate,8,2019,0.4,#000000,https://cards.scryfall.io/normal/front/e/e/ee13d6f1-66bb-433d-9250-f18aa30fa4fc.jpg?1783931656,Legendary Creature — Avatar,Lius Lasahido
+Torment of Hailfire,2,2017,37.58,#000000,https://cards.scryfall.io/normal/front/f/6/f69d77d1-5980-436c-bf48-790939b069aa.jpg?1783936036,Sorcery,Grzegorz Rutkowski
+Tortured Existence,1,2026,12.69,#000000,https://cards.scryfall.io/normal/front/6/e/6ee6d264-e83f-4596-be73-c0a0568d1d7d.jpg?1783904241,Enchantment,Josh Freydkis
+Toshiro Umezawa,3,2005,5.04,#000000,https://cards.scryfall.io/normal/front/0/e/0e767e07-febd-4025-bf03-d4d816bc1d3d.jpg?1783944194,Legendary Creature — Human Samurai,Christopher Moeller
+To the Slaughter,3,2016,0.23,#000000,https://cards.scryfall.io/normal/front/5/a/5a645c8d-7cfb-466b-9fd0-e1c26bf6f652.jpg?1783937761,Instant,Christine Choi
+Tourach- Dread Cantor,2,2021,1.12,#000000,https://cards.scryfall.io/normal/front/f/3/f3526751-0101-4d91-a496-c53cd92326e0.jpg?1783926855,Legendary Creature — Human Cleric,Greg Staples
+Tourach's Gate,3,1994,0.71,#000000,https://cards.scryfall.io/normal/front/d/7/d77f6401-a9fb-449c-b511-6fb837055bb4.jpg?1783947898,Enchantment — Aura,Sandra Everingham
+Toxic Deluge,3,2026,3.52,#000000,https://cards.scryfall.io/normal/front/d/e/de5afccc-8d42-4bd6-b068-b9ea2361655e.jpg?1783903236,Sorcery,Anthony Devine
+Toxin Sliver,4,2003,3.58,#000000,https://cards.scryfall.io/normal/front/c/0/c04ab6b6-27ee-4c93-a87c-cbc3743f4faf.jpg?1783944910,Creature — Sliver,Lars Grant-West
+Toxrill- the Corrosive,7,2021,17.46,#d78f42,https://cards.scryfall.io/normal/front/8/4/84e64f38-b1f3-47cd-8cfb-a4861369aca3.jpg?1783924850,Legendary Creature — Slug Horror,Simon Dominic
+Tragedy Feaster,4,2026,0.28,#000000,https://cards.scryfall.io/normal/front/b/9/b93cbaad-8ed8-4a1d-b95a-20a616dfedc9.jpg?1783903673,Creature — Demon,Raph Lomotan
+Transpose,3,2025,0.41,#000000,https://cards.scryfall.io/normal/front/6/6/66392b0e-8691-42a4-bc84-03b017174a73.jpg?1783906356,Instant,Toni Infante
+Traveling Plague,5,2001,0.39,#000000,https://cards.scryfall.io/normal/front/d/4/d4b6413d-68d3-4097-9bb3-873df4900e4c.jpg?1783945239,Enchantment — Aura,Dave Dorman
+Trazyn the Infinite,6,2022,1.3,#000000,https://cards.scryfall.io/normal/front/1/a/1ae95cfb-1c3e-43cc-acfa-68f25b0f6e52.jpg?1783920903,Legendary Artifact Creature — Necron,Michał Miłkowski
+Treacherous Blessing,3,2020,0.36,#000000,https://cards.scryfall.io/normal/front/3/5/35b3ad6b-9966-489f-a4c9-2639a634fd62.jpg?1783931560,Enchantment,Marco Teixeira
+Treacherous Pit-Dweller,2,2012,0.36,#000000,https://cards.scryfall.io/normal/front/e/e/eec7dfd7-d7b2-44fa-b351-022a19fe81b8.jpg?1783940690,Creature — Demon,Svetlin Velinov
+Tree of Perdition,4,2026,2.56,#000000,https://cards.scryfall.io/normal/front/7/5/750b4c88-26c7-43ec-b6b9-ece3263dfd59.jpg?1783911525,Creature — Plant,Iris Compiet
+Triarch Stalker,5,2022,0.45,#000000,https://cards.scryfall.io/normal/front/f/b/fbe75aae-727b-4cb0-967c-477d5a08b8f7.jpg?1783920898,Artifact Creature — Necron,JB Casacop
+Tribute to Horobi // Echo of Death's Wail,2,2022,0.29,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Spirit,Robin Olausson
+Triskaidekaphobia,4,2018,0.19,#000000,https://cards.scryfall.io/normal/front/8/1/813995f5-e49a-431d-8a3a-8ec569844e11.jpg?1783935157,Enchantment,Willian Murai
+Trystan- Callous Cultivator // Trystan- Penitent Culler,3,2026,0.24,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elf Druid // Legendary Creature — Elf Warlock,Annie Stegg
+Tsabo's Assassin,4,2000,0.8,#000000,https://cards.scryfall.io/normal/front/0/0/0047302d-4e3d-4327-9bb2-ecd5b00b00e3.jpg?1783945689,Creature — Phyrexian Zombie Assassin,Glen Angus
+Tsabo's Decree,6,2000,1.34,#000000,https://cards.scryfall.io/normal/front/0/c/0c1a0ebd-1add-49e6-b5e6-5b26abb1de88.jpg?1783945689,Instant,Thomas M. Baxa
+Twilight Diviner,3,2026,2.31,#000000,https://cards.scryfall.io/normal/front/4/4/443b6f30-1493-4d48-93d9-a91e22a7ebb3.jpg?1783904455,Creature — Elf Cleric,Pauline Voss
+Twilight Prophet,4,2024,2.77,#000000,https://cards.scryfall.io/normal/front/0/5/050ca791-265a-4e7b-9640-4fd5a6d8cd3a.jpg?1783913002,Creature — Vampire Cleric,David Astruga
+Twilight's Call,6,2012,0.71,#000000,https://cards.scryfall.io/normal/front/a/6/a6e04dd2-75ad-4427-93cc-37226340c2fb.jpg?1783940393,Sorcery,Mark Romanoski
+Tymaret Calls the Dead,3,2020,0.15,#000000,https://cards.scryfall.io/normal/front/6/8/68c0d087-540a-4249-9265-f13cc8e776ea.jpg?1783931559,Enchantment — Saga,Vincent Proce
+Tyrannical Pitlord,6,2022,0.19,#000000,https://cards.scryfall.io/normal/front/0/2/027ef1fc-4a7a-465c-9c25-dc19c771b5f5.jpg?1783921246,Creature — Demon,Donato Giancola
+Uchuulon,4,2022,1.84,#000000,https://cards.scryfall.io/normal/front/e/c/ecef5fca-72ec-4aee-af6e-ee5d6f6bc567.jpg?1783922501,Creature — Crab Ooze Horror,Sam Burley
+Ultron the Annihilator,5,2026,51.93,#000000,https://cards.scryfall.io/normal/front/5/1/51879585-9cdf-499b-b7cc-226319c74a0c.jpg?1783903057,Legendary Artifact Creature — Robot Villain,Eugene Maslovski
+Umbra Stalker,7,2008,0.43,#000000,https://cards.scryfall.io/normal/front/1/e/1efdd70a-5a84-48a5-82bf-ba29fda097c0.jpg?1783942685,Creature — Elemental,Daarken
+Unbreathing Horde,3,2016,0.37,#000000,https://cards.scryfall.io/normal/front/d/d/dd119aa8-8414-4942-9a28-3e68a9a52a8e.jpg?1783937836,Creature — Zombie,Dave Kendall
+Undead Gladiator,3,2002,0.93,#000000,https://cards.scryfall.io/normal/front/b/b/bbc779d9-3200-4369-9289-1a8e90e243b9.jpg?1783945062,Creature — Zombie Barbarian,Jeff Easley
+Undercity Plague,6,2013,0.16,#000000,https://cards.scryfall.io/normal/front/7/b/7b25d3bc-33e9-4d1a-855d-38580e67b6cc.jpg?1783940127,Sorcery,Vincent Proce
+Underworld Connections,3,2021,0.67,#000000,https://cards.scryfall.io/normal/front/1/d/1df71add-7bb6-4687-bb69-cf4450adb7dc.jpg?1783924951,Enchantment — Aura,Yeong-Hao Han
+Underworld Dreams,3,2009,5.09,#000000,https://cards.scryfall.io/normal/front/5/f/5f252826-d2bd-4e25-a500-423a727a7e9e.jpg?1783942378,Enchantment,Carl Critchlow
+Underworld Sentinel,5,2020,0.31,#000000,https://cards.scryfall.io/normal/front/d/8/d8c7aa89-3777-49ec-a6d0-c568150864e8.jpg?1783931489,Creature — Skeleton Soldier,Vincent Proce
+Unearth,1,2026,0.56,#000000,https://cards.scryfall.io/normal/front/c/4/c431aeda-3f4d-43c2-9471-da3ff642cc7e.jpg?1783903476,Sorcery,Ron Spencer
+Unholy Annex // Ritual Chamber,8,2024,2.25,#000000,https://cards.scryfall.io/normal/front/0/f/0fb4c734-c698-46f2-bc78-5f036f472e5b.jpg?1783909475,Enchantment — Room // Enchantment — Room,Matteo Bassini
+Unliving Psychopath,4,2006,0.39,#000000,https://cards.scryfall.io/normal/front/6/9/694bbf39-fd66-4ff4-9cc3-ec75b1fb3a51.jpg?1783943424,Creature — Zombie Assassin,Greg Staples
+Unmarked Grave,2,2021,2.95,#000000,https://cards.scryfall.io/normal/front/4/9/492b368b-de32-45c1-8459-238aae54f9fc.jpg?1783926852,Sorcery,James Paick
+Unmask,4,1999,20.72,#000000,https://cards.scryfall.io/normal/front/2/d/2db7a0e6-eea5-4fa6-ac14-401411b106cc.jpg?1783945945,Sorcery,rk post
+Unnatural Hunger,5,1999,1.4,#000000,https://cards.scryfall.io/normal/front/3/9/3985f240-4289-4d48-978c-bb2ce2b54c36.jpg?1783945943,Enchantment — Aura,Jeff Miracola
+Unshakable Tail,3,2024,0.36,#000000,https://cards.scryfall.io/normal/front/0/5/053183e7-b505-49d2-b614-b704e984cb1a.jpg?1783913044,Creature — Zombie Detective,Sean Murray
+Unstoppable Slasher,3,2024,5.33,#000000,https://cards.scryfall.io/normal/front/c/7/c78da035-6b5b-4136-9ab6-f622b64fdc54.jpg?1783909475,Creature — Zombie Assassin,Maxime Minard
+Urborg Justice,2,1997,3.21,#000000,https://cards.scryfall.io/normal/front/3/9/39f322ff-0b04-41ce-90cd-9896f941e703.jpg?1783946731,Instant,Gary Leach
+Urborg Scavengers,3,2023,0.3,#000000,https://cards.scryfall.io/normal/front/4/d/4dbb4d8f-8ae3-4052-9c6a-e56e96cec832.jpg?1783916524,Creature — Spirit,Svetlin Velinov
+Urborg Stalker,4,1997,0.78,#000000,https://cards.scryfall.io/normal/front/2/d/2d33e3d5-c608-4ba8-8614-0b9d0385af64.jpg?1783946730,Creature — Horror,Cliff Nielsen
+Vadmir- New Blood,2,2024,0.31,#000000,https://cards.scryfall.io/normal/front/8/2/828b5855-af5a-46a6-8fd4-0a2e28f3bb01.jpg?1783911825,Legendary Creature — Vampire Rogue,Andreas Zafiratos
+Valentin- Dean of the Vein // Lisette- Dean of the Root,1,2021,1.06,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Vampire Warlock // Legendary Creature — Human Druid,Jesper Ejsing
+Valgavoth- Terror Eater,9,2024,14.5,#000000,https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg?1783909475,Legendary Creature — Elder Demon,Antonio José Manzanedo
+Valki- God of Lies // Tibalt- Cosmic Impostor,2,2021,3.95,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Planeswalker — Tibalt,Yongjae Choi
+Valley Rotcaller,2,2024,2.23,#000000,https://cards.scryfall.io/normal/front/4/d/4da80a9a-b1d5-4fc5-92f7-36946195d0c7.jpg?1783910826,Creature — Squirrel Warlock,Valera Lutfullina
+Vampire Nocturnus,4,2012,6.15,#000000,https://cards.scryfall.io/normal/front/8/d/8daccbbb-6600-4467-810f-277f01a11771.jpg?1783940488,Creature — Vampire,Raymond Swanland
+Vampiric Spirit,4,2003,0.33,#000000,https://cards.scryfall.io/normal/front/6/e/6e5235e5-deb7-49eb-82a8-858d3ee7c91b.jpg?1783944737,Creature — Spirit,Anson Maddocks
+Vampiric Tutor,1,2023,59.13,#000000,https://cards.scryfall.io/normal/front/3/4/34a0203f-9cce-43a4-9cb7-8ce6647895cd.jpg?1783918468,Instant,Raymond Swanland
+Varragoth- Bloodsky Sire,3,2021,4.59,#000000,https://cards.scryfall.io/normal/front/e/f/efa8dbf0-4e5a-452b-826f-5813e8cd9d85.jpg?1783928237,Legendary Creature — Demon Rogue,Tyler Jacobson
+Vashta Nerada,3,2023,2.99,#000000,https://cards.scryfall.io/normal/front/8/b/8bb2765f-4016-4e41-9db4-5ad463faceab.jpg?1783914656,Creature — Alien Horror,Fang Xinyu
+V.A.T.S.,4,2024,1.65,#000000,https://cards.scryfall.io/normal/front/5/1/512df222-0db0-4b24-9372-d0c01b181b91.jpg?1783912406,Instant,Diego Gisbert
+Vault 12: The Necropolis,6,2024,0.47,#000000,https://cards.scryfall.io/normal/front/1/4/144cd9eb-9b15-40ce-8a48-919e72dbaa67.jpg?1783912407,Enchantment — Saga,Nicholas Gregory
+Vebulid,1,1998,0.65,#000000,https://cards.scryfall.io/normal/front/d/5/d5623194-0cd9-4f3f-bab1-133d6b1e94fe.jpg?1783946336,Creature — Phyrexian Horror,Ron Spencer
+Vein Drinker,6,2017,0.28,#d78f42,https://cards.scryfall.io/normal/front/2/5/25ad3372-51cb-4b82-a23c-81938b7c01b6.jpg?1783935899,Creature — Vampire,Lars Grant-West
+Vein Ripper,6,2024,6.63,#000000,https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg?1783912890,Creature — Vampire Assassin,Bastien L. Deharme
+Veinwitch Coven,3,2026,0.25,#000000,https://cards.scryfall.io/normal/front/c/5/c5cc7d88-b9d3-425e-bef2-f1e3a85a3e4d.jpg?1783903780,Creature — Vampire Warlock,Caio Monteiro
+Veldrane of Sengir,7,1995,0.58,#000000,https://cards.scryfall.io/normal/front/f/e/fe0ce7d7-d370-4ef8-b1fa-aa70b2fd5ab1.jpg?1783947287,Legendary Creature — Human Rogue,Susan Van Camp
+Vengeful Pharaoh,5,2011,1.1,#000000,https://cards.scryfall.io/normal/front/1/2/12e0ca97-bc57-4084-86b4-e2e06152cb1c.jpg?1783941076,Creature — Zombie,Igor Kieryluk
+Venomcrawler,4,2022,0.63,#000000,https://cards.scryfall.io/normal/front/7/b/7b44099c-0b24-423a-b8c0-5d5e8687fe61.jpg?1783920897,Artifact Creature — Demon,Ivan Dedov
+Venom- Eddie Brock,6,2025,12.86,#000000,https://cards.scryfall.io/normal/front/e/a/eab647ce-fe86-450d-b5e8-ebcda631f6a1.jpg?1783905371,Legendary Creature — Symbiote Villain,Simon Dominic
+Vermiculos,5,2003,0.32,#000000,https://cards.scryfall.io/normal/front/9/b/9b68e084-0760-4817-a656-32dc4b094370.jpg?1783944545,Creature — Horror,Daren Bader
+Victimize,3,2026,8.33,#000000,https://cards.scryfall.io/normal/front/f/d/fdc741fe-b2ac-4bc8-96b5-aeb1b63cc2f0.jpg?1783904248,Sorcery,Mila Pesic
+Vilis- Broker of Blood,8,2019,9.19,#000000,https://cards.scryfall.io/normal/front/e/c/ecdf2bd9-87b9-470a-ad2e-0ebf98560f87.jpg?1783932985,Legendary Creature — Demon,Tyler Jacobson
+Villainous Wrath,5,2025,0.95,#000000,https://cards.scryfall.io/normal/front/d/7/d78e36fd-5817-4c4a-8880-dabe6dd4ba81.jpg?1783905338,Sorcery,InHyuk Lee
+Vincent Valentine // Galian Beast,4,2025,1.35,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Assassin // Legendary Creature — Werewolf Beast,Norikatsu Miyoshi
+Vindictive Lich,4,2023,0.48,#000000,https://cards.scryfall.io/normal/front/0/1/0120b644-477d-4297-b94f-56120a384bc2.jpg?1783915663,Creature — Zombie Wizard,Toma Feizo Gas
+Viper- Cruel Conspirator,2,2026,0.4,#000000,https://cards.scryfall.io/normal/front/3/a/3a57b64f-2b57-44f3-8d4d-2ff5c5615601.jpg?1783903056,Legendary Creature — Human Assassin Villain,Eglė Mosakaitė
+Virtue of Persistence // Locthwain Scorn,7,2023,7.49,#000000,https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1783915099,Enchantment // Sorcery — Adventure,Piotr Dura
+Virtus's Maneuver,3,2018,0.87,#000000,https://cards.scryfall.io/normal/front/7/3/73f2e058-c1a8-4a66-b1da-1b3885c6736f.jpg?1783934859,Sorcery,Tomasz Jedruszek
+Virtus the Veiled,3,2018,8.97,#000000,https://cards.scryfall.io/normal/front/4/a/4a45a631-f899-4414-8e0a-64d987e9ba8b.jpg?1783934879,Legendary Creature — Azra Assassin,Johann Bodin
+Visara the Dreadful,6,2016,2.97,#000000,https://cards.scryfall.io/normal/front/0/3/03f66946-ff52-4ce4-af25-b81196fa451b.jpg?1783937589,Legendary Creature — Gorgon,Kev Walker
+Visions of Dread,3,2021,0.31,#000000,https://cards.scryfall.io/normal/front/2/7/2716d5b6-9ca7-4c8f-a363-1934221606a6.jpg?1783925371,Sorcery,Andrew Mar
+Vislor Turlough,4,2023,0.32,#000000,https://cards.scryfall.io/normal/front/f/2/f25ec946-036b-480a-bab6-c4102e5c31db.jpg?1783914658,Legendary Creature — Rogue,Wangjie Li
+Vito- Thorn of the Dusk Rose,3,2020,11.39,#000000,https://cards.scryfall.io/normal/front/0/f/0fe79ee4-c3f3-4a6b-a967-203ca3b70ee5.jpg?1783930698,Legendary Creature — Vampire Cleric,Lie Setiawan
+Void Maw,6,2006,0.44,#000000,https://cards.scryfall.io/normal/front/b/a/ba464b81-2633-4422-a4b5-3593dfb7e7aa.jpg?1783943344,Creature — Horror,E. M. Gist
+Voldaren Bloodcaster // Bloodbat Summoner,2,2025,0.35,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Vampire Wizard // Creature — Vampire Wizard,Kim Sokol
+Voldaren Pariah // Abolisher of Bloodlines,5,2016,0.45,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Vampire Horror // Creature — Eldrazi Vampire,James Ryman
+Volrath's Dungeon,4,1998,0.42,#000000,https://cards.scryfall.io/normal/front/a/4/a4ab28e1-74e1-4c4e-920f-a658c6a44d75.jpg?1783946514,Enchantment,Stephen Daniele
+Volrath the Fallen,6,2000,2.1,#000000,https://cards.scryfall.io/normal/front/0/8/08bdd66e-9ca1-456e-a61c-7c96cf6f7c56.jpg?1783945823,Legendary Creature — Phyrexian Shapeshifter,Kev Walker
+Vona's Hunger,3,2018,5.65,#000000,https://cards.scryfall.io/normal/front/a/a/aab958d5-9c1f-420f-b358-ec0325f22f84.jpg?1783935304,Instant,Zack Stella
+Vorpal Sword,1,2021,3.01,#000000,https://cards.scryfall.io/normal/front/7/a/7adbe69f-326d-4b4f-850f-c57a1860d17c.jpg?1783926486,Artifact — Equipment,Caio Monteiro
+Vraan- Executioner Thane,2,2023,0.79,#000000,https://cards.scryfall.io/normal/front/4/c/4c4a3119-c70a-46ff-8ede-6356f2b7bc13.jpg?1783918037,Legendary Creature — Phyrexian Vampire,Helge C. Balzer
+Vraska- Betrayal's Sting,6,2026,0.83,#000000,https://cards.scryfall.io/normal/front/9/f/9f1fa1c5-ff87-4bbc-89aa-dbebc91eada0.jpg?1783904555,Legendary Planeswalker — Vraska,Chase Stone
+Vraska's Contempt,4,2017,0.38,#000000,https://cards.scryfall.io/normal/front/b/d/bd7550dd-dfc5-43cd-a117-1244ee3086a8.jpg?1783935752,Instant,Clint Cearley
+Vraska's Scorn,4,2018,0.19,#000000,https://cards.scryfall.io/normal/front/5/6/569ff807-365d-4f25-9fad-86617ed1c8f2.jpg?1783935258,Sorcery,James Ryman
+Wake the Dead,2,2023,0.79,#000000,https://cards.scryfall.io/normal/front/e/1/e1780be8-26f6-4f33-9bc6-ecafc3751c8e.jpg?1783915661,Instant,Christopher Moeller
+Wand of Orcus,3,2021,14.36,#000000,https://cards.scryfall.io/normal/front/5/1/510af4b7-289a-4de7-9a22-00fe1e8aaabf.jpg?1783926249,Legendary Artifact — Equipment,Andrew Mar
+Warg Rider,5,2023,17.81,#000000,https://cards.scryfall.io/normal/front/1/8/18cc2bc6-12bb-4795-b2b2-9d414823b773.jpg?1783913961,Creature — Orc Warrior,Pascal Quidault
+Warp Artifact,2,1997,0.46,#000000,https://cards.scryfall.io/normal/front/9/4/94355dce-dfd6-45d6-9b86-0c2bc10e0231.jpg?1783946919,Enchantment — Aura,Amy Weber
+Warped Devotion,3,2003,0.23,#000000,https://cards.scryfall.io/normal/front/f/f/ffd41ebd-91a8-4972-8f93-3306e68519f9.jpg?1783944734,Enchantment,Eric Peterson
+Warren Soultrader,3,2024,14.73,#000000,https://cards.scryfall.io/normal/front/b/3/b334e4c6-d316-4141-8889-f95afcc04701.jpg?1784634565,Creature — Zombie Goblin Wizard,Pete Venters
+Wasteland Raider,4,2024,0.39,#000000,https://cards.scryfall.io/normal/front/9/e/9eae2596-013a-4e9b-982b-e0fc8d1e78bf.jpg?1783912406,Creature — Human Mercenary,Yigit Koroglu
+Waste Management,3,2022,0.25,#000000,https://cards.scryfall.io/normal/front/0/f/0f979e7a-4e7b-4b7b-b4eb-cefa3c02d64f.jpg?1783923365,Instant,Aaron Miller
+Waste Not,2,2016,8.61,#000000,https://cards.scryfall.io/normal/front/2/f/2f5500a2-c6d6-40d7-b586-59b854733160.jpg?1783937067,Enchantment,Matt Stewart
+Wave of Rats,4,2022,3.08,#000000,https://cards.scryfall.io/normal/front/1/5/154dc126-67ca-4759-a424-37f0eb52e1fa.jpg?1783923365,Creature — Rat,Brian Valeza
+Wave of Terror,3,1997,0.87,#000000,https://cards.scryfall.io/normal/front/d/4/d40ab3e7-9abb-4acc-9932-de03b533722f.jpg?1783946730,Enchantment,Adrian Smith
+Weirding Shaman,2,2008,0.58,#000000,https://cards.scryfall.io/normal/front/f/e/fe1d40cc-2871-4a33-bc58-5250fd3d4f0e.jpg?1783942788,Creature — Goblin Shaman,Matt Cavotta
+Welcome the Dead,4,2025,0.27,#000000,https://cards.scryfall.io/normal/front/f/4/f472ea5c-191e-4b19-8ea7-f8649af91530.jpg?1783907174,Sorcery,Ioannis Fiore
+Western Paladin,4,2003,0.4,#000000,https://cards.scryfall.io/normal/front/4/f/4f829763-3dce-453f-a783-177ea085ee01.jpg?1783944735,Creature — Phyrexian Zombie Knight,Carl Critchlow
+Westgate Regent,5,2021,0.31,#000000,https://cards.scryfall.io/normal/front/e/7/e757cc7d-b9cc-4ef1-80c9-a22755a6d271.jpg?1783926487,Creature — Vampire,Mike Jordana
+Westvale Abbey // Ormendahl- Profane Prince,0,2025,3.82,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Land // Legendary Creature — Demon,Min Yum
+Whip of Erebos,4,2024,8.37,#000000,https://cards.scryfall.io/normal/front/b/7/b738612f-4e78-4b19-9392-6c074956d6e4.jpg?1783909613,Legendary Enchantment Artifact,Yeong-Hao Han
+Whispersteel Dagger,3,2020,0.31,#000000,https://cards.scryfall.io/normal/front/2/b/2bcf89c2-32cc-4c26-8fe4-8cf54f5a2675.jpg?1783929493,Artifact — Equipment,Svetlin Velinov
+Wicked Pact,3,1999,2.14,#000000,https://cards.scryfall.io/normal/front/f/b/fb5c4e80-7c82-4df8-98bf-58f30ef4ccfd.jpg?1783946031,Sorcery,Adam Rex
+Wick- the Whorled Mind,4,2024,0.27,#d78f42,https://cards.scryfall.io/normal/front/2/9/29089810-d7fb-4abe-b729-bfabed6aed2b.jpg?1783910825,Legendary Creature — Rat Warlock,Andrea Piparo
+Wight,2,2021,0.24,#000000,https://cards.scryfall.io/normal/front/f/6/f62abe9c-7599-433b-a964-10d6641f3586.jpg?1783926485,Creature — Zombie Soldier,Slawomir Maniak
+Will of the Abzan,4,2025,5.01,#000000,https://cards.scryfall.io/normal/front/e/7/e7e92b6b-ec63-477b-8a83-18c0e52615cc.jpg?1783907175,Sorcery,Yigit Koroglu
+Will-o'-the-Wisp,1,2005,0.44,#000000,https://cards.scryfall.io/normal/front/5/9/59fb78e2-cb62-43dc-8f5b-bf81d2f02eea.jpg?1783943979,Creature — Spirit,Rob Alexander
+Wire Surgeons,6,2022,0.18,#000000,https://cards.scryfall.io/normal/front/6/5/6590bb3c-7613-457f-a028-d7cda3cd6eb4.jpg?1783919720,Creature — Human Artificer,Josu Hernaiz
+Wishclaw Talisman,2,2024,1.65,#000000,https://cards.scryfall.io/normal/front/6/9/69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5.jpg?1783908926,Artifact,Daarken
+Witch Engine,6,1998,0.53,#000000,https://cards.scryfall.io/normal/front/e/f/ef749290-58e2-4b40-a141-5fe294f9b995.jpg?1783946335,Creature — Horror,Kev Walker
+Witch-king of Angmar,5,2023,8.21,#000000,https://cards.scryfall.io/normal/front/a/5/a55e6508-0b59-4573-bc4e-67b27279cfed.jpg?1783916294,Legendary Creature — Wraith Noble,Anato Finnstark
+Witch of the Moors,5,2026,0.37,#000000,https://cards.scryfall.io/normal/front/d/9/d9367aa0-2da2-4ed5-b52a-c52e40a00adf.jpg?1783903779,Creature — Human Warlock,Caio Monteiro
+Witch's Vengeance,3,2019,0.29,#000000,https://cards.scryfall.io/normal/front/d/b/dbf16457-3444-4130-b220-834b69d9faa3.jpg?1783932629,Sorcery,Titus Lunter
+Withering Curse,3,2026,1.53,#000000,https://cards.scryfall.io/normal/front/5/0/50aaf618-dddb-4cbe-8231-d634b4498563.jpg?1783903672,Sorcery,Tuan Duong Chu
+Within Range,4,2025,0.35,#000000,https://cards.scryfall.io/normal/front/5/1/51188edb-9705-4960-854b-170744f40a88.jpg?1783907174,Enchantment,Hector Ortiz
+Wit's End,7,2012,0.27,#000000,https://cards.scryfall.io/normal/front/7/1/71298c75-533e-4ccd-a1f5-875f63a1e89b.jpg?1783940488,Sorcery,Chris Rahn
+Woebringer Demon,5,2005,0.36,#000000,https://cards.scryfall.io/normal/front/f/0/f0c758c9-3138-49b2-bebf-cdab5dc68a3d.jpg?1783943660,Creature — Demon,Daren Bader
+Woe Strider,3,2026,0.29,#000000,https://cards.scryfall.io/normal/front/f/4/f458ae68-5cda-4c40-a348-47b4196fba02.jpg?1783903780,Creature — Horror,John Thacker
+Words of Waste,3,2002,5.52,#000000,https://cards.scryfall.io/normal/front/d/2/d2dcb8ed-23e7-4cee-9f43-042232c6035a.jpg?1783945061,Enchantment,Jerry Tiritilli
+Worms of the Earth,5,1994,7.37,#000000,https://cards.scryfall.io/normal/front/6/5/65a97821-ca5b-46fb-af08-86de81d0daac.jpg?1783947937,Enchantment,Anson Maddocks
+Worst Fears,8,2014,2.88,#000000,https://cards.scryfall.io/normal/front/8/f/8f4e21ac-4f3e-4a3e-83c0-0a59a1b84020.jpg?1783939427,Sorcery,Eric Deschamps
+Wound Reflection,6,2020,13.79,#000000,https://cards.scryfall.io/normal/front/2/b/2b14a82c-877a-445f-8910-33aaa6fe3d15.jpg?1783930170,Enchantment,Chris Seaman
+Wreck Hunter,2,2022,0.21,#000000,https://cards.scryfall.io/normal/front/b/9/b9a21809-84cb-45f4-8314-80055983450d.jpg?1783919719,Creature — Human Artificer,Josu Hernaiz
+Wretched Confluence,5,2023,0.31,#000000,https://cards.scryfall.io/normal/front/2/0/20203edb-1363-4ed3-8c5b-b1d96ff2b7c0.jpg?1783915661,Instant,Kieran Yanner
+Writ of Return,5,2022,0.35,#000000,https://cards.scryfall.io/normal/front/d/8/d826b38e-a026-472b-afe7-d3a6bd806cf6.jpg?1783923364,Sorcery,Kai Carpenter
+Xander's Pact,6,2022,0.27,#000000,https://cards.scryfall.io/normal/front/2/1/2154df0d-9d35-4a67-aeff-c9f224b969a2.jpg?1783923364,Sorcery,Helge C. Balzer
+Xathrid Demon,6,2014,0.46,#000000,https://cards.scryfall.io/normal/front/0/e/0e33fd08-7c23-4ea6-be98-f907defcbd30.jpg?1783938837,Creature — Demon,Wayne Reynolds
+Xathrid Gorgon,6,2012,0.34,#000000,https://cards.scryfall.io/normal/front/e/0/e07524e0-303d-465d-b112-ca605b9b27fc.jpg?1783940488,Creature — Gorgon,Chase Stone
+Xathrid Necromancer,3,2020,0.33,#000000,https://cards.scryfall.io/normal/front/7/b/7b76e49c-1b02-4ef0-a707-9d85099435bf.jpg?1783931176,Creature — Human Wizard,Maciej Kuciara
+Xenic Poltergeist,3,1997,0.61,#000000,https://cards.scryfall.io/normal/front/f/c/fcedc3f5-f4ab-4f7b-84c0-bd5a6a4b0f5e.jpg?1783946919,Creature — Spirit,Mike Kerr
+Xiahou Dun- the One-Eyed,4,1999,184.5,#000000,https://cards.scryfall.io/normal/front/9/1/91bed8a9-ede6-4fdc-966e-d1e4261c68e4.jpg?1783946111,Legendary Creature — Human Soldier,Junko Taguchi
+Xu-Ifit- Osteoharmonist,3,2025,0.35,#000000,https://cards.scryfall.io/normal/front/c/0/c0838f25-2193-4305-b73a-bf0c0bb4981a.jpg?1783905958,Legendary Creature — Human Wizard,Michal Ivan
+Xun Yu- Wei Advisor,3,1999,51.72,#000000,https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg?1783946111,Legendary Creature — Human Advisor,Jack Wei
+Yahenni's Expertise,4,2017,0.46,#000000,https://cards.scryfall.io/normal/front/f/2/f2f28735-122c-45ba-bde5-decfd9b11b32.jpg?1783936760,Sorcery,Daarken
+Yahenni- Undying Partisan,3,2026,0.32,#000000,https://cards.scryfall.io/normal/front/5/1/518b155a-cb84-48d3-9aba-07577f60f091.jpg?1783903779,Legendary Creature — Aetherborn Vampire,Lius Lasahido
+Yawgmoth Demon,6,2005,0.39,#000000,https://cards.scryfall.io/normal/front/6/9/696a9fe1-ce63-4638-8793-5187fc726731.jpg?1783943978,Creature — Phyrexian Demon,Pete Venters
+Yawgmoth's Agenda,5,2000,0.57,#000000,https://cards.scryfall.io/normal/front/5/0/50f7ea7f-4f17-4f78-b68e-693e265ca829.jpg?1783945688,Enchantment,Arnie Swekel
+Yawgmoth's Vile Offering,5,2023,0.42,#000000,https://cards.scryfall.io/normal/front/3/1/31825ceb-d795-4ad7-81d8-77ab34c272f9.jpg?1783917151,Legendary Sorcery,Chase Stone
+Yawgmoth- Thran Physician,4,2023,30.96,#000000,https://cards.scryfall.io/normal/front/b/5/b5a79f5d-d0df-4799-ac3a-84305e3af0c9.jpg?1783918469,Legendary Creature — Human Cleric,Mark Winters
+Yukora- the Prisoner,4,2005,0.51,#000000,https://cards.scryfall.io/normal/front/5/4/54aeca31-1175-4d2d-adc3-e3682d7e9e07.jpg?1783944193,Legendary Creature — Demon Spirit,Tony Szczudlo
+Zenos yae Galvus // Shinryu- Transcendent Rival,5,2025,0.38,#000000,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Noble Warrior // Legendary Creature — Dragon,Alexander Mokhov
+Zero Point Ballad,1,2025,0.32,#000000,https://cards.scryfall.io/normal/front/5/9/59cf9f4d-54cd-4cda-9726-65e16100ab46.jpg?1783905958,Sorcery,David Astruga
+Zhang He- Wei General,5,1999,92.89,#000000,https://cards.scryfall.io/normal/front/7/3/736e4bf1-fee9-47cc-9bbc-093f21c77297.jpg?1783946110,Legendary Creature — Human Soldier,Jack Wei
+Zhang Liao- Hero of Hefei,6,1999,34.19,#000000,https://cards.scryfall.io/normal/front/8/f/8f42a953-3073-4e74-9bb8-c8c5a45d1dfa.jpg?1783946110,Legendary Creature — Human Soldier,Li Youliang
+Zodiark- Umbral God,5,2025,0.75,#000000,https://cards.scryfall.io/normal/front/9/b/9ba292d5-5139-42ea-950d-0a638445277f.jpg?1783906608,Legendary Creature — God,AKAGI
+Zombie Apocalypse,6,2021,0.98,#000000,https://cards.scryfall.io/normal/front/8/5/854ae40d-ee52-434e-8fe0-1b5a0d4ea58b.jpg?1783925332,Sorcery,Volkan Baǵa
+Zombie Master,3,1999,4.95,#000000,https://cards.scryfall.io/normal/front/3/4/346707a7-e816-432c-bb93-16b5cb4616e0.jpg?1783946176,Creature — Zombie,Jeff A. Menges
+Zombify,4,2026,2.22,#000000,https://cards.scryfall.io/normal/front/0/5/05b50907-41e2-4613-b030-7c6556874bd2.jpg?1783903509,Sorcery,Hisashi Momose
+Zulaport Cutthroat,2,2025,17.5,#000000,https://cards.scryfall.io/normal/front/2/1/21562285-5fed-4227-be4b-3470972a5437.jpg?1783906667,Creature — Human Rogue Ally,Frank Frazetta
+Zul Ashur- Lich Lord,2,2024,0.67,#000000,https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg?1783909107,Legendary Creature — Zombie Warlock,Raluca Marinescu
+Zzzyxas's Abyss,3,2004,0.93,#000000,https://cards.scryfall.io/normal/front/d/1/d1ead203-b976-46d7-81c7-86ada091a4ec.jpg?1783944248,Enchantment,Pete Venters

--- a/magic_card_csv_files_by_color/G.csv
+++ b/magic_card_csv_files_by_color/G.csv
@@ -1,0 +1,1575 @@
+name,cmc,release_year,price,color,image,type_line,artist
+Abomination- Irradiated Brute,4,2026,1.39,#087500,https://cards.scryfall.io/normal/front/0/b/0b82c865-ae3e-43f0-9ac8-fabdd5539b36.jpg?1783903109,Legendary Creature — Gamma Villain,Kieran Yanner
+Aboroth,6,1997,1.06,#087500,https://cards.scryfall.io/normal/front/8/c/8c72ac67-e4fb-49a1-b1e5-cd2e414bec28.jpg?1783946722,Creature — Elemental,Brom
+Abundance,4,2023,1.64,#087500,https://cards.scryfall.io/normal/front/9/b/9bc359b0-8886-415b-a497-e98a2241084e.jpg?1783915428,Enchantment,Rebecca Guay
+Abundant Harvest,1,2021,0.36,#087500,https://cards.scryfall.io/normal/front/1/6/16782095-0b7f-4489-8a97-b74f8efef352.jpg?1783927427,Sorcery,Barbara Rosiak
+Accomplished Alchemist,4,2021,0.4,#087500,https://cards.scryfall.io/normal/front/0/d/0d7b7830-b65e-4c53-98e8-152026764e4b.jpg?1783927349,Creature — Elf Druid,Randy Vargas
+Ace- Fearless Rebel,4,2023,0.17,#087500,https://cards.scryfall.io/normal/front/7/5/75f001a0-8393-4977-84bb-cde39740606c.jpg?1783914645,Legendary Creature — Human Rebel,Colin Boyer
+Aetherwind Basker,7,2017,0.29,#087500,https://cards.scryfall.io/normal/front/f/a/fa04d5fa-6ba2-4833-8ea0-1941a03bd3e9.jpg?1783936746,Creature — Lizard,Svetlin Velinov
+Aeve- Progenitor Ooze,5,2021,0.35,#087500,https://cards.scryfall.io/normal/front/d/f/dfe9b1b8-dffe-427d-be1e-2c6b8395bd54.jpg?1783926836,Legendary Creature — Ooze,Andrew Mar
+Afiya Grove,2,1996,1.09,#087500,https://cards.scryfall.io/normal/front/c/4/c495e1f3-0845-4556-83e6-de8b9d518d1d.jpg?1783947069,Enchantment,Stuart Griffin
+Afterburner Expert,3,2025,0.15,#087500,https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg?1783907875,Creature — Goblin Artificer,April Prime
+Ageless Entity,5,2021,0.38,#087500,https://cards.scryfall.io/normal/front/8/f/8fefd7d1-8c70-4d54-be0a-f45833340670.jpg?1783927538,Creature — Elemental,Jeff Miracola
+Aggressive Mammoth,6,2024,0.45,#087500,https://cards.scryfall.io/normal/front/7/7/7724b978-999b-4654-96f3-58e28aa7cb34.jpg?1783908947,Creature — Elephant,Filip Burburan
+Agonasaur Rex,5,2025,0.66,#087500,https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg?1783907875,Creature — Dinosaur,Lucas Graciano
+Aid from the Cowl,5,2023,0.33,#087500,https://cards.scryfall.io/normal/front/3/2/327dbb25-833a-4293-b397-ebe7859227a5.jpg?1783917143,Enchantment,Viktor Titov
+Allosaurus Rider,7,2014,4.8,#087500,https://cards.scryfall.io/normal/front/8/f/8fdaedf0-c4d2-4c2c-a183-026f06f3c360.jpg?1783938775,Creature — Elf Warrior,Daren Bader
+Allosaurus Shepherd,1,2022,50.43,#087500,https://cards.scryfall.io/normal/front/7/a/7afa0ee5-a0b8-472e-9991-09402ddb5de3.jpg?1783921876,Creature — Elf Shaman,Randy Vargas
+All Suns' Dawn,5,2015,0.28,#087500,https://cards.scryfall.io/normal/front/1/5/15629398-bb20-4ff3-ab0e-061dcea916d5.jpg?1783938401,Sorcery,Glen Angus
+Alluring Scent,3,1999,5.03,#087500,https://cards.scryfall.io/normal/front/2/c/2c488688-4e50-4705-afd5-09310e240777.jpg?1783946024,Sorcery,Melissa A. Benson
+Ambitious Augmenter,1,2026,0.3,#087500,https://cards.scryfall.io/normal/front/8/5/85629088-2007-4db5-9397-bac12a3d7498.jpg?1783903661,Creature — Turtle Wizard,Mariah Tekulve
+Analyze the Pollen,1,2024,0.34,#087500,https://cards.scryfall.io/normal/front/5/5/5563967f-09fd-4ccf-8892-4dd0c2544c98.jpg?1783912872,Sorcery,Anna Christenson
+Anavolver,4,2001,0.31,#d78f42,https://cards.scryfall.io/normal/front/5/e/5e685a8c-fba6-495f-ac0f-1ff5456b22d0.jpg?1783945341,Creature — Volver,Matt Cavotta
+Ancestral Communion,2,2026,0.33,#087500,https://cards.scryfall.io/normal/front/a/d/ad4224f8-ee83-4833-99a1-71e3ecbe9718.jpg?1783903279,Sorcery,Nereida
+Ancient Adamantoise,8,2025,3.04,#087500,https://cards.scryfall.io/normal/front/4/c/4c139f30-5ecd-48fd-ae7c-ec2cc98889ff.jpg?1783906591,Creature — Turtle,Kevin Glint
+Ancient Bronze Dragon,7,2022,19.06,#087500,https://cards.scryfall.io/normal/front/7/8/781af4dd-9e3c-48af-80e9-b52c427d2120.jpg?1783922721,Creature — Elder Dragon,Johan Grenier
+Ancient Cornucopia,3,2024,4.91,#087500,https://cards.scryfall.io/normal/front/f/9/f977975d-0439-4731-b129-270cc4cdbb23.jpg?1783912000,Artifact,Bartek Fedyczak
+Ancient Greenwarden,6,2024,12.63,#087500,https://cards.scryfall.io/normal/front/1/2/12a0bf5c-a165-48f1-9a57-3a7cc9f3b0f9.jpg?1783911913,Creature — Elemental,Grzegorz Rutkowski
+Ancient Imperiosaur,7,2023,0.35,#087500,https://cards.scryfall.io/normal/front/6/8/687d3261-dfbf-4c49-986f-20117b7ab5e7.jpg?1783916978,Creature — Dinosaur,Piotr Foksowicz
+Ancient Ooze,7,2003,1.46,#087500,https://cards.scryfall.io/normal/front/3/b/3b57b41c-f99c-4525-8541-f025b7e31974.jpg?1783944869,Creature — Ooze,Erica Gassalasca-Jape
+Ancient Silverback,6,2005,0.48,#087500,https://cards.scryfall.io/normal/front/8/1/818a0944-3534-49e4-8d93-274244043696.jpg?1783943941,Creature — Ape,Scott M. Fischer
+Ancient Stirrings,1,2026,1.52,#087500,https://cards.scryfall.io/normal/front/c/f/cff57828-c5c4-405f-a118-dc91c5f754ac.jpg?1783903996,Sorcery,SimzArt
+An-Havva Constable,3,1997,0.31,#087500,https://cards.scryfall.io/normal/front/5/9/5955eb2b-31a2-4e1e-bbbe-82eb53def698.jpg?1783946901,Creature — Human,Dan Frazier
+Animal Friend,2,2024,0.35,#087500,https://cards.scryfall.io/normal/front/a/f/af31a045-0387-44ff-b735-54e19b04d925.jpg?1783912399,Enchantment — Aura,Maxim Kostin
+Animal Magnetism,5,2002,0.37,#087500,https://cards.scryfall.io/normal/front/c/3/c33db646-b30d-4a15-9f8a-63bda74e2d81.jpg?1783945046,Sorcery,Ron Spears
+Animist's Awakening,1,2026,0.35,#087500,https://cards.scryfall.io/normal/front/d/5/d5ace571-0644-40d6-a05f-15f2e47d8861.jpg?1783903769,Sorcery,Chris Rahn
+Anthousa- Setessan Hero,5,2013,0.18,#087500,https://cards.scryfall.io/normal/front/c/a/ca89e4d4-185d-4a08-b7af-03f6eff38ba3.jpg?1783939750,Legendary Creature — Human Warrior,Howard Lyon
+Ant Queen,5,2015,0.75,#087500,https://cards.scryfall.io/normal/front/4/9/499cc16c-9ead-45b9-b56c-7512cd54cf7c.jpg?1783938400,Creature — Insect,Trevor Claxton
+Apex Altisaur,9,2023,8.24,#087500,https://cards.scryfall.io/normal/front/1/e/1e6beba4-128c-418e-83ed-8a82afc0c39e.jpg?1783913862,Creature — Dinosaur,Simon Dominic
+Apex Devastator,10,2020,5.97,#087500,https://cards.scryfall.io/normal/front/8/f/8fa281e1-5c48-4bba-b8e9-88c6f5f53abb.jpg?1783928799,Creature — Chimera Hydra,Svetlin Velinov
+Arachnogenesis,3,2024,7.41,#087500,https://cards.scryfall.io/normal/front/f/5/f5f18431-64c0-4ae5-bdc1-1e953313f086.jpg?1783909610,Instant,Johannes Voss
+Arachnus Spinner,6,2011,0.22,#087500,https://cards.scryfall.io/normal/front/2/3/23321b80-d7e7-48fd-985d-1e9dc3adcd35.jpg?1783941063,Creature — Spider,Karl Kopinski
+Arashi- the Sky Asunder,5,2021,0.24,#087500,https://cards.scryfall.io/normal/front/9/5/95bfae4a-01fe-4309-9291-b3123395f057.jpg?1783927538,Legendary Creature — Spirit,Kev Walker
+Arasta of the Endless Web,4,2025,0.37,#087500,https://cards.scryfall.io/normal/front/9/5/95a87b4e-f0ea-457c-9517-4acf313c4ca6.jpg?1783907053,Legendary Enchantment Creature — Spider,Sam Rowan
+Arbor Adherent,4,2025,1.46,#087500,https://cards.scryfall.io/normal/front/5/7/57d0502f-5ae8-40b6-9f2b-cd4418016219.jpg?1783907169,Creature — Dog Druid,Christina Kraus
+Arbor Colossus,5,2015,0.17,#087500,https://cards.scryfall.io/normal/front/8/7/87a12eac-c104-4a91-a9d3-ccc450d5114c.jpg?1783938070,Creature — Giant,Jaime Jones
+Arboreal Alliance,2,2023,0.54,#087500,https://cards.scryfall.io/normal/front/1/0/107f9fbf-4111-41a8-8e5d-9889fa2e3047.jpg?1783914199,Enchantment,Alexander Mokhov
+Arbor Elf,1,2024,18.23,#087500,https://cards.scryfall.io/normal/front/d/8/d81bce60-78f6-4f42-9fcd-383f66f85de5.jpg?1783910879,Creature — Elf Druid,Andrew MacLean
+Arboria,4,2023,0.29,#087500,https://cards.scryfall.io/normal/front/b/1/b18f4de2-adfe-4784-bd57-9e2ad9088825.jpg?1783918449,World Enchantment,Uriah Voth
+Archdruid's Charm,3,2024,6.32,#087500,https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg?1783912870,Instant,Liiga Smilshkalne
+Architect of the Untamed,3,2016,0.16,#087500,https://cards.scryfall.io/normal/front/7/b/7bc540f5-96a1-44d8-910d-914b9e61b2a5.jpg?1783937184,Creature — Elf Artificer Druid,Sara Winters
+A Realm Reborn,6,2025,0.37,#087500,https://cards.scryfall.io/normal/front/d/1/d1af74e4-38d5-44b5-85e1-4d13f6970453.jpg?1783906582,Enchantment,Anna Podedworna
+Argothian Enchantress,2,2016,66.24,#087500,https://cards.scryfall.io/normal/front/b/9/b99ff81f-08d9-4b4a-a879-de5e5e402802.jpg?1783937569,Creature — Human Druid,Daren Bader
+Argothian Wurm,4,1998,2.4,#087500,https://cards.scryfall.io/normal/front/9/3/93294349-75ae-4a6b-896d-b403a5d69e98.jpg?1783946320,Creature — Wurm,Kev Walker
+Arwen- Weaver of Hope,3,2023,3.16,#087500,https://cards.scryfall.io/normal/front/4/d/4d4f4d41-232d-4377-be69-de590b880edb.jpg?1783916027,Legendary Creature — Elf Noble,Axel Sauerwald
+Ascendant Acolyte,5,2022,0.35,#087500,https://cards.scryfall.io/normal/front/9/1/918a9e38-29ec-4279-8cf6-f01141497cab.jpg?1783923989,Creature — Human Monk,Micah Epstein
+Ascendant Packleader,1,2021,0.33,#087500,https://cards.scryfall.io/normal/front/1/4/142c5b67-5de9-41da-b57f-7ce771457a3e.jpg?1783924820,Creature — Wolf,Alessandra Pisano
+Asceticism,5,2010,8.28,#087500,https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg?1783941722,Enchantment,Daarken
+Ashaya- Soul of the Wild,5,2024,16.1,#087500,https://cards.scryfall.io/normal/front/0/a/0a74b4e6-f6c9-4fef-a83c-a285a541e720.jpg?1783909609,Legendary Creature — Elemental,Chase Stone
+As Luck Would Have It,1,2017,0.38,#087500,https://cards.scryfall.io/normal/front/d/1/d17892f5-5c4a-4149-8d5e-ba9df013866e.jpg?1783935414,Enchantment,Milivoj Ćeran
+Aspect of Wolf,2,1997,0.57,#087500,https://cards.scryfall.io/normal/front/3/8/38af8356-2d7f-4699-9e57-08906c1c831b.jpg?1783946901,Enchantment — Aura,Janine Johnston
+Assault Formation,2,2025,0.36,#087500,https://cards.scryfall.io/normal/front/4/0/40452217-9d8c-48e7-b5b4-2740b97bea2a.jpg?1783907051,Enchantment,Kieran Yanner
+Assemble the Entmoot,4,2023,0.31,#087500,https://cards.scryfall.io/normal/front/4/0/409c226b-ef01-4ccd-b23e-d94bdc1e4aa5.jpg?1783916025,Enchantment,Alex Brock
+Audience with Trostani,3,2024,0.25,#087500,https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg?1783912873,Sorcery,Ben Hill
+Augmenter Pugilist // Echoing Equation,3,2021,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Troll Druid // Sorcery,Volkan Baǵa
+Augur of Autumn,3,2025,0.35,#087500,https://cards.scryfall.io/normal/front/c/0/c09f0e1b-c13b-4e53-ab0e-c8b8a6151d82.jpg?1783906036,Creature — Human Druid,Billy Christian
+Aurora Awakener,7,2026,0.8,#087500,https://cards.scryfall.io/normal/front/9/1/913977c2-73f9-466b-bd01-827c1736e070.jpg?1783904435,Creature — Giant Druid,Paolo Parente
+Avabruck Caretaker // Hollowhenge Huntmaster,6,2021,4.98,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Heonhwa
+Avacyn's Pilgrim,1,2025,2.77,#d78f42,https://cards.scryfall.io/normal/front/2/8/28f23108-0a1e-4406-9002-0bff20462e56.jpg?1783907549,Creature — Human Monk,Mark Zug
+Avatar Destiny,4,2025,0.31,#087500,https://cards.scryfall.io/normal/front/4/d/4d74da72-8443-4fce-9d64-d2041f6a3292.jpg?1783904948,Enchantment — Aura,Iwamoto05
+Avatar Kyoshi- Earthbender,8,2025,14.61,#087500,https://cards.scryfall.io/normal/front/e/5/e5505044-d181-4af7-bd24-1a703e58d400.jpg?1783904817,Legendary Creature — Human Avatar,Tetsuko
+Avatar of Growth,6,2018,25.13,#087500,https://cards.scryfall.io/normal/front/f/5/f524a232-7158-4f85-880e-fede2f9d35d1.jpg?1783933994,Creature — Elemental Avatar,Grzegorz Rutkowski
+Avatar of Might,8,2007,0.66,#087500,https://cards.scryfall.io/normal/front/c/a/ca570876-23b2-4915-a5b9-20f1fa976fab.jpg?1783943006,Creature — Avatar,rk post
+Avatar of the Resolute,2,2015,0.3,#087500,https://cards.scryfall.io/normal/front/7/b/7bf18a2f-f93e-4a18-92d5-c9d2cca276d7.jpg?1783938582,Creature — Avatar,Jeff Simpson
+Aveline de Grandpré,4,2024,0.39,#d78f42,https://cards.scryfall.io/normal/front/d/b/db3b4f73-e241-4d60-a877-25327092c291.jpg?1783910976,Legendary Creature — Human Assassin,Aurore Folny
+Avenger of Zendikar,7,2026,0.41,#087500,https://cards.scryfall.io/normal/front/c/6/c6f1e60f-a195-4590-80b0-86767de6c423.jpg?1783904552,Creature — Elemental,Zoltan Boros & Gabor Szikszai
+Awakening,4,1998,6.51,#087500,https://cards.scryfall.io/normal/front/5/9/59612c02-6028-4953-ac4d-aca94b0ce4b9.jpg?1783946552,Enchantment,Dan Frazier
+Awakening of Vitu-Ghazi,5,2019,0.31,#087500,https://cards.scryfall.io/normal/front/b/4/b42b2fb4-8016-462c-8764-2639adec931f.jpg?1783933417,Instant,Jaime Jones
+Awakening Zone,3,2026,0.37,#087500,https://cards.scryfall.io/normal/front/1/3/13724768-83d3-4da2-82d7-35787c4f9877.jpg?1783903768,Enchantment,Johann Bodin
+Awaken the Woods,2,2022,14.42,#087500,https://cards.scryfall.io/normal/front/1/c/1c95f8b8-faba-4412-8d8f-093e2ec903f0.jpg?1783920050,Sorcery,Bryan Sola
+Axebane Ferox,4,2024,0.21,#087500,https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg?1783912873,Creature — Beast,Maxime Minard
+Ayula- Queen Among Bears,2,2019,1.4,#087500,https://cards.scryfall.io/normal/front/c/0/c046dfb0-9ca3-4219-a6b0-d7503bc2fbd0.jpg?1783933100,Legendary Creature — Bear,Jesper Ejsing
+Ayula's Influence,3,2019,0.38,#087500,https://cards.scryfall.io/normal/front/1/b/1b9296ca-39a8-4aad-be92-0a56c704e950.jpg?1783933100,Enchantment,Kari Christensen
+Ayumi- the Last Visitor,5,2005,0.75,#087500,https://cards.scryfall.io/normal/front/f/0/f037520e-2a44-4650-b7cb-c81d93d1418d.jpg?1783944140,Legendary Creature — Spirit,rk post
+Azusa- Lost but Seeking,3,2023,12.27,#087500,https://cards.scryfall.io/normal/front/2/f/2fe97fbe-a6d6-4e96-8c26-f81bcdf579a1.jpg?1783915637,Legendary Creature — Human Monk,Winona Nelson
+Badgermole Cub,2,2025,48.55,#087500,https://cards.scryfall.io/normal/front/3/4/340c5799-4964-44dd-8c48-8f3f3aba5211.jpg?1783904948,Creature — Badger Mole,Nathaniel Himawan
+Bag of Tricks,2,2021,0.32,#087500,https://cards.scryfall.io/normal/front/f/0/f0b22a3e-90b0-4dde-8a63-789bab92ba01.jpg?1783926244,Artifact,Jakub Kasper
+Baloth Prime,4,2025,0.34,#087500,https://cards.scryfall.io/normal/front/2/c/2c723fc9-d5c9-4126-a9a6-f80c247a4b6b.jpg?1783906064,Creature — Beast,Joshua Raphael
+Balustrade Wurm,5,2024,0.3,#087500,https://cards.scryfall.io/normal/front/7/6/76610e6e-b60f-494f-bb11-68371eb494f2.jpg?1783909460,Creature — Wurm,Maxime Minard
+Bane of Progress,6,2026,0.4,#087500,https://cards.scryfall.io/normal/front/5/4/54c98a43-d358-4bb5-ba65-dff25c2f12ea.jpg?1783904550,Creature — Elemental,Lars Grant-West
+Barroom Brawl,2,2022,0.22,#087500,https://cards.scryfall.io/normal/front/0/4/0452a08e-1a04-432f-9c35-11699d7d44fe.jpg?1783922720,Sorcery,Craig J Spearing
+Bartz and Boko,5,2025,0.34,#087500,https://cards.scryfall.io/normal/front/d/8/d818d574-2832-4a7a-a13b-aa6e695fdaa5.jpg?1783906591,Legendary Creature — Human Bird,Ryuichi Sakuma
+Baru- Fist of Krosa,5,2007,0.76,#087500,https://cards.scryfall.io/normal/front/1/a/1a74fcde-7685-402c-9b2a-245aa75d75c1.jpg?1783943096,Legendary Creature — Human Druid,Lucio Parrillo
+Baru- Wurmspeaker,4,2022,1.79,#087500,https://cards.scryfall.io/normal/front/2/c/2cae4149-d8ef-4772-9db4-cb576bef61b5.jpg?1783921468,Legendary Creature — Human Druid,Andrew Mar
+Basic Conjuration,3,2021,0.33,#087500,https://cards.scryfall.io/normal/front/8/b/8be52d88-f430-4437-a0d3-590c2947c838.jpg?1783927348,Sorcery — Lesson,Randy Vargas
+Battle Mammoth,5,2022,0.44,#087500,https://cards.scryfall.io/normal/front/d/f/df70dc42-a28c-41f3-8d3b-5a0375aab326.jpg?1783922410,Creature — Elephant,Jesper Ejsing
+Beacon of Creation,4,2004,7.02,#087500,https://cards.scryfall.io/normal/front/5/b/5bc629de-18a3-4780-9df6-28ee54a34b81.jpg?1783944392,Sorcery,Mark Tedin
+Bearscape,3,2001,4.48,#087500,https://cards.scryfall.io/normal/front/3/2/3284b61a-bd95-4846-ad3f-903cd1158867.jpg?1783945221,Enchantment,Heather Hudson
+Bear Umbra,4,2022,11.78,#087500,https://cards.scryfall.io/normal/front/5/a/5a195fb1-f2e9-4e05-8a04-c335e1afbef6.jpg?1783923955,Enchantment — Aura,Howard Lyon
+Beastcaller Savant,2,2015,0.67,#087500,https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg?1783938191,Creature — Elf Shaman Ally,Anthony Palumbo
+Beastmaster Ascension,3,2022,5.0,#087500,https://cards.scryfall.io/normal/front/f/4/f404d133-fc1a-4751-ac72-554e6553e486.jpg?1783923253,Enchantment,Alex Horley-Orlandelli
+Beast Whisperer,4,2024,7.63,#087500,https://cards.scryfall.io/normal/front/d/a/daf4bcd2-3ae4-4803-9ea1-3bcc3de5ca59.jpg?1783912531,Creature — Elf Druid,Matt Stewart
+Beast Within,3,2026,1.39,#087500,https://cards.scryfall.io/normal/front/b/6/b6b6c66f-e3e0-4904-ae41-2ecc786f70c5.jpg?1783903312,Instant,Jack Kirby
+Become the Avalanche,6,2025,0.31,#087500,https://cards.scryfall.io/normal/front/f/4/f49b7b11-ce78-44c4-98c2-dc8e2332c667.jpg?1783907168,Sorcery,Slawomir Maniak
+Bedrock Tortoise,4,2023,2.61,#087500,https://cards.scryfall.io/normal/front/7/0/701bd623-3100-44dc-adec-53fa3a95ab19.jpg?1783913751,Creature — Turtle,Maxime Minard
+Belt of Giant Strength,2,2021,2.87,#087500,https://cards.scryfall.io/normal/front/4/e/4ef2b9aa-4f7c-4640-bb34-9775e1be0935.jpg?1783926245,Artifact — Equipment,Viko Menezes
+Benefactor's Draught,2,2016,16.0,#087500,https://cards.scryfall.io/normal/front/e/4/e40f3dfb-3c5d-468a-9e0e-610ad3e11787.jpg?1783937087,Instant,Scott Murphy
+Benevolent Hydra,2,2026,0.89,#087500,https://cards.scryfall.io/normal/front/0/6/064595cb-089e-4cf2-afe3-223235ce3f92.jpg?1783903818,Creature — Hydra,Vincent Christiaens
+Berserk,1,2016,15.51,#087500,https://cards.scryfall.io/normal/front/6/2/62bc9bff-89bd-4454-a876-53822cf48546.jpg?1783937297,Instant,Steve Prescott
+Bifurcate,4,1999,0.44,#087500,https://cards.scryfall.io/normal/front/d/e/dedb483e-b2c6-46c6-b02b-a49599d33521.jpg?1783945930,Sorcery,John Matson
+Bind,2,2000,4.28,#087500,https://cards.scryfall.io/normal/front/c/f/cfa51783-9ef8-4e51-ba0d-ce8439d83bdf.jpg?1783945677,Instant,Mark Zug
+B-I-N-G-O,2,2020,0.19,#087500,https://cards.scryfall.io/normal/front/2/c/2cf4a081-3532-45e5-be72-1ff2fb88bb08.jpg?1783931327,Creature — Dog,Ron Spencer
+Bioengineered Future,3,2025,0.3,#087500,https://cards.scryfall.io/normal/front/8/0/800ee479-c1dc-4dd0-9b98-436c78997958.jpg?1783905943,Enchantment,Constantin Marin
+Biogenic Ooze,5,2026,0.31,#087500,https://cards.scryfall.io/normal/front/0/e/0e850205-d010-49af-b68b-262360751b70.jpg?1783904159,Creature — Ooze,James Bousema
+Biophagus,2,2022,17.48,#087500,https://cards.scryfall.io/normal/front/c/f/cfd188ec-5e63-414e-a949-20a0daa82690.jpg?1783920882,Creature — Human Tyranid Wizard,Thea Dumitriu
+Bioplasm,5,2006,0.29,#087500,https://cards.scryfall.io/normal/front/7/1/7170a1db-3502-4caf-a54b-bd0df0d93f2d.jpg?1783943495,Creature — Ooze,Jon Foster
+Biorhythm,8,2005,33.68,#087500,https://cards.scryfall.io/normal/front/1/7/17d1a10f-ce21-4914-9984-c7c559161230.jpg?1783943940,Sorcery,Ron Spears
+Biowaste Blob,4,2020,0.4,#087500,https://cards.scryfall.io/normal/front/8/b/8bbf476f-ccc8-42ac-8d01-64bb85552acd.jpg?1783928799,Creature — Ooze,Simon Dominic
+Birds of Paradise,1,2026,8.98,#087500,https://cards.scryfall.io/normal/front/4/9/492c2f9a-51e7-4e0f-9899-23bf43ea988b.jpg?1783903230,Creature — Bird,Kevin Sidharta
+Birthing Pod,4,2011,13.46,#087500,https://cards.scryfall.io/normal/front/b/7/b768efa2-e56b-4a7e-ace8-d673f10e0714.jpg?1783941303,Artifact,Daarken
+Birthing Ritual,2,2024,3.91,#087500,https://cards.scryfall.io/normal/front/4/8/4820d223-4ea1-4850-931c-3d2ab5eb003b.jpg?1783911264,Enchantment,Drew Tucker
+Bison Whistle,2,2025,0.18,#087500,https://cards.scryfall.io/normal/front/3/2/32d4a2b1-5f39-49a2-b067-e74d2dc31b30.jpg?1783904816,Artifact,Brandon L. Hunt
+Blessing of Frost,4,2021,0.32,#087500,https://cards.scryfall.io/normal/front/4/2/42f01f4d-491e-4f25-a017-a0d9c437ac8c.jpg?1783928219,Snow Sorcery,Mila Pesic
+Blex- Vexing Pest // Search for Blex,3,2021,12.1,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Pest // Sorcery,Ekaterina Burmak
+Blizzard,2,1995,0.88,#087500,https://cards.scryfall.io/normal/front/c/3/c369e4f9-0f2b-446c-9e2d-d3eefab0586d.jpg?1783947481,Enchantment,Anson Maddocks
+Bloated Contaminator,3,2023,4.66,#087500,https://cards.scryfall.io/normal/front/4/1/411bda96-6c65-475d-9850-0a9b3eefa553.jpg?1783918018,Creature — Phyrexian Beast,Johann Bodin
+Bloodroot Apothecary,3,2024,4.9,#087500,https://cards.scryfall.io/normal/front/d/3/d39e0024-9a91-49d6-bfbf-9dbf7d228687.jpg?1783910729,Creature — Squirrel Druid,Alessandra Pisano
+Bloodspore Thrinax,4,2023,0.36,#087500,https://cards.scryfall.io/normal/front/6/e/6efe9126-15ba-468e-a15a-7f9cbb779cf6.jpg?1783915636,Creature — Lizard,Ralph Horsley
+Bloom Tender,2,2026,13.43,#087500,https://cards.scryfall.io/normal/front/b/a/ba86688d-18f0-4b5c-a797-42bf125a6c9f.jpg?1783904436,Creature — Elf Druid,Nils Hamm
+Bloomvine Regent // Claim Territory,5,2025,1.25,#087500,https://cards.scryfall.io/normal/front/1/0/10e0a9a3-f63a-4f92-a083-9d181580e498.jpg?1783907345,Creature — Dragon // Sorcery — Omen,Johann Bodin
+Blossoming Bogbeast,5,2026,0.45,#087500,https://cards.scryfall.io/normal/front/7/6/764054f1-e848-4cee-b623-4861ce15c370.jpg?1783903768,Creature — Beast,Aaron Miller
+Blossoming Tortoise,4,2023,5.82,#087500,https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg?1783915085,Creature — Turtle,Simon Dominic
+Blurred Mongoose,2,2000,0.56,#087500,https://cards.scryfall.io/normal/front/4/b/4b073e3f-6a6f-495a-ab16-39d906b660f1.jpg?1783945677,Creature — Mongoose,Heather Hudson
+Bone Sabres,3,2022,4.97,#087500,https://cards.scryfall.io/normal/front/7/3/73d9374d-72b8-4397-9c46-be9216fab911.jpg?1783920880,Artifact — Equipment,David Auden Nash
+Boon Satyr,3,2018,0.18,#087500,https://cards.scryfall.io/normal/front/4/7/477a30f3-3cbe-42a5-9fae-fe5885a8cf25.jpg?1783934292,Enchantment Creature — Satyr,Wesley Burt
+Bootleggers' Stash,6,2022,0.64,#087500,https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg?1783923109,Artifact,Anastasia Ovchinnikova
+Borrowing the East Wind,2,1999,122.98,#087500,https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg?1783946102,Sorcery,Gao Yan
+Boundless Realms,7,2012,3.77,#087500,https://cards.scryfall.io/normal/front/e/3/e3c3cf16-ba81-4558-b1a6-79942a02f629.jpg?1783940474,Sorcery,Cliff Childs
+Bounteous Kirin,7,2005,0.39,#087500,https://cards.scryfall.io/normal/front/1/d/1d7fe65e-81b1-4e69-913a-25fc99d96d81.jpg?1783944141,Legendary Creature — Kirin Spirit,Shishizaru
+Bounty of Might,6,2018,0.2,#087500,https://cards.scryfall.io/normal/front/e/9/e9a950d8-e6e2-42d6-83d7-a60c15d2035d.jpg?1783934154,Instant,Even Amundsen
+Bounty of Skemfar,3,2021,0.36,#087500,https://cards.scryfall.io/normal/front/3/1/3185a67e-648c-48a8-9aad-180e1ca0f4ae.jpg?1783928336,Sorcery,Colin Boyer
+Bow of Nylea,3,2013,4.17,#087500,https://cards.scryfall.io/normal/front/8/9/89a2c408-e953-4386-abaf-4af85aba9620.jpg?1783939748,Legendary Enchantment Artifact,Yeong-Hao Han
+Boxing Ring,2,2022,0.61,#087500,https://cards.scryfall.io/normal/front/a/d/ade9e358-0379-4ad3-a580-4ed0fe770ed2.jpg?1783923342,Artifact,James Paick
+Bramble Familiar // Fetch Quest,2,2023,0.57,#087500,https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1783915084,Creature — Elemental Raccoon // Sorcery — Adventure,Simon Dominic
+Bramble Sovereign,4,2022,3.58,#087500,https://cards.scryfall.io/normal/front/0/f/0fae6a19-6a16-443e-adae-78a7380ee012.jpg?1783922719,Creature — Dryad,Andreas Zafiratos
+Bramblewood Paragon,2,2008,44.83,#087500,https://cards.scryfall.io/normal/front/c/a/ca687bef-3503-4020-a054-953152be7aad.jpg?1783942771,Creature — Elf Warrior,Jim Murray
+Branching Evolution,3,2024,6.86,#087500,https://cards.scryfall.io/normal/front/c/0/c0f1a736-8b12-4f58-a031-bf1733f65c51.jpg?1783911212,Enchantment,Lucas Graciano
+Briarbridge Tracker,3,2021,0.09,#087500,https://cards.scryfall.io/normal/front/e/2/e215a7bd-112f-4228-a99e-5a8cb4be5cee.jpg?1783925585,Creature — Human Scout,Mathias Kollros
+Briar Hydra,6,2022,0.34,#087500,https://cards.scryfall.io/normal/front/3/9/390fd5d1-3ce9-456e-b130-30ad0557f4cf.jpg?1783921241,Creature — Plant Hydra,Caio Monteiro
+Bribe Taker,6,2022,0.25,#087500,https://cards.scryfall.io/normal/front/7/0/70aeb0a0-67dc-4cee-9b88-000e98b11d2c.jpg?1783923358,Creature — Rhino Warrior,Christopher Burdett
+Brightcap Badger // Fungus Frolic,4,2024,0.83,#087500,https://cards.scryfall.io/normal/front/0/e/0e843102-b8cc-4bc8-872e-79924197f4cc.jpg?1783910732,Creature — Badger Druid // Instant — Adventure,Izzy
+Brigid- Clachan's Heart // Brigid- Doun's Mind,3,2026,0.62,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Kithkin Warrior // Legendary Creature — Kithkin Soldier,Zoltan Boros
+Bringer of the Green Dawn,9,2004,1.45,#d78f42,https://cards.scryfall.io/normal/front/b/c/bc208f3e-5a6a-4fae-8a7c-2bed28ad0c41.jpg?1783944391,Creature — Bringer,Jim Murray
+Bristlebane Battler,2,2026,0.32,#087500,https://cards.scryfall.io/normal/front/c/8/c857fa32-1b5d-4139-8809-b4d0df44b472.jpg?1783904434,Creature — Kithkin Soldier,Steve Ellis
+Bristlebud Farmer,4,2024,1.1,#087500,https://cards.scryfall.io/normal/front/d/4/d498c4de-5e80-4baa-9fcb-70f164880c84.jpg?1783911998,Creature — Plant Druid,Adrián Rodríguez Pérez
+Bristling Hydra,4,2016,0.15,#087500,https://cards.scryfall.io/normal/front/4/b/4bf38096-05bc-4734-b33c-eb1e8f2986de.jpg?1783937182,Creature — Hydra,Chris Rahn
+Bristly Bill- Spine Sower,2,2024,42.86,#087500,https://cards.scryfall.io/normal/front/5/2/52eef0d6-24b7-40b7-8403-e8e863d0cd55.jpg?1783911810,Legendary Creature — Plant Druid,Daniel Zrom
+Broodcaller Scourge,7,2025,0.4,#087500,https://cards.scryfall.io/normal/front/6/f/6fc0a74b-0b8a-4c70-87f2-f9f2625d5ff2.jpg?1783907167,Creature — Dragon,Loïc Canavaggia
+Brooding Saurian,4,2013,0.21,#087500,https://cards.scryfall.io/normal/front/b/3/b3ec586d-14c7-4d3a-9bb5-f6afdf87657c.jpg?1783939662,Creature — Lizard,rk post
+Broodlord,4,2022,1.4,#087500,https://cards.scryfall.io/normal/front/a/5/a5e700b9-ea2f-47a0-8a18-6231c8f2e1e9.jpg?1783920880,Creature — Tyranid,Mathias Kollros
+Brood Sliver,5,2023,5.22,#087500,https://cards.scryfall.io/normal/front/4/4/441a387b-e18a-41c7-84bb-bb7e354f4f2d.jpg?1783915426,Creature — Sliver,Ron Spears
+Brushwagg,3,1996,0.91,#087500,https://cards.scryfall.io/normal/front/6/c/6c20edc3-5ad0-42c1-a5ec-3e680fb03297.jpg?1783947071,Creature — Brushwagg,Ian Miller
+Budoka Gardener // Dokai- Weaver of Life,2,2018,0.59,#087500,https://cards.scryfall.io/normal/front/5/8/58164521-aeec-43fc-9db9-d595432dea6f.jpg?1783934291,Creature — Human Monk // Legendary Creature — Human Monk,Kev Walker
+Bugenhagen- Wise Elder,2,2025,0.49,#087500,https://cards.scryfall.io/normal/front/9/9/99155fae-507a-4eab-918a-bdee021e2262.jpg?1783906352,Legendary Creature — Human Shaman,Racrufi
+Bumi- Eclectic Earthbender,5,2025,8.78,#087500,https://cards.scryfall.io/normal/front/f/3/f324a384-7380-4f6e-bbba-fac1f2a01b5d.jpg?1783904775,Legendary Creature — Human Noble Ally,Olena Richards
+Burgeoning,1,2016,34.43,#087500,https://cards.scryfall.io/normal/front/6/d/6da045f8-6278-4c84-9d39-025adf0789c1.jpg?1783937061,Enchantment,Titus Lunter
+Bygone Marvels,2,2023,0.22,#087500,https://cards.scryfall.io/normal/front/3/c/3cc95fd4-901e-4a96-9c20-9e8ecf5cfb7c.jpg?1783913908,Sorcery,Constantin Marin
+Caldaia Guardian,4,2022,0.22,#087500,https://cards.scryfall.io/normal/front/f/2/f20015ad-8fda-498f-ac28-1ffb824ab480.jpg?1783923357,Creature — Human Soldier,Aaron J. Riley
+Caller of the Claw,3,2015,6.17,#087500,https://cards.scryfall.io/normal/front/9/1/917c5e37-c15e-4260-b380-f1c73df2bf41.jpg?1783938071,Creature — Elf,Matt Cavotta
+Caller of the Hunt,3,1999,1.26,#087500,https://cards.scryfall.io/normal/front/c/0/c0e8e1cf-0a47-4ce4-889a-091229d0e466.jpg?1783945928,Creature — Human,Clyde Caldwell
+Caller of the Untamed,4,2016,0.21,#087500,https://cards.scryfall.io/normal/front/c/6/c62f25d9-7eb2-491e-ba7b-b71e49ee87b4.jpg?1783937345,Creature — Elf Shaman,Iain McCaig
+Call of the Herd,3,2017,0.25,#087500,https://cards.scryfall.io/normal/front/7/f/7ff0c182-f9ec-41d1-beb6-97d0eb1be592.jpg?1783936563,Sorcery,Carl Critchlow
+Call of the Wild,4,2003,0.41,#087500,https://cards.scryfall.io/normal/front/3/3/3332b35c-fd4f-4195-baee-e759dee6a682.jpg?1783944689,Enchantment,Paolo Parente
+Campsite Cuisine,2,2025,15.59,#087500,https://cards.scryfall.io/normal/front/e/c/ec6d3402-eed6-44be-a572-9ec0678af403.jpg?1783904649,Enchantment,Winona Nelson
+Canopy Dragon,6,1996,1.09,#087500,https://cards.scryfall.io/normal/front/2/0/20c5e4d6-b716-4994-b226-b1eb799bec25.jpg?1783947068,Creature — Dragon,Alan Rabinowitz
+Canopy Gargantuan,7,2025,2.91,#087500,https://cards.scryfall.io/normal/front/8/7/87736547-7534-4f0a-86e0-be9b0428be1e.jpg?1783907166,Creature — Dragon,John Tedrick
+Canopy Tactician,4,2021,3.24,#087500,https://cards.scryfall.io/normal/front/3/e/3eaf48c9-09bc-4d81-a3a5-432219a71754.jpg?1783928121,Creature — Elf Warrior,Ekaterina Burmak
+Capricopian,1,2020,2.12,#087500,https://cards.scryfall.io/normal/front/0/b/0b81f82a-f004-44f3-9dad-1675941fe57b.jpg?1783931211,Creature — Goat Hydra,Nicholas Gregory
+Cardboard Carapace,6,1998,2.27,#087500,https://cards.scryfall.io/normal/front/0/5/059fc73f-7a00-4014-9e92-75765798cf2d.jpg?1783946424,Enchantment — Aura,Douglas Shuler
+Carnage Tyrant,6,2017,3.9,#087500,https://cards.scryfall.io/normal/front/3/b/3bd78731-949c-464a-826a-92f86d784911.jpg?1783935731,Creature — Dinosaur,Yeong-Hao Han
+Carnassid,6,1998,0.31,#087500,https://cards.scryfall.io/normal/front/a/e/ae10e7fe-ee51-4c39-86ec-503324d19f6c.jpg?1783946552,Creature — Beast,Brom
+Carpet of Flowers,1,2025,2.85,#087500,https://cards.scryfall.io/normal/front/d/d/dd28c05c-9473-4df8-9bb3-70593f2c5a50.jpg?1783906382,Enchantment,ISAMU KAMIKOKURYO
+Casal- Lurkwood Pathfinder // Casal- Pathbreaker Owlbear,4,2025,14.31,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Tiefling Druid // Legendary Creature — Bird Bear,Victor Adame Minguez
+Case of the Locked Hothouse,4,2024,1.99,#087500,https://cards.scryfall.io/normal/front/0/9/0929a1bd-e35c-4ca5-8c8c-dd304cf4b830.jpg?1783912869,Enchantment — Case,Leanna Crossan
+Cavalier of Thorns,5,2026,0.26,#087500,https://cards.scryfall.io/normal/front/a/c/ace83f5b-2349-46b8-b27f-bf705912a6df.jpg?1783904559,Creature — Elemental Knight,Jehan Choo
+Cazur- Ruthless Stalker,4,2024,0.38,#087500,https://cards.scryfall.io/normal/front/6/e/6ee4fda8-07cd-4091-8850-a6925080b464.jpg?1783911912,Legendary Creature — Human Warrior,Daarken
+Celebrate the Harvest,4,2021,0.39,#087500,https://cards.scryfall.io/normal/front/7/0/70432583-33c1-4d1a-bb94-765f6d71fed3.jpg?1783925375,Sorcery,Eelis Kyttanen
+Celestial Reunion,1,2026,0.96,#087500,https://cards.scryfall.io/normal/front/5/8/583b2863-aca1-4dab-9196-ea453b5d9454.jpg?1783904435,Sorcery,Justin Gerard
+Cemetery Prowler,3,2021,4.16,#087500,https://cards.scryfall.io/normal/front/b/1/b124ccc4-76e3-41a4-92b2-8f1d06ea9cb8.jpg?1783924818,Creature — Wolf,Daarken
+Centaur of Attention,5,2022,0.13,#087500,https://cards.scryfall.io/normal/front/3/e/3eecbc0a-237d-433f-9edf-7420819f1301.jpg?1783920558,Creature — Centaur Performer,Leonardo Santanna
+Centaur Vinecrasher,4,2025,0.14,#087500,https://cards.scryfall.io/normal/front/c/f/cf8712ba-574b-4e53-9c7e-0a1465116320.jpg?1783906035,Creature — Plant Centaur,Robbie Trevino
+Chameleon Colossus,4,2021,0.74,#087500,https://cards.scryfall.io/normal/front/1/5/15401ca4-f6cd-400e-8e5e-ea47493b56a4.jpg?1783926196,Creature — Shapeshifter,Darrell Riche
+Champion of Lambholt,3,2023,4.26,#087500,https://cards.scryfall.io/normal/front/4/6/46eff31d-f460-48f2-aab7-8b9b89cd87fe.jpg?1783917143,Creature — Human Warrior,Christopher Moeller
+Champion of Rhonas,4,2017,0.21,#087500,https://cards.scryfall.io/normal/front/b/1/b185b24d-ae33-48ca-966a-511627fdac6d.jpg?1783936478,Creature — Jackal Warrior,Winona Nelson
+Champions of the Perfect,4,2026,0.78,#087500,https://cards.scryfall.io/normal/front/4/f/4f359211-8be5-4818-b73c-14f24b7ddb21.jpg?1783904433,Creature — Elf Warrior,Chris Rahn
+Chancellor of the Tangle,7,2011,1.07,#087500,https://cards.scryfall.io/normal/front/6/d/6d129aa8-b637-451e-8123-5221e08cc2cc.jpg?1783941303,Creature — Phyrexian Beast,Steve Prescott
+Channel,2,2017,1.15,#087500,https://cards.scryfall.io/normal/front/c/e/ce54c7c1-3401-4414-8da0-5846cb0ae1b4.jpg?1783935522,Sorcery,Rebecca Guay
+Channeler Initiate,2,2026,0.21,#087500,https://cards.scryfall.io/normal/front/9/0/9011936a-ec69-4c1b-ae8e-c2d212047ca4.jpg?1783904547,Creature — Human Druid,Yongjae Choi
+Charging Rhino,5,1997,0.67,#087500,https://cards.scryfall.io/normal/front/4/9/49e47248-051c-4ee6-aad2-352ebd1f38ca.jpg?1783946808,Creature — Rhino,Una Fricker
+Chatterfang- Squirrel General,3,2021,11.2,#d78f42,https://cards.scryfall.io/normal/front/1/7/1785cf85-1ac0-4246-9b89-1a8221a8e1b2.jpg?1783926835,Legendary Creature — Squirrel Warrior,Jason A. Engle
+Child of Gaea,6,1998,0.91,#087500,https://cards.scryfall.io/normal/front/a/8/a836d9bd-a4cb-4676-935c-5fb7b793a42f.jpg?1783946319,Creature — Elemental,Paolo Parente
+Chitterspitter,3,2021,0.48,#087500,https://cards.scryfall.io/normal/front/7/e/7ee33ff3-d3d6-4519-9d9f-72e342d8b215.jpg?1783926833,Artifact,Jason Felix
+Chlorophant,3,2001,0.44,#087500,https://cards.scryfall.io/normal/front/c/4/c4fd0ea3-4134-4f7d-a0c8-01c49bacfcfc.jpg?1783945219,Creature — Elemental,John Avon
+Chord of Calling,3,2024,6.57,#087500,https://cards.scryfall.io/normal/front/b/1/b18fe7e0-8344-40cc-b242-83f01c6be7a6.jpg?1783913306,Instant,Heather Hudson
+Circle of Dreams Druid,3,2021,14.66,#087500,https://cards.scryfall.io/normal/front/b/e/be6fdec0-a2c4-4da2-ae14-961185eaee66.jpg?1783926466,Creature — Elf Druid,Sam Guay
+Citanul Centaurs,4,1998,0.86,#087500,https://cards.scryfall.io/normal/front/5/a/5a3ac987-7906-4159-a007-ed409baea9d7.jpg?1783946318,Creature — Centaur,Val Mayerik
+Citanul Hierophants,4,2024,0.31,#087500,https://cards.scryfall.io/normal/front/f/3/f378ee17-bf8b-4a83-b42e-86da10817dba.jpg?1783909640,Creature — Human Druid,Zezhou Chen
+City of Death,3,2023,1.68,#087500,https://cards.scryfall.io/normal/front/b/d/bd4d9b25-02ea-4ce3-a35f-7f427a74f591.jpg?1783914644,Enchantment — Saga,Miklós Ligeti
+City of Solitude,3,1997,23.84,#087500,https://cards.scryfall.io/normal/front/b/e/be499b81-bb2d-4f1d-9deb-c8bfcdca8e13.jpg?1783946984,Enchantment,Romas Kukalis
+Clamavus,5,2022,2.94,#087500,https://cards.scryfall.io/normal/front/1/2/127e9c03-f8de-497e-b94d-d6c484cab7fd.jpg?1783920880,Creature — Human Tyranid Artificer,Adrián Rodríguez Pérez
+Clear the Land,3,1999,1.63,#087500,https://cards.scryfall.io/normal/front/b/8/b87f3579-f314-4207-a02c-14e9cb269b47.jpg?1783945927,Sorcery,Bradley Williams
+Cliffrunner Behemoth,4,2009,0.36,#087500,https://cards.scryfall.io/normal/front/7/6/764c1a14-143f-4601-92c5-ebeabf3e375d.jpg?1783942476,Creature — Rhino Beast,Wayne Reynolds
+Cloudthresher,6,2017,0.33,#087500,https://cards.scryfall.io/normal/front/4/e/4e18bff6-bf0b-48f8-93e2-09d435247596.jpg?1783936269,Creature — Elemental,Christopher Moeller
+Cockatrice,5,1997,0.71,#087500,https://cards.scryfall.io/normal/front/8/5/853d15cd-a1a2-47a8-89c4-81b7ca663fff.jpg?1783946899,Creature — Cockatrice,Dan Frazier
+Collected Company,4,2015,2.04,#087500,https://cards.scryfall.io/normal/front/c/f/cfa7b456-7e83-4587-a875-9b35fde318c2.jpg?1783938582,Instant,Franz Vohwinkel
+Collective Unconscious,6,2017,0.85,#087500,https://cards.scryfall.io/normal/front/3/b/3b64755f-1381-4537-a12d-48da274993e6.jpg?1783936270,Sorcery,Andrew Goldhawk
+Collective Voyage,1,2016,7.47,#087500,https://cards.scryfall.io/normal/front/3/f/3f2d44f0-c71e-4061-bb7c-1f91fbce8f51.jpg?1783937061,Sorcery,Charles Urbach
+Collector Ouphe,2,2019,3.54,#087500,https://cards.scryfall.io/normal/front/0/8/085107a2-c1ec-473c-81d8-23e5a7197776.jpg?1783933099,Creature — Ouphe,Filip Burburan
+Colossal Dreadmaw,6,2023,6.72,#087500,https://cards.scryfall.io/normal/front/b/b/bb4fd0a3-c596-4a88-809b-6f16caf35adb.jpg?1783913445,Creature — Dinosaur,Dan Mumford & Thomas Roach
+Colossal Rattlewurm,4,2024,0.3,#087500,https://cards.scryfall.io/normal/front/1/7/17a104d3-e4ac-44a0-9c6a-39965b1b9751.jpg?1783911809,Creature — Wurm,Filip Burburan
+Colossification,7,2024,0.72,#087500,https://cards.scryfall.io/normal/front/c/2/c2cad902-ffd2-4bab-b114-b4b6df2ac6b3.jpg?1783910740,Enchantment — Aura,Johan Grenier
+Comforting Counsel,2,2026,0.33,#087500,https://cards.scryfall.io/normal/front/5/2/5223a04f-6b47-4379-80ce-8489c4a91734.jpg?1783903660,Enchantment,Chris Rahn
+Communal Brewing,3,2024,0.82,#087500,https://cards.scryfall.io/normal/front/a/c/acf6399f-f389-4b13-8563-a078a5d198f4.jpg?1783910728,Enchantment,Andreia Ugrai
+Composer of Spring,2,2023,6.83,#087500,https://cards.scryfall.io/normal/front/b/5/b57e06f8-e542-47d4-b527-7d8fc3dec38c.jpg?1783915480,Creature — Satyr Bard,Gaboleps
+Compost,2,2022,5.6,#087500,https://cards.scryfall.io/normal/front/d/b/dbf89e72-1448-48c0-b2b4-ebac0262efdb.jpg?1783920220,Enchantment,Victor Adame Minguez
+Conclave Sledge-Captain,6,2023,1.75,#087500,https://cards.scryfall.io/normal/front/9/9/99ad5807-2adc-40d7-b398-d03fd2cd58b9.jpg?1783917279,Creature — Elephant Soldier,Ilse Gort
+Concordant Crossroads,1,2022,32.21,#087500,https://cards.scryfall.io/normal/front/c/9/c9a26f51-5bff-4f06-abaa-6fbb56a8b5b6.jpg?1783921872,World Enchantment,Alayna Danner
+Concord with the Kami,4,2022,0.21,#087500,https://cards.scryfall.io/normal/front/c/3/c3e38dec-178b-497a-bfbd-371905690a39.jpg?1783923990,Enchantment,Marta Nael
+Conduit of Worlds,4,2026,1.31,#087500,https://cards.scryfall.io/normal/front/8/3/8380eb8d-d1c3-4f96-b3b9-54845188c1d1.jpg?1783903232,Artifact,Le Vuong
+Constant Mists,2,2025,27.02,#087500,https://cards.scryfall.io/normal/front/6/9/69ffe198-2696-43ea-b63b-9329f751d9ad.jpg?1783906665,Instant,Phil Foglio
+Consuming Blob,5,2021,0.44,#087500,https://cards.scryfall.io/normal/front/4/5/4540fa4b-93e8-4749-a839-9a6e816c1145.jpg?1783925582,Creature — Ooze,Simon Dominic
+Contaminant Grafter,5,2023,12.9,#087500,https://cards.scryfall.io/normal/front/0/e/0ef2f776-ff35-464b-bfcf-075c9ae4baa7.jpg?1783918158,Creature — Phyrexian Druid,Lars Grant-West
+Contest of Claws,2,2023,3.71,#087500,https://cards.scryfall.io/normal/front/c/6/c6679e01-acd1-460a-a4c6-096059510288.jpg?1783913932,Sorcery,Cristi Balanescu
+Copperhoof Vorrac,5,2003,0.37,#087500,https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg?1783944535,Creature — Boar Beast,Matt Cavotta
+Cosmium Confluence,5,2023,0.2,#087500,https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1783913749,Sorcery,Kasia 'Kafis' Zielińska
+Courier of Comestibles,2,2026,0.29,#087500,https://cards.scryfall.io/normal/front/2/1/2155537f-37b1-4121-9612-63781b461497.jpg?1783904636,Creature — Human Citizen,Andrea Tentori Montalto
+Courser of Kruphix,3,2023,2.01,#087500,https://cards.scryfall.io/normal/front/d/c/dc63d2ea-a980-466e-9ebb-f28008f84c3d.jpg?1783915426,Enchantment Creature — Centaur,Eric Deschamps
+Court of Bounty,4,2020,1.17,#087500,https://cards.scryfall.io/normal/front/d/c/dcffbea4-0126-483d-87da-b20e3c0b88a7.jpg?1783928799,Enchantment,Milivoj Ćeran
+Court of Garenbrig,3,2023,17.11,#087500,https://cards.scryfall.io/normal/front/d/7/d7a8cc1d-aabb-4eb6-b0f1-6c93ec246f61.jpg?1783914983,Enchantment,Sam Guay
+Cragplate Baloth,7,2020,0.2,#087500,https://cards.scryfall.io/normal/front/a/b/ab62382d-2dc9-4a60-b031-c845ebad0357.jpg?1783929341,Creature — Beast,Jesper Ejsing
+Crashing Footfalls,0,2019,1.67,#087500,https://cards.scryfall.io/normal/front/a/8/a8cca2a2-69e3-4136-936c-7a2774c19351.jpg?1783933099,Sorcery,Dan Murayama Scott
+Crash of Rhino Beetles,5,2018,0.32,#087500,https://cards.scryfall.io/normal/front/c/8/c87715d6-4ce1-43d8-9909-e1d80c2d099f.jpg?1783934334,Creature — Insect,Mike Burns
+Crash the Party,6,2022,0.43,#087500,https://cards.scryfall.io/normal/front/9/b/9bfaa187-580f-4bb7-bc9b-0d3998098833.jpg?1783923358,Instant,Ben Wootten
+Craterhoof Behemoth,8,2025,22.84,#087500,https://cards.scryfall.io/normal/front/2/7/276f5cee-a501-4658-bd4d-7a044bf1ccbc.jpg?1783907345,Creature — Beast,Magali Villeneuve
+Crazed Armodon,4,1997,0.35,#087500,https://cards.scryfall.io/normal/front/b/8/b83e4b36-57c1-493d-ab79-52075990b2d5.jpg?1783946619,Creature — Elephant,Gary Leach
+Cream of the Crop,2,2026,0.51,#087500,https://cards.scryfall.io/normal/front/9/4/943be0ee-cab1-4678-9ee0-960919ed519e.jpg?1783904547,Enchantment,Howard Lyon
+Creeperhulk,5,2017,0.28,#087500,https://cards.scryfall.io/normal/front/e/4/e450cbd1-1d08-44ab-be87-95674dfc96cf.jpg?1783936268,Creature — Plant Elemental,Ralph Horsley
+Creeping Corrosion,4,2011,5.2,#087500,https://cards.scryfall.io/normal/front/0/5/05d5a7b3-18b6-4b1d-85cc-2253e605390c.jpg?1783941377,Sorcery,Ryan Pancoast
+Creeping Renaissance,5,2018,1.14,#087500,https://cards.scryfall.io/normal/front/7/1/71569961-d56c-43f9-ae51-d86561419743.jpg?1783934291,Sorcery,Tomasz Jedruszek
+Crown of Skemfar,4,2021,1.56,#087500,https://cards.scryfall.io/normal/front/e/6/e6297586-8953-408e-a38c-2239d45807e1.jpg?1783928337,Enchantment — Aura,Jason Felix
+Crush of Wurms,9,2002,1.71,#087500,https://cards.scryfall.io/normal/front/3/2/32a924b3-3bd6-43ad-acbd-1303dd670db4.jpg?1783945113,Sorcery,Christopher Moeller
+Cryptolith Rite,2,2025,15.29,#087500,https://cards.scryfall.io/normal/front/0/a/0a4e707f-b760-434d-ba97-a0fe651f3f6a.jpg?1783908102,Enchantment,Zack Stella
+Crystalline Armor,4,2025,0.32,#087500,https://cards.scryfall.io/normal/front/2/5/2558ce86-ee30-4075-b991-bfb5f7513a5e.jpg?1783904813,Enchantment — Aura,Susumu Kuroi
+Cultivator Colossus,7,2025,6.67,#087500,https://cards.scryfall.io/normal/front/4/2/426ed66e-41b3-4e44-90a2-697aafaa8c5c.jpg?1783908104,Creature — Plant Beast,Antonio José Manzanedo
+Cultivator of Blades,5,2021,0.34,#087500,https://cards.scryfall.io/normal/front/c/2/c2e6e8a1-2e69-43de-964d-72f722439d4a.jpg?1783928317,Creature — Elf Artificer,Bastien L. Deharme
+Curator Beastie,6,2024,0.28,#087500,https://cards.scryfall.io/normal/front/8/3/83eafcd9-0918-43a8-a1be-13deec424235.jpg?1783909656,Creature — Beast,Nils Hamm
+Curious Altisaur,4,2023,4.25,#087500,https://cards.scryfall.io/normal/front/8/3/83fb87d8-d6f6-4cb0-aca1-49e6fcb181b1.jpg?1783913908,Creature — Dinosaur,Simon Dominic
+Curious Herd,4,2020,0.54,#087500,https://cards.scryfall.io/normal/front/5/a/5a20acbc-6ca8-4b0c-ab7e-4bb8d429336b.jpg?1783931210,Instant,Zoltan Boros
+Curse of Clinging Webs,3,2021,2.05,#087500,https://cards.scryfall.io/normal/front/5/e/5e2d349e-fe5f-4627-84b7-2f01982603d2.jpg?1783925375,Enchantment — Aura Curse,Marie Magny
+Curse of Predation,3,2017,0.29,#087500,https://cards.scryfall.io/normal/front/d/a/daf631ad-762f-4bec-9588-aca88507cad5.jpg?1783935521,Enchantment — Aura Curse,Jack Wang
+Cycle of Life,3,1996,0.72,#087500,https://cards.scryfall.io/normal/front/4/9/49b53861-97aa-4fff-9526-7d496d1717a4.jpg?1783947067,Enchantment,Chippy
+Cylian Sunsinger,2,2009,0.21,#d78f42,https://cards.scryfall.io/normal/front/9/0/90665426-118e-4f0b-8222-1b516678a2f5.jpg?1783942475,Creature — Elf Shaman,Jesper Ejsing
+Cytoplast Root-Kin,4,2006,0.47,#087500,https://cards.scryfall.io/normal/front/7/b/7b83483c-95d0-4db8-b4d4-c6db400ebc97.jpg?1783943413,Creature — Elemental Mutant,Thomas M. Baxa
+Daughter of Autumn,4,1995,0.79,#d78f42,https://cards.scryfall.io/normal/front/9/7/972e9c59-f340-414c-b55b-39d46dd97e8e.jpg?1783947280,Legendary Creature — Avatar,Margaret Organ-Kean
+Dauntless Dourbark,4,2007,4.19,#087500,https://cards.scryfall.io/normal/front/a/d/ad87cb77-6b49-4e93-9151-29f53b48dd4b.jpg?1783942866,Creature — Treefolk Warrior,Jeremy Jarvis
+Dawnglade Regent,7,2020,0.52,#087500,https://cards.scryfall.io/normal/front/d/2/d26025f0-72c0-4875-b2d7-916666b835d9.jpg?1783928798,Creature — Elk,YW Tang
+Dawnstrider,2,1999,5.48,#087500,https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg?1783945927,Creature — Dryad Spellshaper,rk post
+Daybreak Ranger // Nightfall Predator,3,2011,0.46,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Archer Ranger Werewolf // Creature — Werewolf,Steve Prescott
+Deadbridge Goliath,4,2012,0.15,#087500,https://cards.scryfall.io/normal/front/6/a/6ad03e99-25d3-4a09-819b-9192dfd8c9d2.jpg?1783940350,Creature — Insect,Chase Stone
+Deathcap Cultivator,2,2024,0.3,#d78f42,https://cards.scryfall.io/normal/front/1/7/17f9339a-d327-4239-a0d8-12f7ff58982b.jpg?1783909608,Creature — Human Druid,Karla Ortiz
+Deathgorge Scavenger,3,2023,0.3,#087500,https://cards.scryfall.io/normal/front/c/1/c175e50f-3858-43d7-8d4b-359ece106ccf.jpg?1783913861,Creature — Dinosaur,Tyler Jacobson
+Deathmist Raptor,3,2024,0.27,#087500,https://cards.scryfall.io/normal/front/e/d/ed6e6cf5-8fb7-4ba6-943a-e5aa14a3ee92.jpg?1783909607,Creature — Dinosaur Beast,Filip Burburan
+Death's Presence,6,2021,0.4,#087500,https://cards.scryfall.io/normal/front/f/d/fd24d5dc-a4c5-4821-92f6-52d1840be66a.jpg?1783925329,Enchantment,Ryan Barger
+Decree of Savagery,9,2021,0.33,#087500,https://cards.scryfall.io/normal/front/e/c/ec6d7db1-eeb2-4e9e-9a4f-488595bbcf1c.jpg?1783926194,Instant,Alex Horley-Orlandelli
+Deep Forest Hermit,5,2019,0.65,#087500,https://cards.scryfall.io/normal/front/3/2/3287775f-7bec-4e8f-bb8d-daf5ce92e4a8.jpg?1783933100,Creature — Elf Druid,Chris Seaman
+Deeproot Champion,2,2017,0.27,#087500,https://cards.scryfall.io/normal/front/e/a/ea1e7fed-e6f3-4445-8d01-dca3971f726f.jpg?1783935727,Creature — Merfolk Shaman,Raymond Swanland
+Deeproot Elite,2,2023,0.25,#087500,https://cards.scryfall.io/normal/front/9/9/991e24e5-8b37-4034-9be7-2fab5983ee7b.jpg?1783913861,Creature — Merfolk Warrior,Winona Nelson
+Deeproot Historian,4,2023,0.25,#087500,https://cards.scryfall.io/normal/front/f/f/fffb73ed-5748-4c2a-afe5-e29bf954b578.jpg?1783913907,Creature — Merfolk Druid,Stella Spente
+Deeproot Wayfinder,2,2023,0.24,#087500,https://cards.scryfall.io/normal/front/b/4/b4066d41-0eb5-4dfd-93ec-2f242c3a27a4.jpg?1783916970,Creature — Merfolk Scout,Anna Pavleeva
+Deepwood Elder,2,1999,0.39,#087500,https://cards.scryfall.io/normal/front/d/2/d2a1ed74-027e-4c8e-ac7e-e58c5fccff14.jpg?1783945927,Creature — Dryad Spellshaper,Greg Hildebrandt & Tim Hildebrandt
+Defense of the Heart,4,1999,24.45,#087500,https://cards.scryfall.io/normal/front/9/e/9e93381f-627f-41b6-b1b6-45d712a44d8e.jpg?1783946231,Enchantment,Rebecca Guay
+Defiler of Vigor,5,2022,3.19,#087500,https://cards.scryfall.io/normal/front/0/8/0896860c-d028-4193-89a5-97e05c12a1e7.jpg?1783921304,Creature — Phyrexian Wurm,Chase Stone
+Demolisher Spawn,7,2024,0.3,#087500,https://cards.scryfall.io/normal/front/1/6/16b97600-e4cf-4b9e-8f2d-2eb74298eb54.jpg?1783909657,Enchantment Creature — Horror,Nino Is
+Den Protector,2,2024,0.27,#087500,https://cards.scryfall.io/normal/front/c/2/c22d8b77-4274-48ae-a36f-5739d785b599.jpg?1783912992,Creature — Human Warrior,Viktor Titov
+Dense Foliage,3,1999,0.94,#087500,https://cards.scryfall.io/normal/front/f/6/f6232f04-cd4c-4889-97dc-cccc4a09f9c4.jpg?1783946162,Enchantment,Alan Rabinowitz
+Deranged Outcast,2,2012,0.18,#087500,https://cards.scryfall.io/normal/front/e/2/e2b35fee-8e24-4d89-ad77-d55d06bb1d7f.jpg?1783940809,Creature — Human Rogue,Nils Hamm
+Descendants' Path,3,2025,0.83,#087500,https://cards.scryfall.io/normal/front/6/e/6edb20a3-31f5-4bf9-a5e3-943d8d5a1def.jpg?1783904804,Enchantment,Pauline Voss
+Desert Warfare,4,2024,0.42,#087500,https://cards.scryfall.io/normal/front/b/c/bc7778d4-f1b6-4295-adb9-78ba7c185e9d.jpg?1783911419,Enchantment,Alexandre Honoré
+Devil Dinosaur,4,2026,41.78,#087500,https://cards.scryfall.io/normal/front/f/c/fcb4c268-441f-41cf-8c25-538eefc6a710.jpg?1783903041,Legendary Creature — Dinosaur,Wero Gallo
+Devoted Druid,2,2026,8.95,#087500,https://cards.scryfall.io/normal/front/1/e/1eb51419-726e-4b59-af0e-d1f07ae8ea5f.jpg?1783904336,Creature — Elf Druid,Ryan Riller
+Dictate of Karametra,5,2014,0.86,#087500,https://cards.scryfall.io/normal/front/d/5/d5114607-df8f-4e44-8ef5-b6af89964bbc.jpg?1783939415,Enchantment,Noah Bradley
+Dig Up,1,2021,0.39,#d78f42,https://cards.scryfall.io/normal/front/8/f/8f14c947-2452-4fd6-8f1a-391cf5898100.jpg?1783924813,Sorcery,Slawomir Maniak
+Diligent Zookeeper,4,2025,0.19,#087500,https://cards.scryfall.io/normal/front/2/1/21f52564-9820-42dc-a08d-459d51afc397.jpg?1783904946,Creature — Human Citizen Ally,Maojin Lee
+Dinosaur Egg,2,2023,0.39,#087500,https://cards.scryfall.io/normal/front/9/a/9afdb38b-cdb4-4f64-8fc7-2df666a9db1b.jpg?1783913908,Creature — Dinosaur Egg,Alessandra Pisano
+Dirtcowl Wurm,5,1997,2.31,#087500,https://cards.scryfall.io/normal/front/a/9/a9e2df7d-5d72-4a32-a453-6d8611f0d63c.jpg?1783946619,Creature — Wurm,Dan Frazier
+Disorienting Choice,4,2024,0.35,#087500,https://cards.scryfall.io/normal/front/a/7/a756a35d-a630-41a2-8b3d-6f1bafd7409a.jpg?1783909656,Sorcery,Mirko Failoni
+District Mascot,1,2025,0.38,#087500,https://cards.scryfall.io/normal/front/3/1/3171b16f-cd67-416d-be5e-5d9cccb8d0a0.jpg?1783907873,Creature — Dog Mount,Liiga Smilshkalne
+Dodgy Jalopy,3,2022,0.21,#087500,https://cards.scryfall.io/normal/front/9/b/9b5617c2-6d23-4bfb-bc1f-c27f0cfdb022.jpg?1783923358,Artifact — Vehicle,Sean Murray
+Doomskar Warrior,4,2023,0.24,#087500,https://cards.scryfall.io/normal/front/a/a/aa1db4e3-e98c-49af-8682-3b7aa20bc31e.jpg?1783916970,Creature — Human Warrior,Chris Rallis
+Dosan the Falling Leaf,3,2004,27.68,#087500,https://cards.scryfall.io/normal/front/f/f/ffb190db-48fc-4c39-ae9f-5e304eabb4f4.jpg?1783944291,Legendary Creature — Human Monk,Mark Zug
+Doubling Chant,6,2011,0.36,#087500,https://cards.scryfall.io/normal/front/f/7/f71dc232-9b7e-4c0e-ac05-8e48b4936aa9.jpg?1783941065,Sorcery,Wayne England
+Doubling Season,5,2024,35.06,#087500,https://cards.scryfall.io/normal/front/f/2/f2c4f80e-84a0-463b-82c3-5c6503809351.jpg?1783909062,Enchantment,Chuck Lukacs
+Dragonsguard Elite,2,2021,0.24,#087500,https://cards.scryfall.io/normal/front/6/5/658ec634-3eb2-4967-b938-d20d31ab77e3.jpg?1783927344,Creature — Human Druid,David Rapoza
+Dramatic Entrance,5,2008,1.22,#087500,https://cards.scryfall.io/normal/front/4/5/4562a300-8777-4a47-8650-8a2bc2678def.jpg?1783942744,Instant,Mike Dringenberg
+Druid of Purification,4,2021,1.02,#087500,https://cards.scryfall.io/normal/front/0/9/096c2b28-3e29-4c27-998d-51bff0ba96c5.jpg?1783926244,Creature — Human Druid,Jake Murray
+Druids' Repository,3,2012,3.23,#087500,https://cards.scryfall.io/normal/front/5/7/57e6fb62-7ee3-444d-8fd4-c1f44014a05c.jpg?1783940668,Enchantment,Daarken
+Dryad Arbor,0,2024,3.5,#087500,https://cards.scryfall.io/normal/front/e/3/e3ddbebf-72cd-4d1b-ba0d-d94934654ab7.jpg?1783909577,Land Creature — Forest Dryad,Eric Fortune
+Dryad of the Ilysian Grove,3,2023,10.07,#087500,https://cards.scryfall.io/normal/front/4/3/43be1363-7e73-4862-b45f-07f490ab46be.jpg?1783915427,Enchantment Creature — Nymph Dryad,Scott Murphy
+Dual Nature,6,2000,2.58,#087500,https://cards.scryfall.io/normal/front/6/8/6890e414-d7e1-4320-924c-083e65a2ae72.jpg?1783945773,Enchantment,Arnie Swekel
+Dubious Challenge,4,2016,0.09,#087500,https://cards.scryfall.io/normal/front/9/2/92965a78-277d-4a27-8174-fc2564bd1ee3.jpg?1783937180,Sorcery,Scott Murphy
+Dune Chanter,3,2024,2.13,#087500,https://cards.scryfall.io/normal/front/c/b/cbed084b-c0bc-4c05-9a89-ce4630f0897c.jpg?1783911963,Creature — Plant Druid,Dmitry Burmak
+Dungrove Elder,3,2011,0.79,#087500,https://cards.scryfall.io/normal/front/b/8/b8b4ebbf-1613-42a0-97ff-2f36dc8d984a.jpg?1783941061,Creature — Treefolk,Matt Stewart
+Dwynen- Gilt-Leaf Daen,4,2021,0.36,#087500,https://cards.scryfall.io/normal/front/2/e/2eb0f12b-9199-440d-9b85-831a5aec5dae.jpg?1783928317,Legendary Creature — Elf Warrior,Johannes Voss
+Earl of Squirrel,6,2017,3.53,#087500,https://cards.scryfall.io/normal/front/c/3/c3bbf567-bdb4-4f88-906c-eb1503c02d9f.jpg?1783935409,Creature — Squirrel Noble Advisor,Milivoj Ćeran
+Early Harvest,3,2005,1.19,#087500,https://cards.scryfall.io/normal/front/2/2/22113d08-ecc9-4efd-90f1-00d699582ec3.jpg?1783943938,Instant,Heather Hudson
+Earthbender Ascension,3,2025,1.84,#087500,https://cards.scryfall.io/normal/front/5/9/590a58ab-5e98-4031-8aa6-ce396dc1429f.jpg?1783904943,Enchantment,Logan Feliciano
+Earthcraft,2,1997,265.65,#087500,https://cards.scryfall.io/normal/front/9/d/9dda7531-82a1-4f49-8858-601ddbc6e2bc.jpg?1783946620,Enchantment,Randy Gallegos
+Earthen Ally,1,2025,0.24,#d78f42,https://cards.scryfall.io/normal/front/d/7/d7a0f2d9-efa4-4a53-a24b-36694457bd1c.jpg?1783904943,Creature — Human Soldier Ally,Boell Oyino
+Earthquake Dragon,15,2022,3.85,#087500,https://cards.scryfall.io/normal/front/b/f/bfedfd30-8075-429e-a0fa-4919920c8632.jpg?1783922715,Creature — Elemental Dragon,Johan Grenier
+Earth's Mightiest Heroes,6,2026,0.91,#087500,https://cards.scryfall.io/normal/front/b/3/b38b9bd6-1dd7-4bbc-8a82-ce391c1172e1.jpg?1783902919,Sorcery,Steve Morris
+Earth Surge,4,2006,1.53,#087500,https://cards.scryfall.io/normal/front/3/2/325503ee-ea62-459b-a58a-53fb3c1ef027.jpg?1783943493,Enchantment,Luca Zontini
+Ecological Appreciation,3,2021,0.68,#087500,https://cards.scryfall.io/normal/front/1/1/115f3d72-1aaf-4237-91b9-389256e5e5c8.jpg?1783927344,Sorcery,Lie Setiawan
+Eidolon of Blossoms,4,2023,3.45,#087500,https://cards.scryfall.io/normal/front/f/8/f882aa63-d43c-4359-9de6-77231500a08e.jpg?1783915427,Enchantment Creature — Spirit,Min Yum
+Eladamri- Korvecdal,3,2024,4.39,#087500,https://cards.scryfall.io/normal/front/d/f/dfdabdda-bd46-4ea2-8b37-5d7f6cec6aff.jpg?1783911264,Legendary Creature — Elf Warrior,Zoltan Boros
+Eladamri- Lord of Leaves,2,1997,74.08,#087500,https://cards.scryfall.io/normal/front/0/b/0b1689f3-9dfa-4525-90b3-7af15f7eb720.jpg?1783946619,Legendary Creature — Elf Warrior,Ron Chironna
+Eladamri's Vineyard,1,1997,4.09,#087500,https://cards.scryfall.io/normal/front/d/8/d8531643-5657-44b6-89d1-9cdf67ed09c4.jpg?1783946619,Enchantment,Ron Chironna
+Elanor Gardner,4,2023,4.56,#087500,https://cards.scryfall.io/normal/front/6/1/6165eb73-49a8-4337-aa5d-7d9d48b916c9.jpg?1783916222,Legendary Creature — Halfling Scout,Torgeir Fjereide
+Elder Druid,4,2001,0.26,#087500,https://cards.scryfall.io/normal/front/a/a/aa88ff5b-44df-40eb-b0bb-37936ae0d854.jpg?1783945432,Creature — Elf Cleric Druid,Alan Pollack
+Elder Gargaroth,5,2020,2.28,#087500,https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg?1783930678,Creature — Beast,Nicholas Gregory
+Elder of Laurels,3,2011,0.27,#087500,https://cards.scryfall.io/normal/front/3/2/32b82ef0-c974-4357-b21a-4c2a28ec7279.jpg?1783940921,Creature — Human Advisor,Terese Nielsen
+Elderscale Wurm,7,2012,2.9,#087500,https://cards.scryfall.io/normal/front/2/0/20f3f63d-0f04-4945-9895-940c916a2547.jpg?1783940473,Creature — Wurm,Richard Wright
+Eldritch Evolution,3,2025,4.0,#087500,https://cards.scryfall.io/normal/front/6/0/606caf13-c0d3-4a61-9a1a-32f13b6448ab.jpg?1783908101,Sorcery,Jason Rainville
+Elemental Bond,3,2025,4.24,#087500,https://cards.scryfall.io/normal/front/d/a/da25ea1d-2fa6-42ca-bd06-a2edeb300eb5.jpg?1783904849,Enchantment,Viacom
+Elemental Resonance,4,2006,2.51,#087500,https://cards.scryfall.io/normal/front/9/7/9757631a-c505-4a16-94c1-8bb609ce7bc5.jpg?1783943413,Enchantment — Aura,Mark Tedin
+Elemental Spectacle,6,2026,0.19,#087500,https://cards.scryfall.io/normal/front/b/0/b012cbef-c9bc-41ac-8318-f1687340c5fa.jpg?1783904602,Sorcery,Aldo Domínguez
+Elemental Teachings,5,2025,0.32,#087500,https://cards.scryfall.io/normal/front/c/a/cac8ac35-6860-4839-ab85-93d409206c08.jpg?1783904943,Instant — Lesson,Yoshioka
+Elephant Resurgence,2,2000,0.36,#087500,https://cards.scryfall.io/normal/front/2/2/22147f72-7ff8-40c4-9bdd-df41dce17dad.jpg?1783945773,Sorcery,DiTerlizzi
+Ellywick Tumblestrum,4,2021,0.36,#087500,https://cards.scryfall.io/normal/front/b/a/bab81bc0-0369-469e-9296-6d9681697b21.jpg?1783926464,Legendary Planeswalker — Ellywick,Anna Steinbauer
+Elven Chorus,4,2023,4.8,#087500,https://cards.scryfall.io/normal/front/6/1/616cfb94-3faf-44fe-bf04-e90643765e48.jpg?1783916271,Enchantment,Anato Finnstark
+Elven Riders,5,1994,9.31,#087500,https://cards.scryfall.io/normal/front/a/d/ad1d349b-b5ab-4b2b-9b39-f8d8f6374aa5.jpg?1783948048,Creature — Elf,Melissa A. Benson
+Elven Warhounds,4,1997,0.6,#087500,https://cards.scryfall.io/normal/front/2/9/29138c1e-11cb-488f-8e04-f5488e08a81e.jpg?1783946619,Creature — Dog,Kev Walker
+Elves of Deep Shadow,1,2024,17.12,#d78f42,https://cards.scryfall.io/normal/front/9/0/90438697-02be-4bb4-8ef3-8536c4fb0446.jpg?1783911038,Creature — Elf Druid,Julie Bell
+Elvish Archdruid,3,2024,0.44,#087500,https://cards.scryfall.io/normal/front/3/4/341da856-7414-403b-b2e3-4bebd58a5aa4.jpg?1783909059,Creature — Elf Druid,Karl Kopinski
+Elvish Archers,2,2001,0.49,#087500,https://cards.scryfall.io/normal/front/0/e/0e8411c9-4f6f-4301-ac36-386016a32852.jpg?1783945432,Creature — Elf Archer,Doug Chaffee
+Elvish Archivist,2,2023,0.34,#087500,https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg?1783915083,Creature — Elf Artificer,Mila Pesic
+Elvish Champion,3,2007,20.67,#087500,https://cards.scryfall.io/normal/front/a/d/ad42a3fd-21ae-49cf-b11d-3700835f2f96.jpg?1783943003,Creature — Elf,D. Alexander Gregory
+Elvish Clancaller,2,2018,0.43,#087500,https://cards.scryfall.io/normal/front/4/d/4da3b0bc-84da-4b85-992b-d0700c97157c.jpg?1783934537,Creature — Elf Druid,Matt Stewart
+Elvish Mystic,1,2024,33.39,#087500,https://cards.scryfall.io/normal/front/a/c/acbe8763-1373-49f8-b4a6-dd5984b1d25f.jpg?1783911494,Creature — Elf Druid,Ekaterina Burmak
+Elvish Piper,4,2018,3.19,#087500,https://cards.scryfall.io/normal/front/1/a/1a8e47b9-6735-4e46-b3fd-ac69edc39745.jpg?1783935132,Creature — Elf Shaman,Rebecca Guay
+Elvish Reclaimer,1,2019,6.05,#087500,https://cards.scryfall.io/normal/front/3/9/39c431d7-d94b-46c4-bb89-f3db56214ab4.jpg?1783932966,Creature — Elf Warrior,Victor Adame Minguez
+Elvish Soultiller,5,2003,0.41,#087500,https://cards.scryfall.io/normal/front/9/e/9e2c8de5-bc80-4fad-af09-6d0a639f6e18.jpg?1783944900,Creature — Elf Mutant,Ron Spears
+Elvish Spirit Guide,3,2022,33.23,#087500,https://cards.scryfall.io/normal/front/0/2/024110ee-5520-49f8-afab-54dcce87c650.jpg?1783924010,Creature — Elf Spirit,Yuko Shimizu
+Elvish Vanguard,2,2002,2.67,#087500,https://cards.scryfall.io/normal/front/4/5/455c6923-8d0e-4a7f-a5c0-add8db519ee3.jpg?1783945042,Creature — Elf Warrior,Glen Angus
+Elvish Warmaster,2,2021,3.06,#087500,https://cards.scryfall.io/normal/front/5/8/58da074a-a776-4e3f-be04-9e7f18320ae1.jpg?1783928215,Creature — Elf Warrior,Alexander Mokhov
+Emergent Woodwurm,7,2023,2.76,#087500,https://cards.scryfall.io/normal/front/a/f/af1b9c3d-5700-4298-a6a5-9379cad8726e.jpg?1783917277,Creature — Wurm,Mathias Kollros
+Emeritus of Abundance // Regrowth,3,2026,2.74,#087500,https://cards.scryfall.io/normal/front/a/c/ac095763-6f4e-4d4e-9c99-414646368f8d.jpg?1783903660,Creature — Elf Druid // Sorcery,Justyna Dura
+Emissary Green,5,2024,1.42,#087500,https://cards.scryfall.io/normal/front/3/2/323e9430-b87c-4b02-9ade-c4c65343147b.jpg?1783912584,Legendary Creature — Human Advisor,Heonhwa
+Emperor Crocodile,4,2005,0.14,#087500,https://cards.scryfall.io/normal/front/8/c/8c4bf2db-b282-4c9d-8afe-053204271996.jpg?1783943935,Creature — Crocodile,Kev Walker
+Emperor's Vanguard,4,2017,0.16,#087500,https://cards.scryfall.io/normal/front/f/1/f10c22b9-bdb7-4933-a58a-c53d040ae3bb.jpg?1783935726,Creature — Human Scout,Victor Adame Minguez
+Emrakul's Evangel,3,2016,0.33,#087500,https://cards.scryfall.io/normal/front/5/1/51c21822-972f-4c20-ac3b-80ba9af101c5.jpg?1783937449,Creature — Human Horror,Jason Felix
+Enchantress's Presence,3,2023,1.69,#087500,https://cards.scryfall.io/normal/front/3/f/3f50538b-f866-4e75-8856-2ad8af635011.jpg?1783915426,Enchantment,Rebecca Guay
+Endless Swarm,8,2005,1.53,#087500,https://cards.scryfall.io/normal/front/f/6/f64d9404-9685-495d-a591-63d6164a88a9.jpg?1783944139,Sorcery,Jeremy Jarvis
+Endless Wurm,5,1998,2.07,#087500,https://cards.scryfall.io/normal/front/5/3/53772435-e20e-4b9e-a2f1-c1c6a4dcac79.jpg?1783946317,Creature — Wurm,DiTerlizzi
+End-Raze Forerunners,8,2022,0.47,#087500,https://cards.scryfall.io/normal/front/4/7/47a74813-6d8b-4b11-8a5e-5b83d2d98c34.jpg?1783922408,Creature — Boar,Mathias Kollros
+Endurance,3,2026,3.94,#087500,https://cards.scryfall.io/normal/front/b/7/b770471c-1bf7-4179-8418-dcd790ca5405.jpg?1783911523,Creature — Elemental Incarnation,Paolo Parente
+Enduring Vitality,3,2024,16.03,#087500,https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg?1783909457,Enchantment Creature — Elk Glimmer,Valera Lutfullina
+Engulfing Slagwurm,7,2010,0.52,#087500,https://cards.scryfall.io/normal/front/8/a/8aeabc4a-7b4f-4e3d-bcc7-423bb703563a.jpg?1783941718,Creature — Wurm,Jaime Jones
+Enshrined Memories,1,2005,0.73,#087500,https://cards.scryfall.io/normal/front/a/e/aeefab6e-582a-42bb-bb27-d6aadd1d35c5.jpg?1783944185,Sorcery,Jeff Easley
+Epic Fight,3,2026,0.38,#087500,https://cards.scryfall.io/normal/front/d/5/d521b80b-4b0b-4d69-bd95-4c83feaf2145.jpg?1783902918,Sorcery,Wei Guan
+Epic Proportions,6,2018,0.28,#087500,https://cards.scryfall.io/normal/front/7/4/7412373a-da0f-4bec-866c-5e1087f49914.jpg?1783934288,Enchantment — Aura,Jesper Ejsing
+Epic Struggle,4,2002,8.19,#087500,https://cards.scryfall.io/normal/front/0/d/0dc71f6f-f831-409e-aafd-3fa82a318e72.jpg?1783945112,Enchantment,Greg Hildebrandt & Tim Hildebrandt
+Erhnam Djinn,4,2002,0.38,#087500,https://cards.scryfall.io/normal/front/5/b/5bcf61ba-37fd-4029-b299-add7cf9d70bc.jpg?1783945112,Creature — Djinn,Greg Staples
+Erithizon,4,1999,0.39,#087500,https://cards.scryfall.io/normal/front/e/c/ec4ea4e2-2102-4b99-bea5-6fc4203f2b26.jpg?1783945927,Creature — Beast,Scott M. Fischer
+Esika- God of the Tree // The Prismatic Bridge,3,2021,18.48,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Enchantment,Johannes Voss
+Esika's Chariot,4,2021,0.4,#087500,https://cards.scryfall.io/normal/front/a/8/a87606cc-fbf0-4e2c-9798-f1c935d0573d.jpg?1783928215,Legendary Artifact — Vehicle,Raoul Vitale
+Esper Origins // Summon: Esper Maduin,2,2025,0.82,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Enchantment Creature — Saga Elemental,Solan & Danciao
+Essence of the Wild,6,2011,0.47,#087500,https://cards.scryfall.io/normal/front/d/e/dec48cba-1b5d-44e7-9e25-16922dedb67d.jpg?1783940920,Creature — Avatar,Terese Nielsen
+Eternal Witness,3,2024,11.4,#087500,https://cards.scryfall.io/normal/front/3/6/362b72b5-4f63-43e2-bd09-4398b6aef5f3.jpg?1783913082,Creature — Human Shaman,Alexander Khabbazi
+Ethereal Elk,5,2019,0.21,#087500,https://cards.scryfall.io/normal/front/3/f/3f4d0ed2-3fc5-4cb0-b886-e30b21e76872.jpg?1783932915,Creature — Elk Spirit,Jason Felix
+Evercoat Ursine,5,2024,0.3,#087500,https://cards.scryfall.io/normal/front/b/2/b299d768-b171-47e5-b69d-82ce13917c43.jpg?1783910727,Creature — Elemental Bear,Allen Douglas
+Evolutionary Leap,2,2022,1.63,#087500,https://cards.scryfall.io/normal/front/4/d/4d007d3c-3356-4394-9bcd-2b2c1031c20b.jpg?1783923250,Enchantment,Chris Rahn
+Evolved Spinoderm,4,2023,0.2,#087500,https://cards.scryfall.io/normal/front/d/d/dd4bcb42-f5cf-410d-8f20-1006b0f92abe.jpg?1783918016,Creature — Phyrexian Beast,Svetlin Velinov
+Evolving Door,3,2022,0.24,#087500,https://cards.scryfall.io/normal/front/0/1/01bc3b04-46b7-43df-9b29-1502b9f18bbf.jpg?1783923104,Artifact,Drew Baker
+Experimental Lab // Staff Room,7,2024,0.31,#087500,https://cards.scryfall.io/normal/front/0/e/0ee64079-76f2-49da-bd62-3d22dc1ec0c0.jpg?1783909654,Enchantment — Room // Enchantment — Room,Arthur Yuan
+Experiment Twelve,4,2024,0.32,#087500,https://cards.scryfall.io/normal/front/7/d/7d76089e-b21a-4d89-9562-957c18474967.jpg?1783913042,Creature — Elf Lizard Warrior,Michele Giorgi
+Exploration,1,2023,31.97,#087500,https://cards.scryfall.io/normal/front/5/b/5b372045-a4a0-44c8-96ec-1e201d61ed26.jpg?1783918444,Enchantment,Lindsey Look
+Exploration Broodship,1,2025,3.78,#087500,https://cards.scryfall.io/normal/front/6/1/61596da3-2a0e-47d9-b707-8db4cce2479d.jpg?1783906063,Artifact — Spacecraft,Borja Pindado
+Exponential Growth,2,2021,0.53,#087500,https://cards.scryfall.io/normal/front/7/c/7c129bb7-9489-44bd-a46d-c5f738bf9d25.jpg?1783927343,Sorcery,Izzy
+Eyes of the Wisent,2,2007,0.57,#087500,https://cards.scryfall.io/normal/front/c/6/c6725b96-7390-4599-9d5f-ba08755605af.jpg?1783942865,Kindred Enchantment — Elemental,Aleksi Briclot
+Ezuri's Brigade,4,2010,0.19,#087500,https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg?1783941718,Creature — Elf Warrior,Nic Klein
+Ezuri's Predation,8,2024,2.27,#087500,https://cards.scryfall.io/normal/front/9/a/9a6cd6f6-ae6e-4a77-95ca-64c6882357d5.jpg?1783909607,Sorcery,Uriah Voth
+Ezzaroot Channeler,6,2021,1.37,#087500,https://cards.scryfall.io/normal/front/a/7/a7fd9ede-cc6e-4a96-934b-d91d4aa7fa0a.jpg?1783927590,Creature — Treefolk Druid,Kieran Yanner
+Fade from History,4,2022,3.85,#087500,https://cards.scryfall.io/normal/front/7/1/71f13f67-e852-4a6a-8f32-b16195e53ec3.jpg?1783920046,Sorcery,Alessandra Pisano
+Faerie Noble,3,1995,2.21,#087500,https://cards.scryfall.io/normal/front/0/0/00f8931e-6402-483c-a9e8-63ee344c36a7.jpg?1783947280,Creature — Faerie Noble,Susan Van Camp
+Fall of Gil-galad,2,2023,0.32,#087500,https://cards.scryfall.io/normal/front/f/b/fbaab2c0-ea18-4b2f-b75b-506cbbea97e1.jpg?1783916271,Enchantment — Saga,Craig Elliott
+Family's Favor,3,2022,1.92,#087500,https://cards.scryfall.io/normal/front/a/f/afb85bc6-7799-48c6-98c0-04dd7ced4058.jpg?1783923357,Enchantment,Alexander Mokhov
+Famished Worldsire,8,2025,2.58,#087500,https://cards.scryfall.io/normal/front/2/9/2934c9c8-d23a-462b-83d5-94e88c8663ac.jpg?1783905938,Creature — Leviathan,Kev Walker
+Fanatic of Rhonas,2,2024,11.62,#087500,https://cards.scryfall.io/normal/front/1/f/1f9fb33a-3b39-4aff-93b8-aedafe0ea694.jpg?1783911261,Creature — Snake Druid,Scott Murphy
+Fangorn- Tree Shepherd,7,2023,0.41,#087500,https://cards.scryfall.io/normal/front/0/f/0fb0f946-2127-4aa3-88ac-9bd2e94d8983.jpg?1783916269,Legendary Creature — Treefolk,Jesper Ejsing
+Fangren Firstborn,4,2004,2.46,#087500,https://cards.scryfall.io/normal/front/9/7/97d5fc3c-7f6b-42a5-a482-d789a2a421c7.jpg?1783944436,Creature — Beast,Tim Hildebrandt
+Farhaven Elf,3,2026,0.28,#087500,https://cards.scryfall.io/normal/front/0/0/007dc743-19e4-4086-8afe-364116b0c91c.jpg?1783904340,Creature — Elf Druid,Brandon Kitkouski
+Farseek,2,2026,3.26,#087500,https://cards.scryfall.io/normal/front/2/9/29951997-d769-457b-94ff-fadd5cbfbad5.jpg?1783903393,Sorcery,Gary Baseman
+Fated Intervention,5,2014,0.15,#087500,https://cards.scryfall.io/normal/front/6/2/622e1afc-0d06-4c01-abef-3b3e93bd21c3.jpg?1783939536,Instant,Svetlin Velinov
+Fauna Shaman,2,2022,2.96,#087500,https://cards.scryfall.io/normal/front/b/8/b8b906eb-3223-474c-9b74-eda2c280f9c5.jpg?1783920047,Creature — Elf Shaman,Nicholas Elias
+Feasting Hobbit,2,2023,0.4,#087500,https://cards.scryfall.io/normal/front/1/7/17662301-7284-40d4-af51-45a496c0eac0.jpg?1783916026,Creature — Halfling Citizen,Lorenzo Mastroianni
+Feasting Troll King,6,2019,0.47,#087500,https://cards.scryfall.io/normal/front/9/a/9a6bb435-1205-416a-a5a0-ca6d37b4dcb2.jpg?1783932612,Creature — Troll Noble,Nicholas Gregory
+Fecund Greenshell,5,2024,0.62,#087500,https://cards.scryfall.io/normal/front/8/0/80b3e815-0e2e-4325-b1d5-5531b7b92da6.jpg?1783910810,Creature — Elemental Turtle,Kisung Koh
+Fecundity,3,2024,7.18,#087500,https://cards.scryfall.io/normal/front/6/c/6c402380-2de7-4a47-993e-c365dc104dad.jpg?1783911036,Enchantment,Kathleen Neeley & AndWorld Design
+Feed the Pack,6,2012,0.46,#087500,https://cards.scryfall.io/normal/front/9/8/9831e3cc-659b-4408-b5d8-a27ae2738680.jpg?1783940809,Enchantment,Steve Prescott
+Feline Sovereign,3,2020,2.51,#087500,https://cards.scryfall.io/normal/front/8/4/84a9485a-d356-4cbe-b257-b62008a21328.jpg?1783930677,Creature — Cat,Dan Murayama Scott
+Feral Appetite,3,2026,0.4,#087500,https://cards.scryfall.io/normal/front/6/9/69dda877-c176-456c-8cd8-5a1ea288e4c9.jpg?1783903853,Enchantment,Michal Ivan
+Feral Encounter,2,2023,0.29,#087500,https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg?1783915082,Sorcery,Fajareka Setiawan
+Feral Hydra,1,2010,0.48,#087500,https://cards.scryfall.io/normal/front/b/3/b347b543-0363-4759-90c9-afb12ee52bf0.jpg?1783941904,Creature — Hydra Beast,Steve Prescott
+Feral Throwback,6,2003,0.39,#087500,https://cards.scryfall.io/normal/front/4/9/49e0c5e5-b293-419e-aac5-3b81af4b6498.jpg?1783944900,Creature — Beast,Carl Critchlow
+Ferrafor- Young Yew,7,2026,0.33,#087500,https://cards.scryfall.io/normal/front/d/6/d6313ef4-c1a0-4315-8db9-a3666e49daa8.jpg?1783904601,Legendary Creature — Treefolk Druid,Jesper Ejsing
+Fight for the Throne,2,2026,0.45,#087500,https://cards.scryfall.io/normal/front/6/d/6da747ef-4d8f-49a2-8682-52ab87e6ad6e.jpg?1783903281,Instant,Le Vuong
+Fight Rigging,3,2022,0.71,#087500,https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg?1783923103,Enchantment,Daarken
+Finale of Devastation,2,2023,52.79,#087500,https://cards.scryfall.io/normal/front/b/1/b10d99bf-b2ce-4443-b924-ff0eb8be1033.jpg?1783915632,Sorcery,Bayard Wu
+First Responder,4,2022,0.27,#087500,https://cards.scryfall.io/normal/front/3/6/3688a806-9bff-4106-a14e-81d00bc6c87c.jpg?1783923355,Creature — Ogre Citizen,Helge C. Balzer
+Flare of Cultivation,3,2024,0.61,#087500,https://cards.scryfall.io/normal/front/b/d/bda2fa87-81c0-41ac-8831-556ce392c058.jpg?1783911261,Sorcery,Billy Christian
+Flora Colossus,7,2026,0.49,#087500,https://cards.scryfall.io/normal/front/7/9/79543a40-2943-41c0-8def-773dbf4ce196.jpg?1783903095,Creature — Treefolk,Riccardo Federici
+Floral Evoker,3,2025,0.29,#087500,https://cards.scryfall.io/normal/front/4/4/4452f54b-1b44-4ccf-be99-7d3c2614d89a.jpg?1783907165,Creature — Snake Druid,Monztre
+Foe-Razer Regent,7,2015,0.36,#087500,https://cards.scryfall.io/normal/front/0/4/04a266c3-de47-4e94-bdc4-210e34981de3.jpg?1783938580,Creature — Dragon,Lucas Graciano
+Fog,1,2026,4.85,#087500,https://cards.scryfall.io/normal/front/9/2/92bfd2c6-2226-4f92-bb77-e614ad096996.jpg?1783903400,Instant,Caleb Meurer
+Food Chain,3,2022,42.69,#087500,https://cards.scryfall.io/normal/front/e/b/eb912458-e016-4ea2-a2ea-40ac1a57f8fb.jpg?1783921868,Enchantment,Daarken
+Forbidden Lore,3,1995,0.38,#087500,https://cards.scryfall.io/normal/front/5/f/5fc225cf-4fe2-4a5b-828e-ffcb99e404e8.jpg?1783947478,Enchantment — Aura,Christopher Rush
+Force of Savagery,3,2007,0.72,#087500,https://cards.scryfall.io/normal/front/b/3/b344511d-631e-4f1d-9d7d-d7c89a473d1b.jpg?1783943100,Creature — Elemental,Dan Murayama Scott
+Force of Vigor,4,2019,8.52,#087500,https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg?1783933099,Instant,Randy Vargas
+Forgotten Ancient,4,2026,0.37,#087500,https://cards.scryfall.io/normal/front/f/8/f8c9d744-8294-4747-ae7e-99be2b6e7479.jpg?1783903766,Creature — Elemental,Mark Tedin
+Forgotten Harvest,2,2000,0.27,#087500,https://cards.scryfall.io/normal/front/9/f/9fefbace-03cb-43db-a221-0be2b8784357.jpg?1783945773,Enchantment,DiTerlizzi
+Formidable Speaker,3,2026,8.15,#087500,https://cards.scryfall.io/normal/front/2/6/265522eb-4f6a-40e7-b374-3833fa63c80b.jpg?1783904430,Creature — Elf Druid,Aurore Folny
+Formless Genesis,3,2025,0.25,#087500,https://cards.scryfall.io/normal/front/b/2/b2222cae-2b12-4163-ab1b-7d315877ee8d.jpg?1783906034,Kindred Sorcery — Shapeshifter,Mark Poole
+Form of the Squirrel,1,2004,8.75,#087500,https://cards.scryfall.io/normal/front/2/2/2241203c-1219-4e75-9973-7e1a44885341.jpg?1783944241,Enchantment,Carl Critchlow
+For the Ancestors,3,2023,3.32,#087500,https://cards.scryfall.io/normal/front/0/d/0da1b0a5-b6ca-41f8-be1c-05a56383c9a9.jpg?1783915479,Instant,Hristo D. Chukov
+For the Common Good,1,2024,3.7,#087500,https://cards.scryfall.io/normal/front/3/e/3ec72a27-b622-47d7-bdf3-970ccaef0d2a.jpg?1783910810,Sorcery,Serena Malyon
+Foster,4,2013,0.27,#087500,https://cards.scryfall.io/normal/front/0/0/00f86a0b-0f46-4ce1-bbeb-7f46881e1627.jpg?1783939660,Enchantment,Carl Critchlow
+Fractal Harness,3,2026,0.29,#087500,https://cards.scryfall.io/normal/front/8/d/8d196dcf-80bc-4a0a-83c9-ae87da5e74bf.jpg?1783903766,Artifact — Equipment,Yeong-Hao Han
+Fraction Jackson,3,2004,0.58,#087500,https://cards.scryfall.io/normal/front/8/6/86d42015-6cab-485f-9266-428db0b2b773.jpg?1783944242,Creature — Human Hero,Mark Poole
+Freestrider Lookout,3,2024,0.35,#087500,https://cards.scryfall.io/normal/front/3/2/32370f05-52a2-405f-b2bb-1b8a9b0b69f8.jpg?1783911808,Creature — Human Rogue,Matt Zeilinger
+Frenzied Baloth,2,2025,1.54,#087500,https://cards.scryfall.io/normal/front/c/7/c72d85e9-a0bc-4f73-8d73-c58843577f4e.jpg?1783905939,Creature — Beast,Diana Franco
+Fresh Meat,4,2019,0.29,#087500,https://cards.scryfall.io/normal/front/7/8/78bbdc81-d47f-4f0a-b359-c146cc07931d.jpg?1783932747,Instant,Dave Allsop
+Freyalise- Llanowar's Fury,5,2023,3.67,#087500,https://cards.scryfall.io/normal/front/5/2/52311be7-b484-4b14-a091-904c6b0c83d1.jpg?1783915632,Legendary Planeswalker — Freyalise,Adam Paquette
+Froghemoth,5,2021,0.36,#087500,https://cards.scryfall.io/normal/front/7/2/728e9567-2585-4c03-99a5-3e84fd8044d2.jpg?1783926463,Creature — Frog Horror,Brent Hollowell
+Frontier Siege,4,2025,0.3,#087500,https://cards.scryfall.io/normal/front/f/4/f419710e-3a73-4db0-bf2e-e76730f22c4d.jpg?1783907046,Enchantment,James Ryman
+Fugitive Druid,4,1997,0.44,#087500,https://cards.scryfall.io/normal/front/a/f/afe165cd-8ef7-408e-ae56-3c6a0cc4e409.jpg?1783946618,Creature — Human Druid,Quinton Hoover
+Fugitive of the Judoon,5,2023,0.19,#087500,https://cards.scryfall.io/normal/front/e/1/e15f1891-4f80-4c68-8421-8e16ff8d6a6d.jpg?1783914644,Enchantment — Saga,Lie Setiawan
+Full Flowering,1,2019,1.67,#087500,https://cards.scryfall.io/normal/front/e/a/ea2e9f4c-b6b4-4199-93ae-10df75590715.jpg?1783932804,Sorcery,Sidharth Chaturvedi
+Fungal Behemoth,4,2007,0.61,#087500,https://cards.scryfall.io/normal/front/5/3/53c1910b-9475-4551-b9a0-4b24511a6f98.jpg?1783943141,Creature — Fungus,Mark Tedin
+Fungusaur,4,2003,0.32,#087500,https://cards.scryfall.io/normal/front/7/9/79324f73-25cd-477a-b4f0-fd3e1319e451.jpg?1783944678,Creature — Fungus Dinosaur,Heather Hudson
+Fungus Elemental,4,1997,0.67,#087500,https://cards.scryfall.io/normal/front/4/3/4336bfd1-27a4-414d-b6fe-f186a0563dc0.jpg?1783946719,Creature — Fungus Elemental,Scott M. Fischer
+Fungus Sliver,4,2021,0.7,#087500,https://cards.scryfall.io/normal/front/8/6/864a67e4-5deb-45d5-bd42-3078716e142b.jpg?1783927782,Creature — Fungus Sliver,Daniel Gelon
+Fyndhorn Elves,1,2026,39.26,#087500,https://cards.scryfall.io/normal/front/5/8/586986d4-0782-4c73-a928-90d7e5519d05.jpg?1783903407,Creature — Elf Druid,Julie Dillon
+Fynn- the Fangbearer,2,2023,53.88,#087500,https://cards.scryfall.io/normal/front/0/f/0fb05d34-05cb-4536-b7e6-2d526dc30a9f.jpg?1783914745,Legendary Creature — Human Warrior,Magali Villeneuve
+Gaea's Anthem,3,2007,0.51,#087500,https://cards.scryfall.io/normal/front/e/a/ea9e0de1-2299-4ff9-b49a-88535a96bda0.jpg?1783943137,Enchantment,Greg Staples
+Gaea's Avenger,3,1994,58.75,#087500,https://cards.scryfall.io/normal/front/3/9/39d763bd-b0a9-46ba-bcd2-9304063446f2.jpg?1783948366,Creature — Treefolk,Pete Venters
+Gaea's Blessing,2,2023,1.81,#087500,https://cards.scryfall.io/normal/front/3/c/3cb93d27-ca54-4d56-a55e-19cec740cd69.jpg?1783915184,Sorcery,Ryan Alexander Lee
+Gaea's Herald,2,2007,4.16,#087500,https://cards.scryfall.io/normal/front/8/9/89a60271-edfc-4bb1-83d5-4d6fa0403b19.jpg?1783943002,Creature — Elf,Jim Murray
+Gaea's Liege,6,1995,0.49,#087500,https://cards.scryfall.io/normal/front/4/d/4d9e1c1b-bc7c-41b8-a983-b1c60f558547.jpg?1783947818,Creature — Avatar,Dameon Willich
+Gaea's Revenge,7,2015,0.25,#087500,https://cards.scryfall.io/normal/front/5/0/50fad73f-c6eb-46d7-8971-9be4d7d7b75f.jpg?1783938322,Creature — Elemental,Kekai Kotaki
+Gaea's Will,0,2021,0.29,#087500,https://cards.scryfall.io/normal/front/4/8/488996b2-06c8-4866-bf0d-4664640c2be1.jpg?1783926830,Sorcery,Lucas Graciano
+Galadhrim Ambush,4,2023,4.96,#087500,https://cards.scryfall.io/normal/front/e/6/e69e06f0-6142-4f80-9208-362b3e74d51d.jpg?1783916026,Instant,John Di Giovanni
+Galadhrim Brigade,3,2023,13.15,#087500,https://cards.scryfall.io/normal/front/d/1/d1ac1534-ce78-467d-abf4-67a2e11cfac5.jpg?1783914198,Creature — Elf Soldier,Alexander Mokhov
+Galadriel- Gift-Giver,5,2023,6.4,#087500,https://cards.scryfall.io/normal/front/8/2/8229264e-af6c-4f1f-b86a-257889ace9ce.jpg?1783916216,Legendary Creature — Elf Noble,Alexander Mokhov
+Gala Greeters,2,2022,1.17,#087500,https://cards.scryfall.io/normal/front/3/c/3c1baaa2-bd0b-4627-b93a-0753e0acd0f2.jpg?1783923104,Creature — Elf Druid,Bud Cook
+Game Preserve,3,1999,0.6,#087500,https://cards.scryfall.io/normal/front/1/b/1bb62356-72bb-4dc1-a2f9-45a3aca62e41.jpg?1783945925,Enchantment,Luca Zontini
+Gamma Grotesque,3,2026,1.16,#087500,https://cards.scryfall.io/normal/front/7/1/717c33a4-e9f0-4df9-b484-103f77f557e8.jpg?1783903096,Creature — Gamma Horror Villain,Nino Is
+Gargos- Vicious Watcher,6,2019,1.17,#087500,https://cards.scryfall.io/normal/front/4/e/4e446e90-6e31-43ed-bcb1-a01422b503c0.jpg?1783932967,Legendary Creature — Hydra,Mathias Kollros
+Garruk- Caller of Beasts,6,2013,3.28,#087500,https://cards.scryfall.io/normal/front/a/9/a96d0c67-e9f4-46d9-bd74-13a8606fdfe3.jpg?1783939906,Legendary Planeswalker — Garruk,Karl Kopinski
+Garruk- Primal Hunter,5,2021,2.2,#087500,https://cards.scryfall.io/normal/front/7/9/79cfc0d7-fccb-47fb-87b6-08dd32528be6.jpg?1783927534,Legendary Planeswalker — Garruk,D. Alexander Gregory
+Garruk Relentless // Garruk- the Veil-Cursed,4,2025,1.4,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Planeswalker — Garruk // Legendary Planeswalker — Garruk,Eric Deschamps
+Garruk's Harbinger,3,2020,0.28,#087500,https://cards.scryfall.io/normal/front/9/e/9e0fa0b6-5f3f-4669-84e8-2c38c9593d88.jpg?1783930675,Creature — Beast,Lie Setiawan
+Garruk's Horde,7,2017,0.2,#087500,https://cards.scryfall.io/normal/front/9/b/9b501b60-e541-430e-b7e2-b51c287093db.jpg?1783936546,Creature — Beast,Steve Prescott
+Garruk's Warsteed,5,2020,0.2,#087500,https://cards.scryfall.io/normal/front/d/6/d6099863-8d3d-44bf-8d3b-dc3602119617.jpg?1783930617,Creature — Rhino,Ilse Gort
+Garruk- Unleashed,4,2020,0.86,#087500,https://cards.scryfall.io/normal/front/a/f/af2fdbec-bca2-4af5-9c2a-28b0b35b18a3.jpg?1783930676,Legendary Planeswalker — Garruk,Lie Setiawan
+Garruk Wildspeaker,4,2011,2.96,#087500,https://cards.scryfall.io/normal/front/0/8/08cf7ee6-ba30-42cd-a5b3-fd2fe7252f11.jpg?1783941195,Legendary Planeswalker — Garruk,Aleksi Briclot
+Gelatinous Genesis,1,2010,0.65,#087500,https://cards.scryfall.io/normal/front/1/e/1ea40dc5-de1b-4d2b-ae0e-df8e52876647.jpg?1783941966,Sorcery,Daniel Ljunggren
+Gemrazer,4,2020,0.54,#087500,https://cards.scryfall.io/normal/front/0/0/0095245c-a30e-4e2a-88c9-632c678e9f03.jpg?1783931035,Creature — Beast,Svetlin Velinov
+Generous Patron,3,2018,7.02,#087500,https://cards.scryfall.io/normal/front/5/9/59ea095b-af0e-4178-b6f4-816abb635fc0.jpg?1783934853,Creature — Elf Advisor,Lucas Graciano
+Genesis,5,2019,0.54,#087500,https://cards.scryfall.io/normal/front/9/b/9b741d88-513a-4f47-a4fd-af42c5e44b6d.jpg?1783933098,Creature — Incarnation,Alayna Danner
+Genesis Hydra,2,2024,0.37,#087500,https://cards.scryfall.io/normal/front/5/5/55502dd7-a92b-41bc-b6b1-8e0347649faf.jpg?1783911911,Creature — Plant Hydra,Donato Giancola
+Genesis Storm,6,2018,0.66,#087500,https://cards.scryfall.io/normal/front/0/6/066578ed-ffaf-473d-87b8-e614035748b6.jpg?1783934335,Sorcery,Mark Poole
+Genesis Wave,3,2024,0.35,#087500,https://cards.scryfall.io/normal/front/d/4/d46f7ddb-f986-4f1f-b096-ae1a02d0bdc8.jpg?1783909059,Sorcery,Arif Wijaya
+Germination Practicum,5,2026,9.55,#087500,https://cards.scryfall.io/normal/front/a/b/abe8332f-c76e-44e2-9427-d1228453abec.jpg?1783903658,Sorcery — Lesson,Johan Grenier
+Ghalta- Primal Hunger,12,2024,1.37,#087500,https://cards.scryfall.io/normal/front/6/a/6a9c39e4-a8cf-42dd-8d0e-45634b335546.jpg?1783909058,Legendary Creature — Elder Dinosaur,Chase Stone
+Ghalta- Stampede Tyrant,8,2023,26.39,#087500,https://cards.scryfall.io/normal/front/7/2/72e805e9-69be-45c1-aa04-f460641a0c1e.jpg?1783913747,Legendary Creature — Elder Dinosaur,Lars Grant-West
+Ghoultree,8,2012,0.43,#087500,https://cards.scryfall.io/normal/front/a/4/a413c65e-5965-429b-8c25-11f8b73cba03.jpg?1783940809,Creature — Zombie Treefolk,Volkan Baǵa
+Giant Adephage,7,2024,0.38,#087500,https://cards.scryfall.io/normal/front/8/9/893b22a7-b46c-4473-8d88-11ddf4406af1.jpg?1783909607,Creature — Insect,Christine Choi
+Giant Growth,1,2023,662.0,#087500,https://cards.scryfall.io/normal/front/6/5/65a168b8-285b-4725-a982-671557d4f0bc.jpg?1783916616,Instant,Wooden Cyclops
+Giant Inheritance,5,2023,0.47,#087500,https://cards.scryfall.io/normal/front/3/e/3e8d46e1-7aad-4e2b-82a5-af81cd6c8ae5.jpg?1783914986,Enchantment — Aura,Borja Pindado
+Giant-Man- Gargantuan Genius,5,2026,0.46,#087500,https://cards.scryfall.io/normal/front/4/5/45c6871c-0b6a-4ae1-a2b6-e1049b2225ea.jpg?1783903039,Legendary Creature — Human Scientist Hero,Vlad Petruchik
+Gigantiform,5,2009,0.25,#087500,https://cards.scryfall.io/normal/front/a/a/aa476306-9d6b-45ed-9e6c-fd4aee6592e7.jpg?1783942136,Enchantment — Aura,Justin Sweet
+Gigantomancer,8,2010,0.39,#087500,https://cards.scryfall.io/normal/front/a/f/af25e35c-d1a4-4c10-8574-82babaaac4fd.jpg?1783941966,Creature — Human Shaman,Chippy
+Gigantosaurus,5,2018,2.83,#087500,https://cards.scryfall.io/normal/front/c/1/c1db84d8-d426-4c0d-b44e-5be7b0f5f5bf.jpg?1783934535,Creature — Dinosaur,Jonathan Kuo
+Gilded Goose,1,2026,0.31,#087500,https://cards.scryfall.io/normal/front/5/e/5ea59511-24b1-4925-9948-9d4c0d27d1c5.jpg?1783903766,Creature — Bird,Lindsey Look
+Gilt-Leaf Archdruid,5,2008,10.04,#087500,https://cards.scryfall.io/normal/front/a/9/a913f9b3-abbd-424b-8dea-061e15364fb0.jpg?1783942779,Creature — Elf Druid,Steve Prescott
+Gladehart Cavalry,7,2018,0.31,#087500,https://cards.scryfall.io/normal/front/5/0/50558302-eea7-4d60-a65b-50386e73fccd.jpg?1783935093,Creature — Elf Knight,Steven Belledin
+Glademuse,3,2020,0.29,#087500,https://cards.scryfall.io/normal/front/8/9/89a40dc1-3bd8-4c7e-9446-5abc8c1f6995.jpg?1783931210,Creature — Beast,Ilse Gort
+Glimpse of Nature,1,2004,9.82,#087500,https://cards.scryfall.io/normal/front/1/d/1ddcd76b-a7a1-4ae6-bf4a-f929c6574bdc.jpg?1783944290,Sorcery,Shishizaru
+Glissa's Retriever,6,2023,0.56,#087500,https://cards.scryfall.io/normal/front/8/1/81836d7f-ba8d-4c52-8b1f-c86b422e23b5.jpg?1783918157,Creature — Phyrexian Beast,Josu Hernaiz
+Glissa Sunseeker,4,2003,0.9,#087500,https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg?1783944533,Legendary Creature — Elf Warrior,Brom
+Glistener Elf,1,2023,3.93,#087500,https://cards.scryfall.io/normal/front/9/7/97685645-43ab-4dd3-926a-f7439d7a31e6.jpg?1783917380,Creature — Phyrexian Elf Warrior,Steve Argyle
+Glistening Dawn,4,2023,0.21,#087500,https://cards.scryfall.io/normal/front/5/4/5443f4f6-a549-4912-a919-69e3570a9933.jpg?1783916968,Sorcery,Chris Ostrowski
+Glorious Sunrise,5,2021,2.2,#087500,https://cards.scryfall.io/normal/front/a/2/a2caf73e-c3eb-4fa8-996a-d3d18b2ffaeb.jpg?1783924813,Enchantment,Andreas Zafiratos
+Gnarled Professor,4,2021,0.2,#087500,https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg?1783927342,Creature — Treefolk Druid,Simon Dominic
+God-Eternal Rhonas,5,2019,5.12,#087500,https://cards.scryfall.io/normal/front/0/e/0eb444f0-69cc-47c8-8cd6-1f9edad5d903.jpg?1783933412,Legendary Creature — Zombie God,Lius Lasahido
+Goldvein Hydra,1,2026,2.83,#087500,https://cards.scryfall.io/normal/front/3/b/3baebc29-bc89-4b56-a821-b5d3ca0cd3b4.jpg?1783903766,Creature — Hydra,David Auden Nash
+Golgari Grave-Troll,5,2024,2.2,#087500,https://cards.scryfall.io/normal/front/d/3/d332acbc-6224-43bc-a509-3a7edc877423.jpg?1783913302,Creature — Troll Skeleton,Greg Hildebrandt
+Goliath Hatchery,6,2023,0.34,#087500,https://cards.scryfall.io/normal/front/0/e/0e1141ca-78c0-46e5-99f8-28069d69f23a.jpg?1783917918,Enchantment,Simon Dominic
+Goreclaw- Terror of Qal Sisma,4,2018,1.28,#087500,https://cards.scryfall.io/normal/front/3/6/36d4574a-3266-4497-b145-fb25820d8a7f.jpg?1783934534,Legendary Creature — Bear,Svetlin Velinov
+Gorm the Great,4,2018,0.43,#087500,https://cards.scryfall.io/normal/front/4/1/41603938-9527-42fc-a870-b662c3871ae3.jpg?1783934878,Legendary Creature — Giant Warrior,Johann Bodin
+Go-Shintai of Life's Origin,4,2022,8.41,#d78f42,https://cards.scryfall.io/normal/front/9/4/9476fe67-d2d3-4835-8ba6-2a17d18cc141.jpg?1783923985,Legendary Enchantment Creature — Shrine,Alexander Mokhov
+Gourmand's Talent,1,2024,0.37,#087500,https://cards.scryfall.io/normal/front/8/9/89670a1b-a6f1-491d-bbb4-92e3382da653.jpg?1783910728,Enchantment — Class,Fiona Hsieh
+Graham O'Brien,2,2023,0.27,#087500,https://cards.scryfall.io/normal/front/3/4/3467d66e-1a81-40d6-945a-f2c679d214d1.jpg?1783914644,Legendary Creature — Human Pilot,Tyukina Tatiana
+Grave Sifter,6,2017,12.53,#087500,https://cards.scryfall.io/normal/front/7/6/76e7bae6-8da3-4e9c-a3c9-dc4173334fca.jpg?1783936267,Creature — Elemental Beast,Jesper Ejsing
+Greatbow Doyen,5,2008,3.89,#087500,https://cards.scryfall.io/normal/front/a/0/a0f64e8a-2775-4f64-8728-36e7d613f54c.jpg?1783942779,Creature — Elf Archer,Steven Belledin
+Great Divide Guide,2,2025,1.25,#087500,https://cards.scryfall.io/normal/front/c/c/cc3063ec-5ea6-46c1-8331-c740cbaf6c76.jpg?1783904942,Creature — Human Scout Ally,Song Qijin
+Greater Good,4,2026,1.45,#087500,https://cards.scryfall.io/normal/front/9/d/9dd8b16f-3dfd-4e04-a2e9-ec87d0e007c9.jpg?1783903229,Enchantment,Eli Minaya
+Great Sable Stag,3,2009,0.33,#087500,https://cards.scryfall.io/normal/front/4/5/451c8a79-1e8a-437d-836f-31155914c551.jpg?1783942362,Creature — Elk,Matt Cavotta
+Greenbelt Rampager,1,2017,0.29,#087500,https://cards.scryfall.io/normal/front/f/3/f3f06124-bcc4-48c0-a7a6-a461c7485ecd.jpg?1783936744,Creature — Elephant,Filip Burburan
+Greener Pastures,3,1998,0.63,#087500,https://cards.scryfall.io/normal/front/5/5/55c3222e-ac18-4f57-9c9e-50deb0a69db3.jpg?1783946315,Enchantment,Heather Hudson
+Greensleeves- Maro-Sorcerer,5,2022,13.2,#087500,https://cards.scryfall.io/normal/front/0/9/0969d7f3-cec5-4118-adb1-ff957eedf6ab.jpg?1783921467,Legendary Creature — Elemental Sorcerer,Tuan Duong Chu
+Green Slime,3,2022,1.47,#087500,https://cards.scryfall.io/normal/front/b/1/b1beaaae-9406-4beb-8e74-d278822434c7.jpg?1783922499,Creature — Ooze,Igor Kieryluk
+Green Sun's Twilight,1,2023,0.36,#087500,https://cards.scryfall.io/normal/front/1/8/184c985d-cb70-41a7-9f66-3506708b7e26.jpg?1783918017,Sorcery,Yeong-Hao Han
+Green Sun's Zenith,1,2022,28.95,#087500,https://cards.scryfall.io/normal/front/7/0/70291c7b-a86f-4466-8502-c28765a89b2a.jpg?1783921868,Sorcery,David Rapoza
+Greenwarden of Murasa,6,2026,0.32,#087500,https://cards.scryfall.io/normal/front/2/4/24249343-8274-4c16-bb51-4d37b4b60741.jpg?1783904545,Creature — Elemental,Eric Deschamps
+Greenwheel Liberator,2,2017,0.1,#087500,https://cards.scryfall.io/normal/front/1/a/1ad9bf0f-4271-497f-8d67-3c7bf09342dc.jpg?1783936744,Creature — Elf Warrior,Todd Lockwood
+Grist- Voracious Larva // Grist- the Plague Swarm,1,2024,1.1,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Insect // Legendary Planeswalker — Grist,Chris Rahn
+Grothama- All-Devouring,5,2018,0.62,#087500,https://cards.scryfall.io/normal/front/a/b/ab8935b1-ec87-4330-9952-9ef8cd344531.jpg?1783934853,Legendary Creature — Wurm,Mark Behm
+Groundbreaker,3,2007,1.33,#087500,https://cards.scryfall.io/normal/front/f/4/f467cdea-6166-4289-918b-18f5038c94ed.jpg?1783943136,Creature — Elemental,Matt Cavotta
+Groundchuck & Dirtbag,6,2026,0.68,#087500,https://cards.scryfall.io/normal/front/1/5/1563592e-0f21-4488-a3ec-ca766386e423.jpg?1783904088,Legendary Creature — Ox Mole Mutant,Nicholas Gregory
+Ground Seal,2,2018,0.29,#087500,https://cards.scryfall.io/normal/front/c/4/c4e9995e-f26b-4638-b69d-a310f58f0331.jpg?1783934286,Enchantment,Charles Urbach
+Growing Rites of Itlimoc // Itlimoc- Cradle of the Sun,3,2023,8.8,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Enchantment // Legendary Land,Josu Hernaiz
+Growth-Chamber Guardian,2,2019,0.18,#087500,https://cards.scryfall.io/normal/front/0/f/0f97cdf4-231d-4bd0-af5e-bcb64ce1556c.jpg?1783933671,Creature — Elf Crab Warrior,Bram Sels
+Gruff Triplets,6,2023,0.37,#087500,https://cards.scryfall.io/normal/front/f/8/f8760ab9-ac76-4e2e-b82f-0ee2a6dc5634.jpg?1783915082,Creature — Satyr Warrior,Fajareka Setiawan
+Guardian Augmenter,3,2026,0.92,#087500,https://cards.scryfall.io/normal/front/7/8/78ba1a2a-a2dd-4e90-900e-1421b5e3924a.jpg?1783903765,Creature — Troll Wizard,Uros Sljivic
+Guardian Project,4,2024,14.92,#087500,https://cards.scryfall.io/normal/front/2/c/2c523ef7-d6c4-4887-9a4e-0c2bc6f63676.jpg?1783913302,Enchantment,Chris Rallis
+Gurzigost,5,2002,0.41,#087500,https://cards.scryfall.io/normal/front/f/4/f4e672c6-6ddc-4dd2-b4c7-5083d7566e87.jpg?1783945142,Creature — Beast,Scott M. Fischer
+Gutter Grime,5,2011,0.37,#087500,https://cards.scryfall.io/normal/front/a/9/a9d007a2-163d-4e09-a70b-280a6fa3203b.jpg?1783940917,Enchantment,Erica Yang
+Gwenna- Eyes of Gaea,3,2022,4.63,#087500,https://cards.scryfall.io/normal/front/7/e/7ee387b7-18e4-41b7-aefe-f2b5954e3051.jpg?1783920043,Legendary Creature — Elf Druid Scout,Steve Prescott
+Gyre Sage,2,2023,4.74,#087500,https://cards.scryfall.io/normal/front/b/e/be573ae7-967a-4b98-9058-ec3ff82ff63f.jpg?1783917142,Creature — Elf Druid,Tyler Jacobson
+Haldir- Lórien Lieutenant,1,2023,0.31,#087500,https://cards.scryfall.io/normal/front/4/4/440e5796-9264-4649-bf2f-58826dd0352c.jpg?1783916026,Legendary Creature — Elf Soldier,Syd Mills
+Hall of Gemstone,3,1996,14.38,#087500,https://cards.scryfall.io/normal/front/1/8/18e4551f-9f6c-4421-ad66-a270df6d3463.jpg?1783947064,World Enchantment,David A. Cherry
+Hamlet Vanguard,3,2021,0.19,#087500,https://cards.scryfall.io/normal/front/f/3/f31e108b-8cb5-4f30-b68b-274aa7ac2a81.jpg?1783924812,Creature — Human Warrior,PINDURSKI
+Harabaz Druid,2,2010,9.12,#087500,https://cards.scryfall.io/normal/front/7/8/78a538cf-2291-49aa-8429-17d97d454479.jpg?1783942044,Creature — Human Druid Ally,Wayne Reynolds
+Hardened Scales,1,2026,1.93,#087500,https://cards.scryfall.io/normal/front/9/9/99cfd1a8-49fd-4cc0-96f2-f9f159ce5d55.jpg?1783903765,Enchantment,Mark Winters
+Hardy of Myra's Marvels,4,2022,0.1,#087500,https://cards.scryfall.io/normal/front/8/0/80225482-6566-41fb-ade7-d9646426a4be.jpg?1783920553,Legendary Creature — Elf Performer,Gaboleps
+Harmonize,4,2025,24.53,#087500,https://cards.scryfall.io/normal/front/3/a/3aa569e7-0f65-47b7-851f-1377c39f71a9.jpg?1783905566,Sorcery,Terry Dodson
+Harold and Bob- First Numens,3,2024,0.34,#087500,https://cards.scryfall.io/normal/front/d/7/d730ac69-20ec-4ef3-85ee-a5fd24e5f277.jpg?1783912398,Legendary Creature — Treefolk Mutant,Andrea Piparo
+Harrow,3,2025,8.82,#087500,https://cards.scryfall.io/normal/front/5/b/5b9549ef-c4e8-4b2b-8f7d-19e64edcbe38.jpg?1783907446,Instant,Jordan Crane
+Haruspex,4,2022,0.38,#087500,https://cards.scryfall.io/normal/front/7/6/76e93d5d-c255-45a6-9217-84ac270740a7.jpg?1783920878,Creature — Tyranid,Helge C. Balzer
+Harvest Season,3,2021,0.91,#087500,https://cards.scryfall.io/normal/front/3/2/326b5fad-bb8d-4019-84a8-1a319a14962e.jpg?1783928314,Sorcery,Shreya Shetty
+Hatchery Sliver,2,2023,8.57,#087500,https://cards.scryfall.io/normal/front/1/5/15d2737c-d8ef-4b03-9316-be3f61288d3c.jpg?1783915479,Creature — Sliver,Svetlin Velinov
+Hatchery Spider,7,2018,0.38,#087500,https://cards.scryfall.io/normal/front/0/b/0b841904-202c-4b42-869a-e345112ab1c8.jpg?1783934150,Creature — Spider,Livia Prima
+Hauntwoods Shrieker,3,2024,0.99,#087500,https://cards.scryfall.io/normal/front/7/4/744ef0bc-9973-450e-a0c4-056d8244f357.jpg?1783909453,Creature — Beast Mutant,John Tedrick
+Healing Technique,4,2021,0.37,#087500,https://cards.scryfall.io/normal/front/3/3/33897125-a1df-4d7a-a45a-9c049cb662f6.jpg?1783927590,Sorcery,Michele Parisi
+Heartbeat of Spring,3,2020,3.43,#087500,https://cards.scryfall.io/normal/front/8/c/8ccb1e59-b858-42cf-93f8-8a3badb3eaad.jpg?1783930147,Enchantment,Rob Alexander
+Heartwood Storyteller,3,2021,4.48,#087500,https://cards.scryfall.io/normal/front/7/a/7a5e2f7a-8cfe-4d1b-a68d-7e6d8d10bd27.jpg?1783927781,Creature — Treefolk,Anthony S. Waters
+Hedge Shredder,4,2024,2.52,#087500,https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg?1783909453,Artifact — Vehicle,Cristi Balanescu
+Hei Bai- Forest Guardian,4,2025,6.36,#d78f42,https://cards.scryfall.io/normal/front/9/5/95a3fda4-64d6-4440-a77c-b249edca7860.jpg?1783904812,Legendary Creature — Bear Spirit,TAPIOCA
+Helix Pinnacle,1,2008,7.78,#087500,https://cards.scryfall.io/normal/front/9/c/9c1121df-b03e-4ad9-8c45-c3b4066e4a39.jpg?1783942680,Enchantment,Dan Murayama Scott
+Herald of the Pantheon,2,2023,4.72,#087500,https://cards.scryfall.io/normal/front/a/3/a360af3e-626d-46c9-99cf-6c85921f5d26.jpg?1783915425,Creature — Centaur Shaman,Jason A. Engle
+Herd Heirloom,2,2025,4.08,#087500,https://cards.scryfall.io/normal/front/a/8/a88c7713-b3a9-4685-b1d3-623d35b62365.jpg?1783907342,Artifact,Allen Morris
+Herd Migration,7,2022,0.23,#087500,https://cards.scryfall.io/normal/front/b/0/b0244a1f-e696-4223-9c14-22c2ca3cb738.jpg?1783921301,Sorcery,Eric Deschamps
+Heritage Druid,1,2016,3.25,#087500,https://cards.scryfall.io/normal/front/5/7/57948c65-4324-42bc-97ae-7cc700eb3817.jpg?1783937566,Creature — Elf Druid,Larry MacDougall
+Hermit Druid,2,2025,8.29,#087500,https://cards.scryfall.io/normal/front/3/9/39c66895-9c2d-49db-8261-e300a69b6cd5.jpg?1783908097,Creature — Human Druid,Bryan Sola
+Heroes' Bane,5,2024,0.16,#087500,https://cards.scryfall.io/normal/front/7/f/7f83195c-5150-4763-a2e1-5b109d185d55.jpg?1783908917,Creature — Hydra,Raymond Swanland
+Heroic Feast,3,2026,0.34,#087500,https://cards.scryfall.io/normal/front/3/2/32d05c3d-cf03-492e-a956-2e77c36e36c4.jpg?1783902917,Enchantment,Javier Charro
+Heroic Intervention,2,2023,16.33,#087500,https://cards.scryfall.io/normal/front/e/3/e32c67d1-187f-40df-b3b3-6036f5c92834.jpg?1783915629,Instant,James Ryman
+Heronblade Elite,3,2021,3.27,#087500,https://cards.scryfall.io/normal/front/3/6/36938a8e-8da0-4f27-86c3-6032aa7642b5.jpg?1783925374,Creature — Human Warrior,Yigit Koroglu
+Hero of Leina Tower,1,2014,0.22,#087500,https://cards.scryfall.io/normal/front/f/0/f022c0c3-6331-47be-b07f-9768930afd3a.jpg?1783939534,Creature — Human Warrior,Aaron Miller
+Hexdrinker,1,2019,5.13,#087500,https://cards.scryfall.io/normal/front/8/9/89f5cc05-5d9d-4709-b3c5-a6249c294acc.jpg?1783933097,Creature — Snake,Forrest Imel
+Hibernation's End,5,2006,0.99,#087500,https://cards.scryfall.io/normal/front/0/9/093ab03a-99e3-4596-a19a-033845f77a93.jpg?1783943329,Enchantment,Steven Belledin
+Hidden Gibbons,1,1999,10.86,#087500,https://cards.scryfall.io/normal/front/8/f/8f94da51-b4d9-4d79-9113-39f8f4a1be34.jpg?1783946229,Enchantment,Una Fricker
+Hidden Herd,1,1998,0.58,#087500,https://cards.scryfall.io/normal/front/2/0/20f07992-1f81-440a-a80a-164c44d0a471.jpg?1783946314,Enchantment,Andrew Robinson
+Hidden Path,6,1994,7.17,#087500,https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg?1783947932,Enchantment,Rob Alexander
+Hidden Predators,1,1998,0.48,#087500,https://cards.scryfall.io/normal/front/2/7/27f8ee86-a576-4f40-b165-be5b4558507d.jpg?1783946314,Enchantment,John Matson
+Hidden Stag,2,1998,0.47,#087500,https://cards.scryfall.io/normal/front/0/5/0501e115-ef61-4db5-bdb3-36dc4334431c.jpg?1783946312,Enchantment,Berry
+Hide in Plain Sight,4,2024,0.21,#087500,https://cards.scryfall.io/normal/front/d/8/d87c1ed8-c644-4ad5-9a21-c7bd9a7e8d20.jpg?1783912863,Sorcery,Vincent Christiaens
+Hierophant Bio-Titan,12,2022,1.54,#087500,https://cards.scryfall.io/normal/front/b/e/be8a8e26-39cb-440a-a428-58b49ff8d017.jpg?1783920876,Creature — Tyranid,David Astruga
+High Score,3,2026,1.35,#087500,https://cards.scryfall.io/normal/front/b/9/b9077ef5-d19a-4106-950b-bb49b3b37510.jpg?1783904165,Enchantment,Fahmi Fauzi
+Hit-Monkey,4,2026,5.22,#087500,https://cards.scryfall.io/normal/front/7/a/7a253dc9-1593-4914-90ca-309aa3aed53d.jpg?1783903038,Legendary Creature — Monkey Assassin,Peter Scanlan
+Hiveheart Shaman,4,2021,0.15,#087500,https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg?1783924812,Creature — Human Shaman,Eric Deschamps
+Holistic Wisdom,3,2001,1.69,#087500,https://cards.scryfall.io/normal/front/2/1/2134a564-b089-4049-bd9c-a3f10e072263.jpg?1783945217,Enchantment,Rebecca Guay
+Hollowhenge Overlord,6,2021,8.17,#087500,https://cards.scryfall.io/normal/front/d/a/dac9c33c-bff1-491a-b369-ad92395283a5.jpg?1783924994,Creature — Wolf,Milivoj Ćeran
+Honored Hierarch,1,2015,0.22,#087500,https://cards.scryfall.io/normal/front/7/6/769d0447-2c8f-41ef-a950-3a3022161c7f.jpg?1783938322,Creature — Human Druid,Matt Stewart
+Honored Hydra,6,2017,0.32,#087500,https://cards.scryfall.io/normal/front/2/1/21c33902-a06a-4321-bdf4-cea5494fda63.jpg?1783936473,Creature — Snake Hydra,Todd Lockwood
+Hooded Hydra,2,2024,1.55,#087500,https://cards.scryfall.io/normal/front/8/2/828f752e-cf94-4d0e-913d-aa425a005849.jpg?1783912991,Creature — Snake Hydra,Chase Stone
+Horizon Explorer,3,2025,2.49,#087500,https://cards.scryfall.io/normal/front/a/5/a5873a4d-ab6e-4dd2-9380-5eaa367a8396.jpg?1783906062,Creature — Insect Scout,Filip Burburan
+Hormagaunt Horde,1,2022,0.54,#087500,https://cards.scryfall.io/normal/front/6/a/6a623ab2-4cdf-4e2e-a14d-6a709cf34cf1.jpg?1783920876,Creature — Tyranid,Nikola Matkovic
+Hornet Nest,3,2025,0.44,#087500,https://cards.scryfall.io/normal/front/c/c/cc4693c6-f532-4726-b51a-21b04f820448.jpg?1783907044,Creature — Insect,Adam Paquette
+Hornet Queen,7,2024,0.39,#087500,https://cards.scryfall.io/normal/front/b/2/b2af9184-df81-413b-abcf-331c4471e6d4.jpg?1783909606,Creature — Insect,Jonathan Kuo
+Hot Springs,2,1995,0.63,#087500,https://cards.scryfall.io/normal/front/1/d/1d4fe072-81a7-424e-8d21-aaca010d5b1d.jpg?1783947476,Enchantment — Aura,Nicola Leonard
+Hour of Promise,5,2024,0.36,#087500,https://cards.scryfall.io/normal/front/6/a/6a40ae96-60a7-465f-b6d9-87e1e952dcf0.jpg?1783911910,Sorcery,Jonas De Ro
+Howling Moon,3,2021,1.54,#087500,https://cards.scryfall.io/normal/front/c/a/ca50b6a5-2e58-4de3-b0e1-0b33536f69a6.jpg?1783924810,Enchantment,Alessandra Pisano
+Howl of the Night Pack,7,2024,2.22,#087500,https://cards.scryfall.io/normal/front/f/7/f7f60ebd-4f6b-4562-8dec-d4b4e124cb73.jpg?1783911040,Sorcery,Johannes Voss
+Howlpack Piper // Wildsong Howler,4,2021,1.02,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Cristi Balanescu
+Huatli- Poet of Unity // Roar of the Fifth People,3,2023,1.01,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Warrior Bard // Enchantment — Saga,Tyler Jacobson
+Hua Tuo- Honored Physician,3,2013,0.6,#087500,https://cards.scryfall.io/normal/front/8/b/8bbdc7c5-71a1-4db8-98b2-8883bf648dca.jpg?1783939660,Legendary Creature — Human,Gao Jianzhang
+Hulk- Brutal Brawler,4,2026,40.71,#087500,https://cards.scryfall.io/normal/front/4/6/46d9f159-715e-4450-9f83-0fd050e2382e.jpg?1783902999,Legendary Creature — Gamma Berserker Hero,Myles Wohl
+Hulking Raptor,4,2023,2.66,#087500,https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg?1783913745,Creature — Dinosaur,Néstor Ossandón Leal
+Hulk- Strongest There Is,4,2026,4.42,#087500,https://cards.scryfall.io/normal/front/3/3/336a976b-c9db-4fcd-ac57-14eeb97962e8.jpg?1783903036,Legendary Creature — Gamma Berserker Hero,Julie Bell
+Hum of the Radix,4,2003,0.49,#087500,https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg?1783944533,Enchantment,John Avon
+Hungering Hydra,1,2020,3.35,#087500,https://cards.scryfall.io/normal/front/c/c/cce0561d-252a-499f-bfa0-9de59e4ea5ba.jpg?1783931163,Creature — Hydra,Daarken
+Hungry Lynx,2,2017,3.58,#087500,https://cards.scryfall.io/normal/front/c/0/c0ad6f84-8ede-4411-9979-cefee255fa70.jpg?1783935941,Creature — Cat,Shreya Shetty
+Hunted Troll,4,2013,0.65,#087500,https://cards.scryfall.io/normal/front/c/f/cfe19e16-33f6-4594-9dd3-2699a66ba0e8.jpg?1783939659,Creature — Troll Warrior,Greg Staples
+Hunter's Insight,3,2026,2.24,#087500,https://cards.scryfall.io/normal/front/f/6/f68090b1-77f0-49e7-8f2b-e78ce3cf8c86.jpg?1783903400,Instant,Jordan Speer
+Hunter's Prowess,5,2017,0.47,#087500,https://cards.scryfall.io/normal/front/6/4/64e0f9db-fd82-44d0-9d98-12275e2f05e8.jpg?1783935891,Sorcery,Greg Staples
+Hurricane,1,2007,0.49,#087500,https://cards.scryfall.io/normal/front/3/7/371d83e8-f514-433c-bc6a-e0eeef3fab2a.jpg?1783943001,Sorcery,John Howe
+Hurska Sweet-Tooth,3,2024,1.29,#d78f42,https://cards.scryfall.io/normal/front/0/0/00841818-d46a-4865-a41c-daf627d10d1b.jpg?1783908854,Legendary Creature — Bear,GOSSAN
+Hydra Broodmaster,6,2021,0.34,#087500,https://cards.scryfall.io/normal/front/5/b/5b11bb5a-66e3-4dc6-9df4-e1683c57e488.jpg?1783927533,Creature — Hydra,Vincent Proce
+Hydradoodle,2,2017,0.52,#087500,https://cards.scryfall.io/normal/front/7/6/760e482c-8725-410e-9d9f-c377649fe8bb.jpg?1783935407,Creature — Hydra Dog,Mathias Kollros
+Hydra Omnivore,6,2024,0.71,#087500,https://cards.scryfall.io/normal/front/a/6/a6abde7a-da2a-4631-9db6-9d0ffe1e1105.jpg?1783909604,Creature — Hydra,Svetlin Velinov
+Hypergenesis,0,2021,1.42,#087500,https://cards.scryfall.io/normal/front/6/5/65757321-2f26-44dc-a4f8-31d40fbf1681.jpg?1783927779,Sorcery,Ron Spears
+Hystrodon,5,2002,1.59,#087500,https://cards.scryfall.io/normal/front/1/c/1c964473-7c54-4c2d-a3eb-dba01c842103.jpg?1783945040,Creature — Beast,Anthony S. Waters
+Ice Storm,3,2024,3.83,#087500,https://cards.scryfall.io/normal/front/8/0/801185a5-78e0-4a5d-8aee-9a99f32ffbdc.jpg?1783909136,Sorcery,Kevin Sidharta
+Icetill Explorer,4,2025,14.76,#087500,https://cards.scryfall.io/normal/front/d/9/d9482aab-6ddf-48e1-84fa-b13d5ff81e69.jpg?1783905935,Creature — Insect Scout,Warren Mahy
+Ignoble Hierarch,1,2026,1.59,#d78f42,https://cards.scryfall.io/normal/front/e/8/e802cfe1-45e0-47cd-8745-363ccc0f2af8.jpg?1783911524,Creature — Goblin Shaman,Victor Adame Minguez
+Immaculate Magistrate,4,2020,1.23,#087500,https://cards.scryfall.io/normal/front/d/9/d9208db8-1ba5-4f9c-90a4-03e377ae6f86.jpg?1783928793,Creature — Elf Shaman,Jim Nelson
+Imperious Perfect,3,2021,0.93,#087500,https://cards.scryfall.io/normal/front/a/9/a93e9d33-0c5d-4890-a1aa-84f59af9d4fb.jpg?1783928314,Creature — Elf Warrior,Scott M. Fischer
+Impervious Greatwurm,10,2022,5.19,#087500,https://cards.scryfall.io/normal/front/a/1/a1aa77ae-f685-48ee-85dc-ba6084cd30ba.jpg?1783921867,Creature — Wurm,Simon Dominic
+Iname- Life Aspect,6,2004,0.45,#087500,https://cards.scryfall.io/normal/front/b/e/be027e3c-8891-46f0-bca7-d28a94ca281a.jpg?1783944289,Legendary Creature — Spirit,Justin Sweet
+Incoming!,8,1998,1.26,#087500,https://cards.scryfall.io/normal/front/5/7/573cf5e6-35ee-4eb6-990a-524ba7335797.jpg?1783946422,Sorcery,Quinton Hoover
+Increasing Savagery,4,2017,0.39,#087500,https://cards.scryfall.io/normal/front/c/5/c59b2ab3-c5e3-4599-9af0-3fa7a9544b97.jpg?1783936562,Sorcery,Steve Prescott
+Incubation Druid,2,2023,2.44,#087500,https://cards.scryfall.io/normal/front/b/3/b3d8c95e-09b9-46d6-80e9-95adb2c2ea9d.jpg?1783917139,Creature — Elf Druid,Daniel Ljunggren
+Indomitable Might,4,2021,0.74,#087500,https://cards.scryfall.io/normal/front/0/6/063b156b-7e05-4b49-a40a-54d713004ebf.jpg?1783926244,Enchantment — Aura,Svetlin Velinov
+Ineffable Blessing,2,2017,0.73,#087500,https://cards.scryfall.io/normal/front/6/5/65b25c91-892d-48d6-b42e-045d16d35316.jpg?1783935406,Enchantment,Milivoj Ćeran
+Ineffable Blessing,2,2017,0.56,#087500,https://cards.scryfall.io/normal/front/8/0/80545e3d-aff4-4501-a173-b7fa02ef816c.jpg?1783935407,Enchantment,Milivoj Ćeran
+Ineffable Blessing,2,2017,0.96,#087500,https://cards.scryfall.io/normal/front/b/d/bd0d8fc5-5841-403f-96db-2259048ff424.jpg?1783935407,Enchantment,Milivoj Ćeran
+Ineffable Blessing,2,2017,0.64,#087500,https://cards.scryfall.io/normal/front/b/e/be3e867a-208d-4a23-b8a8-a48866889a8d.jpg?1783935407,Enchantment,Milivoj Ćeran
+Ineffable Blessing,2,2017,0.76,#087500,https://cards.scryfall.io/normal/front/9/6/962272f8-7cea-4766-9980-da99a503ca6d.jpg?1783935406,Enchantment,Milivoj Ćeran
+Ineffable Blessing,2,2017,1.06,#087500,https://cards.scryfall.io/normal/front/9/1/91144259-d0a1-4e49-9f9b-9be7e36361d9.jpg?1783935406,Enchantment,Milivoj Ćeran
+Inexorable Blob,3,2016,0.28,#087500,https://cards.scryfall.io/normal/front/0/2/0210ff44-19d9-4d24-9d32-f1f9f219d9e0.jpg?1783937727,Creature — Ooze,Nils Hamm
+Innkeeper's Talent,2,2024,7.56,#087500,https://cards.scryfall.io/normal/front/9/4/941b0afc-0e8f-45f2-ae7f-07595e164611.jpg?1784634092,Enchantment — Class,Alix Branwyn
+Innocuous Researcher,4,2024,0.26,#087500,https://cards.scryfall.io/normal/front/8/4/84039704-d7c9-46fd-987e-4b93f812e803.jpg?1783913040,Creature — Centaur Detective,Simon Dominic
+Inscription of Abundance,2,2024,0.34,#087500,https://cards.scryfall.io/normal/front/d/0/d0429a79-af7a-4de1-be3a-773498cfdc22.jpg?1783909604,Instant,Zoltan Boros
+In Search of Greatness,2,2021,0.4,#087500,https://cards.scryfall.io/normal/front/a/c/ac0e50fa-5114-4f96-89f4-000906da7c76.jpg?1783928212,Enchantment,Ilse Gort
+Insist,1,2002,1.98,#087500,https://cards.scryfall.io/normal/front/4/8/48e1f72d-ef5e-4cea-a0ee-645570a36104.jpg?1783945142,Sorcery,Franz Vohwinkel
+Inspiring Call,3,2025,7.1,#087500,https://cards.scryfall.io/normal/front/1/9/199a94a3-41a5-4e4d-ad46-13eccca42a82.jpg?1783905159,Instant,Rian Gonzales
+Instrument of the Bards,1,2021,0.31,#087500,https://cards.scryfall.io/normal/front/d/5/d58486dc-3e78-4649-89c7-46f6210ff80f.jpg?1783926461,Legendary Artifact,Randy Gallegos
+Into the Wilds,4,2013,0.35,#087500,https://cards.scryfall.io/normal/front/e/c/ecfa6c8d-b5b5-4b68-9ad4-c9d8169659d6.jpg?1783939903,Enchantment,Véronique Meignaud
+Intrepid Paleontologist,2,2023,0.45,#087500,https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg?1783913745,Creature — Human Druid,Irina Nordsol
+Invasion of Ikoria // Zilortha- Apex of Ikoria,2,2023,12.39,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Legendary Creature — Dinosaur,Antonio José Manzanedo
+Invasion of Ixalan // Belligerent Regisaur,2,2023,0.36,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Creature — Dinosaur,Viktor Titov
+Invasion of Shandalar // Leyline Surge,5,2023,1.25,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Enchantment,Adam Paquette
+Invoke the Ancients,5,2022,0.17,#087500,https://cards.scryfall.io/normal/front/b/5/b5c02102-3be7-462f-ab9c-ff404255002d.jpg?1783923846,Sorcery,Filip Burburan
+Ironscale Hydra,5,2020,1.26,#087500,https://cards.scryfall.io/normal/front/0/2/0215cbbf-7bac-4ff7-bceb-23d728797848.jpg?1783931487,Creature — Hydra,Brian Valeza
+Isao- Enlightened Bushi,3,2005,0.83,#087500,https://cards.scryfall.io/normal/front/9/0/90334b59-73d8-4459-af59-d7a0539e2cc5.jpg?1783944184,Legendary Creature — Human Samurai,Christopher Moeller
+Ishkanah- Grafwidow,5,2024,0.63,#d78f42,https://cards.scryfall.io/normal/front/2/a/2a61bad1-f212-4d9b-8422-8ec548b8155c.jpg?1783909603,Legendary Creature — Spider,Christine Choi
+It's Clobberin' Time!,3,2026,0.36,#087500,https://cards.scryfall.io/normal/front/7/6/7665948b-23d0-4b06-a32a-bfab8009b04f.jpg?1783903278,Sorcery,Thomas Chamberlain-Keen
+Ivy Elemental,1,2009,0.22,#087500,https://cards.scryfall.io/normal/front/e/c/ec93afed-b75b-4ee3-97f4-2ceda78f679b.jpg?1783942318,Creature — Elemental,Ron Spencer
+Iwamori of the Open Fist,4,2005,0.53,#087500,https://cards.scryfall.io/normal/front/0/8/08c51fcf-ab5c-46fa-aa4b-14cd01c7a577.jpg?1783944184,Legendary Creature — Human Monk,Paolo Parente
+Jade Leech,4,2000,0.33,#087500,https://cards.scryfall.io/normal/front/3/3/3392171d-ed25-46a1-91cc-a4f24537617d.jpg?1783945674,Creature — Leech,John Howe
+Jadelight Ranger,3,2018,0.35,#087500,https://cards.scryfall.io/normal/front/9/f/9fe5c719-f20d-4469-9750-fb689d5f3fc8.jpg?1783935285,Creature — Merfolk Scout Ranger,Jason Rainville
+Jadelight Spelunker,1,2023,0.3,#087500,https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1783913744,Creature — Merfolk Scout,Izzy
+Jadzi- Oracle of Arcavios // Journey to the Oracle,8,2021,0.71,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Wizard // Sorcery,Chris Rahn
+Jaheira- Friend of the Forest,3,2022,12.7,#087500,https://cards.scryfall.io/normal/front/f/e/feb7ad1b-4466-48f7-b46d-cc83d4e22b51.jpg?1783922710,Legendary Creature — Human Elf Druid,Mila Pesic
+Jaheira's Respite,5,2022,1.0,#087500,https://cards.scryfall.io/normal/front/0/4/04ce0b01-7b52-4cb9-86ea-13395cf52312.jpg?1783922710,Instant,Mila Pesic
+Jamie McCrimmon,3,2023,0.24,#087500,https://cards.scryfall.io/normal/front/7/5/75cececf-8547-4355-972b-7ffbafcda1c2.jpg?1783914643,Legendary Creature — Human Warrior,Wangjie Li
+Jedit Ojanen of Efrava,6,2017,0.99,#087500,https://cards.scryfall.io/normal/front/a/b/aba23c7b-27c0-440b-b9b2-f1cd3892ba7b.jpg?1783935890,Legendary Creature — Cat Warrior,Carl Critchlow
+Jermane- Pride of the Circus,2,2022,0.16,#087500,https://cards.scryfall.io/normal/front/4/b/4b423097-a056-4673-bd7e-ca94a41a7aee.jpg?1783920552,Legendary Creature — Cat Performer,Alexander Mokhov
+Joiner Adept,2,2007,6.31,#087500,https://cards.scryfall.io/normal/front/6/1/61751365-3acf-4eb8-b1f9-358ebccccf94.jpg?1783943001,Creature — Elf Druid,Heather Hudson
+Jolrael- Empress of Beasts,5,2000,2.06,#087500,https://cards.scryfall.io/normal/front/a/d/ad0ea1c3-e920-467b-a3c8-a6b1097c3e8d.jpg?1783945773,Legendary Creature — Human Spellshaper,Matthew D. Wilson
+Jolrael- Mwonvuli Recluse,2,2024,0.22,#087500,https://cards.scryfall.io/normal/front/1/8/188f9016-275f-4060-8b11-9cdeef3759bd.jpg?1783912990,Legendary Creature — Human Druid,Izzy
+Joraga Treespeaker,1,2023,12.81,#087500,https://cards.scryfall.io/normal/front/7/6/76d71b38-c770-4d06-aa03-73d5e8381b9d.jpg?1783916623,Creature — Elf Druid,Aya Kakeda
+Joraga Warcaller,1,2017,14.76,#087500,https://cards.scryfall.io/normal/front/f/a/fa125071-ced8-4ccc-bbff-a2cbff13b9d2.jpg?1783936257,Creature — Elf Warrior,Steven Belledin
+Jorn- God of Winter // Kaldring- the Rimestaff,3,2021,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Snow Creature — God // Legendary Snow Artifact,Magali Villeneuve
+Journey for the Elixir,3,2018,0.27,#087500,https://cards.scryfall.io/normal/front/3/d/3da5b115-84b5-4eb3-bbef-e5024601ebc8.jpg?1783934623,Sorcery,Qiu De En
+Journey to the Lost City,4,2022,0.24,#087500,https://cards.scryfall.io/normal/front/9/6/967b19ce-062d-470c-8716-425a8dec0e18.jpg?1783922498,Enchantment,Alayna Danner
+Jubilation,6,2026,0.34,#087500,https://cards.scryfall.io/normal/front/a/8/a8eef44d-113c-428f-89e1-821418def041.jpg?1783904601,Creature — Elemental Incarnation,Vincent Christiaens
+Jugan Defends the Temple // Remnant of the Rising Star,3,2022,1.24,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Dragon Spirit,Daniel Ljunggren
+Jugan- the Rising Star,6,2017,0.3,#087500,https://cards.scryfall.io/normal/front/d/8/d897caab-3720-4f1a-bf38-4ba266352567.jpg?1783935518,Legendary Creature — Dragon Spirit,Filip Burburan
+Jumbo Cactuar,7,2025,3.83,#087500,https://cards.scryfall.io/normal/front/d/b/db01c222-8795-47e9-a789-e7f749a3ee7d.jpg?1783906585,Creature — Plant,Jason Kiantoro
+Jungle Patrol,4,1996,0.89,#d78f42,https://cards.scryfall.io/normal/front/9/1/91c343b8-bbfd-4bc5-b80a-4bc4565cdd40.jpg?1783947064,Creature — Human Soldier,Mark Poole
+Kalonian Behemoth,7,2009,0.34,#087500,https://cards.scryfall.io/normal/front/7/7/77064471-d0c1-4988-8c47-f767bf9635f3.jpg?1783942361,Creature — Beast,Daarken
+Kalonian Hydra,5,2023,6.25,#087500,https://cards.scryfall.io/normal/front/1/d/1d21ae20-2ef5-4dc0-aced-97497e6a8025.jpg?1783917137,Creature — Hydra,Chris Rahn
+Kalonian Twingrove,6,2014,0.47,#087500,https://cards.scryfall.io/normal/front/d/a/dabe0865-5420-463e-9138-ccd805be8b31.jpg?1783939166,Creature — Treefolk Warrior,Todd Lockwood
+Kamahl- Fist of Krosa,6,2023,0.63,#087500,https://cards.scryfall.io/normal/front/c/9/c960672d-06ad-4d41-8904-9c007f824756.jpg?1783918442,Legendary Creature — Human Druid,Matthew D. Wilson
+Kamahl- Heart of Krosa,8,2020,3.16,#087500,https://cards.scryfall.io/normal/front/4/c/4c3560ae-b1f6-4269-a9eb-1a45247b6232.jpg?1783928792,Legendary Creature — Human Druid,Kekai Kotaki
+Kamahl's Druidic Vow,2,2018,1.01,#087500,https://cards.scryfall.io/normal/front/b/f/bf95ef60-e67b-466d-a6cb-d487ffa88b72.jpg?1783934979,Legendary Sorcery,Noah Bradley
+Kamahl's Will,4,2020,0.34,#087500,https://cards.scryfall.io/normal/front/5/1/51fe007f-fddf-4b3a-b336-0a88df95cb14.jpg?1783928792,Instant,Nicholas Gregory
+Kami of Transience,2,2022,0.29,#087500,https://cards.scryfall.io/normal/front/7/d/7d038a59-e589-45f4-b5ef-6d2f9875d560.jpg?1783923846,Creature — Spirit,Steve Prescott
+Karvanista- Loyal Lupari // Lupari Shield,5,2023,0.34,#087500,https://cards.scryfall.io/normal/front/c/a/ca1cedd8-98d3-408f-8de8-fa682ab0227c.jpg?1783914648,Legendary Creature — Alien Dog Soldier // Sorcery — Adventure,Erion Makuo
+Katabatic Winds,3,1997,0.99,#087500,https://cards.scryfall.io/normal/front/9/7/97b34ce8-1eb2-44eb-813a-09d0308e27a0.jpg?1783946982,Enchantment,Gary Gianni
+Kavu Lair,3,2000,1.17,#087500,https://cards.scryfall.io/normal/front/f/4/f4581b53-23a0-4ca6-a77c-97d79e7a6570.jpg?1783945675,Enchantment,Chippy
+Kavu Mauler,6,2001,0.29,#087500,https://cards.scryfall.io/normal/front/7/9/79adc3af-5fa3-4cb6-9bbc-52ede0c69263.jpg?1783945340,Creature — Kavu,Daren Bader
+Kavu Titan,2,2000,1.29,#087500,https://cards.scryfall.io/normal/front/2/c/2c5fb86d-1d9a-4da2-bb5b-4266faa20197.jpg?1783945674,Creature — Kavu,Todd Lockwood
+Kazandu Mammoth // Kazandu Valley,3,2020,0.36,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Elephant // Land,Grzegorz Rutkowski
+Kazandu Tuskcaller,2,2021,0.23,#087500,https://cards.scryfall.io/normal/front/f/5/f5453591-6377-40de-892c-e8dd46687d11.jpg?1783927532,Creature — Human Shaman,Mike Bierek
+Keen-Eyed Curator,2,2024,1.53,#087500,https://cards.scryfall.io/normal/front/8/c/8cf33d80-0704-4dc4-8e8d-1dcbcbc35add.jpg?1783910807,Creature — Raccoon Scout,PINDURSKI
+Keeper of Progenitus,4,2008,1.61,#087500,https://cards.scryfall.io/normal/front/b/c/bcb023a2-e929-47e9-bd58-cbc6f241e7a4.jpg?1783942553,Creature — Elf Druid,Kev Walker
+Kessig Cagebreakers,5,2021,0.32,#087500,https://cards.scryfall.io/normal/front/e/9/e9bf3f93-a06f-4364-bb8e-b2b1eb77dcc3.jpg?1783925328,Creature — Human Rogue,Wayne England
+Khalni Hydra,8,2010,13.11,#087500,https://cards.scryfall.io/normal/front/7/d/7d27a00e-4402-4410-bab7-ccb34a0de72f.jpg?1783941964,Creature — Hydra,Todd Lockwood
+Kianne- Dean of Substance // Imbraham- Dean of Theory,3,2021,0.16,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elf Druid // Legendary Creature — Bird Wizard,Ryan Pancoast
+Kibo- Uktabi Prince,3,2022,12.77,#d78f42,https://cards.scryfall.io/normal/front/8/b/8b71345a-c3e8-4b35-beb7-6347e41d7626.jpg?1783919180,Legendary Creature — Monkey Noble,Zoltan Boros
+Killer Bees,3,1994,47.27,#087500,https://cards.scryfall.io/normal/front/2/e/2e30b5ff-1239-4c4d-ac7c-554ecf8e1e27.jpg?1783948046,Creature — Insect,Phil Foglio
+Killer Cosplay,1,2022,0.16,#087500,https://cards.scryfall.io/normal/front/9/5/95c0ac1f-8e40-427e-832c-4d1c6d2ce41c.jpg?1783920552,Artifact — Equipment,Leonardo Santanna
+Killer Service,3,2024,0.37,#087500,https://cards.scryfall.io/normal/front/b/8/b86b0177-0533-4b5a-9da7-1e11d398d828.jpg?1783912990,Enchantment,Simon Dominic
+Kindred Summons,7,2026,0.55,#087500,https://cards.scryfall.io/normal/front/3/4/3485e240-4957-421b-86f4-2aa494563747.jpg?1783904547,Instant,Ryan Pancoast
+Kinetic Ooze,1,2026,0.37,#087500,https://cards.scryfall.io/normal/front/f/1/f18ee3a2-997e-47e6-96b9-7438307f4bc5.jpg?1783903853,Creature — Ooze,Raph Lomotan
+Knickknack Ouphe,1,2023,0.33,#087500,https://cards.scryfall.io/normal/front/0/8/08fe7e9c-7c3b-435f-bc0d-e380e6b852c0.jpg?1783914984,Creature — Ouphe,Iris Compiet
+Kodama of the Center Tree,5,2005,0.38,#087500,https://cards.scryfall.io/normal/front/6/b/6b9264c5-1ecd-48cc-a12d-d4bd8050cfae.jpg?1783944184,Legendary Creature — Spirit,Jim Murray
+Kodama of the East Tree,6,2020,3.14,#087500,https://cards.scryfall.io/normal/front/a/f/af5105ee-09e2-4344-ab39-00f0e9034c47.jpg?1783928789,Legendary Creature — Spirit,Daarken
+Kodama of the North Tree,5,2004,0.88,#087500,https://cards.scryfall.io/normal/front/2/d/2d9b5c33-63c4-4ddd-9f04-37bb36970b43.jpg?1783944287,Legendary Creature — Spirit,Shishizaru
+Kodama of the South Tree,4,2004,0.76,#087500,https://cards.scryfall.io/normal/front/1/2/120c05f1-5ec3-4a0f-8628-6919e393104a.jpg?1783944287,Legendary Creature — Spirit,Ron Spears
+Kodama of the West Tree,3,2022,23.99,#087500,https://cards.scryfall.io/normal/front/e/f/ef1e1dff-b559-441d-8df3-b6a418066aca.jpg?1783923845,Legendary Creature — Spirit,Daarken
+Kodama's Reach,3,2025,8.61,#087500,https://cards.scryfall.io/normal/front/f/9/f9fa4a5a-4d9b-41c5-a86e-d0e7230d6e92.jpg?1783905089,Sorcery — Arcane,Mizutametori
+Kogla- the Titan Ape,6,2020,3.28,#087500,https://cards.scryfall.io/normal/front/3/c/3c35ca79-eb72-427a-a8ed-404b2214389a.jpg?1783931034,Legendary Creature — Ape,Chris Rahn
+Kolvori- God of Kinship // The Ringhart Crest,4,2021,0.37,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact,Grzegorz Rutkowski
+Kona- Rescue Beastie,4,2024,1.03,#087500,https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg?1783909453,Legendary Creature — Beast Survivor,Brian Valeza
+Kosei- Penitent Warlord,3,2022,0.26,#087500,https://cards.scryfall.io/normal/front/8/2/82291f66-f4f0-4542-992e-8342e90033da.jpg?1783923988,Legendary Creature — Ogre Samurai,Matt Stewart
+Kraven's Last Hunt,4,2025,0.24,#087500,https://cards.scryfall.io/normal/front/d/0/d0c18ffe-a2b9-40df-a6b4-a9381e6dc467.jpg?1783905327,Enchantment — Saga,Bill Sienkiewicz
+Krosan Beast,4,2001,5.02,#087500,https://cards.scryfall.io/normal/front/a/f/af822507-fd4c-454b-ab07-106c81c535bf.jpg?1783945217,Creature — Squirrel Beast,Kev Walker
+Krosan Cloudscraper,10,2024,0.23,#087500,https://cards.scryfall.io/normal/front/c/1/c1fab763-4e62-418d-b3a6-77c52bf21f23.jpg?1783912991,Creature — Beast Mutant,Ron Spears
+Krosan Colossus,9,2024,0.23,#087500,https://cards.scryfall.io/normal/front/4/f/4f3c1e1a-bd75-4bfb-b44b-05b94f64c634.jpg?1783912990,Creature — Beast,Kev Walker
+Krosan Grip,3,2021,2.03,#087500,https://cards.scryfall.io/normal/front/4/a/4a8b631f-7b03-441a-b551-59236d79804c.jpg?1783924576,Instant,Riot Games
+Kura- the Boundless Sky,5,2022,2.49,#087500,https://cards.scryfall.io/normal/front/0/6/06b25752-26be-4189-bc8b-828db6f0e612.jpg?1783923843,Legendary Creature — Dragon Spirit,Donato Giancola
+Kurbis- Harvest Celebrant,2,2021,0.46,#087500,https://cards.scryfall.io/normal/front/5/e/5ea94e69-36f0-47a6-b7f7-1379625a6955.jpg?1783925374,Legendary Creature — Treefolk,Irvin Rodriguez
+Lady Zhurong- Warrior Queen,5,1999,115.61,#087500,https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg?1783946101,Legendary Creature — Human Soldier Warrior,Miao Aili
+Last March of the Ents,8,2023,29.14,#087500,https://cards.scryfall.io/normal/front/7/f/7f1b99e0-ffb7-4f98-8ee5-4357bb79dd2e.jpg?1783916273,Sorcery,John Tedrick
+Lasyd Prowler,4,2025,0.21,#087500,https://cards.scryfall.io/normal/front/c/7/c7f5c8ef-8e9e-4264-a7d2-126a30a5d341.jpg?1783907339,Creature — Snake Ranger,Anna Pavleeva
+Lattice Library,2,2026,0.26,#087500,https://cards.scryfall.io/normal/front/5/1/51aa3511-e588-4b40-b98c-c5dc3a05bb2d.jpg?1783903852,Enchantment,Constantin Marin
+Leaf-Crowned Elder,4,2008,10.4,#087500,https://cards.scryfall.io/normal/front/c/6/c666dc97-8780-4982-b9e7-7d4a358f922c.jpg?1783942777,Creature — Treefolk Shaman,Wayne Reynolds
+Leaf-Crowned Visionary,2,2022,4.91,#087500,https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg?1783921299,Creature — Elf Druid,Anna Steinbauer
+Leatherhead- Iron Gator,7,2026,0.37,#087500,https://cards.scryfall.io/normal/front/c/0/c0cacd61-bdce-46c6-ac7f-b084987d9aec.jpg?1783904165,Legendary Creature — Crocodile Mutant Rogue,Andrey Kuzinskiy
+Leatherhead- Swamp Stalker,4,2026,0.69,#087500,https://cards.scryfall.io/normal/front/b/1/b1f6b5b5-12ca-468d-bc53-dd0cde60e7b6.jpg?1783904088,Legendary Creature — Crocodile Mutant Rogue,Lie Setiawan
+Leela- Sevateem Warrior,4,2023,0.25,#087500,https://cards.scryfall.io/normal/front/f/5/f5a4e5b5-70c8-4488-9e7d-7d68fe8219d7.jpg?1783914642,Legendary Creature — Human Warrior,Irina Nordsol
+Legolas Greenleaf,3,2023,0.36,#087500,https://cards.scryfall.io/normal/front/1/3/130237e7-6f45-4b92-b49d-12f10db29bb8.jpg?1783916026,Legendary Creature — Elf Archer,Anna Steinbauer
+Legolas- Master Archer,3,2023,0.33,#087500,https://cards.scryfall.io/normal/front/a/9/a9405577-c1dc-48e0-b2aa-6237c569d02e.jpg?1783916270,Legendary Creature — Elf Archer,Campbell White
+Legolas's Quick Reflexes,1,2023,35.77,#087500,https://cards.scryfall.io/normal/front/8/5/851c0167-04ba-4d15-b0fa-c211bd8826f1.jpg?1783914204,Instant,Jason Rainville
+Level Up,2,2026,2.15,#087500,https://cards.scryfall.io/normal/front/d/4/d4398907-17d2-4fad-bfa9-56925fb75834.jpg?1783904165,Enchantment — Aura,Narendra Bintara Adi
+Leyline Immersion,4,2023,0.59,#087500,https://cards.scryfall.io/normal/front/1/9/197f5adc-e14b-4c84-896f-ef5f01f7ff57.jpg?1783916521,Enchantment — Aura,Wisnu Tan
+Leyline of Abundance,4,2019,1.42,#087500,https://cards.scryfall.io/normal/front/c/6/c68e8342-78d2-4826-a287-64c371b97d19.jpg?1783932962,Enchantment,Noah Bradley
+Leyline of Lifeforce,4,2006,6.07,#087500,https://cards.scryfall.io/normal/front/f/7/f7caffa7-29bd-455c-9770-94a0ad7ef5e3.jpg?1783943489,Enchantment,Kev Walker
+Leyline of Mutation,4,2024,0.33,#d78f42,https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg?1783909452,Enchantment,Sergey Glushakov
+Leyline of Vitality,4,2010,3.55,#087500,https://cards.scryfall.io/normal/front/f/5/f5318113-9dfb-492c-9151-de90951d881e.jpg?1783941795,Enchantment,Jim Nelson
+Lhurgoyf,4,2018,0.32,#087500,https://cards.scryfall.io/normal/front/e/a/ea5d550a-bd8b-4f9e-ac7d-c35ebbe313e6.jpg?1783934728,Creature — Lhurgoyf,Pete Venters
+Lichenthrope,5,1997,0.6,#087500,https://cards.scryfall.io/normal/front/7/6/76f0c356-a81d-41d4-a8b7-8c159146a8b8.jpg?1783946982,Creature — Plant Fungus,Bob Eggleton
+Lictor,4,2022,0.34,#087500,https://cards.scryfall.io/normal/front/3/c/3c4d8f36-461f-48a6-a4e4-9ddfb388de19.jpg?1783920875,Creature — Tyranid,Games Workshop
+Liege of the Hollows,4,1997,6.63,#087500,https://cards.scryfall.io/normal/front/d/f/dff4512b-8244-4e38-bffb-0062a97d9531.jpg?1783946719,Creature — Spirit,Ron Spencer
+Liege of the Tangle,8,2020,1.6,#087500,https://cards.scryfall.io/normal/front/f/0/f0dea9d0-9f93-460d-bf69-ae1c1172a95e.jpg?1783930143,Creature — Elemental,Jason Chan
+Life and Limb,4,2021,0.8,#087500,https://cards.scryfall.io/normal/front/2/7/2721724d-92ae-4c0c-88dd-628888c468bf.jpg?1783927776,Enchantment,Jim Nelson
+Lifeblood Hydra,3,2026,0.33,#087500,https://cards.scryfall.io/normal/front/3/4/3431a77c-2027-406b-9230-5d0f8837af62.jpg?1783903764,Creature — Hydra,Alex Horley-Orlandelli
+Life Finds a Way,3,2023,16.52,#087500,https://cards.scryfall.io/normal/front/7/2/72137cda-ab1b-4bb7-9190-66a954c36e1e.jpg?1783913639,Enchantment,Inkognit
+Life from the Loam,2,2025,4.89,#087500,https://cards.scryfall.io/normal/front/c/d/cdb6432f-3f56-4c92-b09a-2a5b64620c04.jpg?1783907137,Sorcery,Carlos Palma Cruchaga
+Lifegift,3,2005,9.39,#087500,https://cards.scryfall.io/normal/front/2/7/27eaba1c-3137-4419-bf90-eb287a7c736e.jpg?1783944183,Enchantment,John Matson
+Lifelace,1,1995,0.38,#087500,https://cards.scryfall.io/normal/front/b/f/bf312acb-2fa6-440a-964b-424ad8abc331.jpg?1783947815,Instant,Amy Weber
+Life's Legacy,2,2022,7.61,#087500,https://cards.scryfall.io/normal/front/b/f/bf0e70d2-5f1a-441b-99b9-d003fa15b999.jpg?1783923245,Sorcery,Howard Lyon
+Lifestream's Blessing,6,2025,0.94,#087500,https://cards.scryfall.io/normal/front/4/8/48b4101b-3428-4b6b-818a-6097a093e9b5.jpg?1783906352,Instant,Kotakan
+Lignify,2,2025,7.33,#087500,https://cards.scryfall.io/normal/front/d/1/d1be11fa-d87f-465f-b036-0b6cb2145a66.jpg?1783905162,Kindred Enchantment — Treefolk Aura,Iron Maiden
+Lily Bowen- Raging Grandma,4,2024,0.39,#087500,https://cards.scryfall.io/normal/front/0/5/052dc548-d356-43fe-9484-665db7e1f505.jpg?1783912398,Legendary Creature — Mutant Warrior,Villarrte
+Living Artifact,1,1997,0.85,#087500,https://cards.scryfall.io/normal/front/8/a/8af097b1-9eae-4bd6-8ee6-582cae57e970.jpg?1783946893,Enchantment — Aura,Anson Maddocks
+Living Hive,8,2009,1.14,#087500,https://cards.scryfall.io/normal/front/5/4/54e4017b-51b1-47b0-90a6-47d680bac963.jpg?1783942318,Creature — Elemental Insect,Anthony S. Waters
+Living Wish,2,2018,1.42,#087500,https://cards.scryfall.io/normal/front/d/5/d505d319-093d-47af-8ee9-fafae3885aa0.jpg?1783935127,Sorcery,Hideaki Takamura
+Lizard- Connors's Curse,4,2025,0.31,#087500,https://cards.scryfall.io/normal/front/6/a/6add5d2a-950e-4bee-9850-e68f5f6d6142.jpg?1783905326,Legendary Creature — Lizard Villain,Steve Prescott
+Llanowar Greenwidow,3,2022,0.21,#087500,https://cards.scryfall.io/normal/front/8/1/81f90e4d-f60f-4175-830f-c2ce04c5a945.jpg?1783921300,Creature — Spider,Jokubas Uogintas
+Llanowar Loamspeaker,2,2022,0.29,#087500,https://cards.scryfall.io/normal/front/b/d/bd5611db-82dd-464d-8b03-70d7619dcefe.jpg?1783921297,Creature — Elf Druid,Zara Alfonso
+Loading Zone,4,2025,1.31,#087500,https://cards.scryfall.io/normal/front/0/d/0d2c95bd-79af-4a23-b265-62cc0b164e3e.jpg?1783905935,Enchantment,Matt Stewart
+Loamcrafter Faun,3,2025,0.18,#087500,https://cards.scryfall.io/normal/front/0/6/066de4d6-3fa4-44e0-ab02-8d97b603015a.jpg?1783906034,Creature — Satyr Druid,Mark Zug
+Loaming Shaman,3,2015,0.29,#087500,https://cards.scryfall.io/normal/front/1/5/15f39dfb-56ee-4aae-b252-afa3f5f05855.jpg?1783938066,Creature — Centaur Shaman,Carl Critchlow
+Long Rest,3,2021,0.21,#087500,https://cards.scryfall.io/normal/front/0/6/0615e930-3b6b-4b2f-a09c-0730d491545c.jpg?1783926459,Sorcery,Chris Seaman
+Loot- Exuberant Explorer,3,2024,2.49,#087500,https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg?1783909097,Legendary Creature — Beast Noble,Arif Wijaya
+Lost in the Woods,5,2012,0.31,#087500,https://cards.scryfall.io/normal/front/5/8/5865603c-0a5e-45c3-84e3-2dc3b4cf0cf7.jpg?1783940803,Enchantment,Matt Stewart
+Lotus Cobra,2,2020,5.81,#087500,https://cards.scryfall.io/normal/front/a/4/a4b759f0-901f-4be3-93fa-224609b08d48.jpg?1783929336,Creature — Snake,Sam Rowan
+Lovestruck Beast // Heart's Desire,3,2022,0.23,#087500,https://cards.scryfall.io/normal/front/4/f/4f80af9c-07a1-46f1-b869-146fda5922f4.jpg?1783922405,Creature — Beast Noble // Sorcery — Adventure,Kev Walker
+Lucky the Pizza Dog,2,2026,2.34,#087500,https://cards.scryfall.io/normal/front/5/f/5fc454a5-39af-421d-a494-727ac7b6115e.jpg?1783903037,Legendary Creature — Dog,Rudy Siswanto
+Lumbering Worldwagon,3,2025,1.05,#087500,https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg?1783907870,Artifact — Vehicle,Raph Lomotan
+Lumra- Bellow of the Woods,6,2024,20.27,#087500,https://cards.scryfall.io/normal/front/a/e/ae4f3aaf-3960-48cd-b34b-32e4ae5ae088.jpg?1783910806,Legendary Creature — Elemental Bear,Matt Stewart
+Lure of Prey,4,1996,3.68,#087500,https://cards.scryfall.io/normal/front/7/1/7165f1d8-7b31-4a81-aab4-c6cd4ff2e67d.jpg?1783947065,Instant,Andrew Robinson
+Lurker,3,1994,4.26,#087500,https://cards.scryfall.io/normal/front/b/3/b39eb671-e17e-4c5a-8913-1e3be7faedfb.jpg?1783947931,Creature — Beast,Anson Maddocks
+Lurking Crocodile,3,2021,1.83,#087500,https://cards.scryfall.io/normal/front/d/0/d0e9b42b-1f5d-4aae-8b91-6fb1b302aff6.jpg?1783924572,Creature — Crocodile,Crocodile Jackson
+Lurking Predators,6,2020,20.87,#087500,https://cards.scryfall.io/normal/front/9/9/9952da7c-3cfc-413f-8849-0f10e9c8dceb.jpg?1783930360,Enchantment,Mike Bierek
+Maester Seymour,3,2025,0.4,#087500,https://cards.scryfall.io/normal/front/f/6/f6a4267b-aa76-4dec-bc72-252236c44968.jpg?1783906351,Legendary Creature — Human Elf Cleric,Norikatsu Miyoshi
+Magnigoth Treefolk,5,2001,0.42,#087500,https://cards.scryfall.io/normal/front/9/0/90c2869b-43cf-4d5e-8a54-9ae200f5bff9.jpg?1783945612,Creature — Treefolk,Peter Bollinger
+Magus of the Candelabra,1,2018,0.71,#087500,https://cards.scryfall.io/normal/front/f/5/f50583b8-6953-4094-b420-580d545e827f.jpg?1783934801,Creature — Human Wizard,Terese Nielsen
+Magus of the Library,2,2007,0.47,#087500,https://cards.scryfall.io/normal/front/8/9/899db99b-df27-4848-a23d-5c645deae450.jpg?1783943140,Creature — Human Wizard,Wayne Reynolds
+Magus of the Order,4,2020,0.27,#087500,https://cards.scryfall.io/normal/front/a/9/a93e5fa9-cfe3-487b-af77-0dbf6c68ee04.jpg?1783928789,Creature — Human Wizard,Tomasz Jedruszek
+Magus of the Vineyard,1,2011,4.01,#087500,https://cards.scryfall.io/normal/front/6/3/63005c92-fc0b-45dc-b488-489350527453.jpg?1783941192,Creature — Human Wizard,Jim Murray
+Majestic Genesis,8,2022,5.38,#087500,https://cards.scryfall.io/normal/front/e/a/eaadb067-4a77-4d6e-931d-447bd0c06594.jpg?1783922711,Sorcery,Alayna Danner
+Majestic Myriarch,5,2020,0.4,#087500,https://cards.scryfall.io/normal/front/4/5/457d66b3-f059-4b2f-91b0-96568e1b17f5.jpg?1783931159,Creature — Chimera,Randy Vargas
+Mammoth Harness,4,1995,0.52,#087500,https://cards.scryfall.io/normal/front/5/b/5be67121-068c-4770-bc42-c081577a442c.jpg?1783947278,Enchantment — Aura,Melissa A. Benson
+Mana Bloom,1,2026,0.26,#087500,https://cards.scryfall.io/normal/front/0/3/03a40bf7-5eb9-4b36-9388-48b482a6fcf2.jpg?1783903764,Enchantment,Mike Bierek
+Managorger Hydra,3,2023,1.32,#087500,https://cards.scryfall.io/normal/front/e/9/e9c124d7-b4b1-43cf-9830-1244053cc056.jpg?1783917137,Creature — Hydra,Lucas Graciano
+Manaplasm,3,2008,0.32,#087500,https://cards.scryfall.io/normal/front/c/4/c48d2cc1-9868-4509-a541-728faf355b6d.jpg?1783942552,Creature — Ooze,Daarken
+Mana Reflection,6,2020,2.29,#087500,https://cards.scryfall.io/normal/front/8/1/81e0d739-990f-4ba5-b456-165c033014cf.jpg?1783930143,Enchantment,Chris Seaman
+Mantle of the Wolf,4,2020,0.34,#087500,https://cards.scryfall.io/normal/front/8/3/83a786fa-4b86-40f7-ac58-1a05fb38fcdb.jpg?1783931536,Enchantment — Aura,Simon Dominic
+March of Burgeoning Life,1,2022,0.19,#087500,https://cards.scryfall.io/normal/front/0/e/0e223d99-408a-413d-abb1-cb2f11ae521d.jpg?1783923843,Instant,Wylie Beckert
+March of the World Ooze,6,2025,1.76,#087500,https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg?1783907868,Enchantment,Helge C. Balzer
+Maro,4,2005,0.25,#087500,https://cards.scryfall.io/normal/front/9/1/9159e250-4eec-4ec4-80e1-42259331b3b9.jpg?1783943926,Creature — Elemental,Stuart Griffin
+Marshaling the Troops,2,1999,58.31,#087500,https://cards.scryfall.io/normal/front/5/6/56e4df87-7908-4274-a07f-81d42be89f18.jpg?1783946100,Sorcery,Liu Shangying
+Marwyn- the Nurturer,3,2021,4.06,#087500,https://cards.scryfall.io/normal/front/a/a/aad61d99-5c8e-47b7-ab1a-e70905f59205.jpg?1783928311,Legendary Creature — Elf Druid,Chris Rahn
+Masked Admirers,4,2021,0.2,#087500,https://cards.scryfall.io/normal/front/b/8/b8cc3361-046c-4908-8b8d-a0502bfc173a.jpg?1783928312,Creature — Elf Shaman,Eric Fortune
+Master of the Hunt,4,1994,35.93,#087500,https://cards.scryfall.io/normal/front/4/e/4e6bf56e-2d74-4e4d-a667-885853979377.jpg?1783948046,Creature — Human,Jeff A. Menges
+Master of the Wild Hunt,4,2018,1.6,#087500,https://cards.scryfall.io/normal/front/3/c/3c56fda1-d286-46b1-9617-4f7c430abb79.jpg?1783935126,Creature — Human Shaman,Kev Walker
+Master's Guidance,3,2025,0.22,#087500,https://cards.scryfall.io/normal/front/9/8/98319aec-f95b-4343-beb9-7804551369f3.jpg?1783904811,Enchantment,Yueko
+Masumaro- First to Live,6,2005,0.89,#087500,https://cards.scryfall.io/normal/front/2/c/2c4625b7-c8b1-4fdf-af9f-935313436b35.jpg?1783944136,Legendary Creature — Spirit,Adam Rex
+Mayor of Avabruck // Howlpack Alpha,2,2025,0.75,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Advisor Werewolf // Creature — Werewolf,Svetlin Velinov
+M'Baku- Jabari Chieftain,3,2026,0.24,#087500,https://cards.scryfall.io/normal/front/2/e/2e330643-5714-4724-a65c-0873ce9cc5a6.jpg?1783903278,Legendary Creature — Human Noble Warrior,Lee Woo-chul
+Meandering Towershell,5,2014,0.16,#087500,https://cards.scryfall.io/normal/front/a/9/a945b43d-39bc-4ce4-be03-0109e1a681b1.jpg?1783939066,Creature — Turtle,YW Tang
+Medusa- Inhuman Queen,3,2026,0.36,#087500,https://cards.scryfall.io/normal/front/3/1/3187ebab-8008-455c-a3c9-794a5b225b88.jpg?1783903276,Legendary Creature — Inhuman Noble Hero,Irvin Rodriguez
+Megantic Sliver,6,2023,1.08,#087500,https://cards.scryfall.io/normal/front/4/9/49c1afd5-d1d3-42b7-8417-bb05c91ef822.jpg?1783915423,Creature — Sliver,Campbell White
+Megatherium,3,1999,0.4,#087500,https://cards.scryfall.io/normal/front/c/5/c58a1e43-a173-45d6-ac55-363664bf6e1b.jpg?1783945923,Creature — Beast,Paolo Parente
+Melira- Sylvok Outcast,2,2011,5.23,#087500,https://cards.scryfall.io/normal/front/e/8/e83851a1-e4e8-49ec-af5c-4efe86fa51ad.jpg?1783941300,Legendary Creature — Human Scout,Min Yum
+Michelangelo- Improviser,4,2026,3.4,#087500,https://cards.scryfall.io/normal/front/9/5/955848c0-5092-4e13-97c9-5978d44d5586.jpg?1783904087,Legendary Creature — Mutant Ninja Turtle,Narendra Bintara Adi
+Michelangelo- On the Scene,6,2026,2.07,#087500,https://cards.scryfall.io/normal/front/6/0/60a80d88-1f76-4a97-9e61-3a0d6304c9c2.jpg?1783904134,Legendary Creature — Mutant Ninja Turtle,Lie Setiawan
+Michelangelo's Technique,5,2026,0.39,#087500,https://cards.scryfall.io/normal/front/3/a/3a63c06a-7c59-4b72-b916-e5b6ad78c684.jpg?1783904086,Sorcery,Dominik Mayer
+Michelangelo- the Heart,2,2026,3.61,#087500,https://cards.scryfall.io/normal/front/b/a/bac2d744-db65-4b56-8634-c87fd00c090e.jpg?1783904173,Legendary Creature — Mutant Ninja Turtle,Néstor Ossandón Leal
+Michelangelo- Weirdness to 11,2,2026,3.2,#087500,https://cards.scryfall.io/normal/front/1/8/18477047-218d-4b2a-a086-37431b6a3025.jpg?1783904086,Legendary Creature — Mutant Ninja Turtle,Jason Kiantoro
+Midsummer Revel,5,1998,0.66,#087500,https://cards.scryfall.io/normal/front/b/4/b40a7f65-10fe-4ce5-ad1c-be53a635d7a9.jpg?1783946311,Enchantment,Steve Firchow
+Mightform Harmonizer,4,2025,1.27,#087500,https://cards.scryfall.io/normal/front/f/3/f32302f1-b54f-4489-9d0b-9b771e59da06.jpg?1783905933,Creature — Insect Druid,Bartek Fedyczak
+Might of Oaks,4,2009,0.36,#087500,https://cards.scryfall.io/normal/front/4/3/438a324b-cf3e-4a0f-95c4-cd548586f7e5.jpg?1783942360,Instant,Jeremy Jarvis
+Mikey & Mona- Mutant Sitters,3,2026,0.4,#087500,https://cards.scryfall.io/normal/front/f/b/fb7fdad9-8a39-4c66-b9d2-cfce8c4928a5.jpg?1783904134,Legendary Creature — Mutant Ninja Turtle Lizard,Randy Vargas
+Miles Morales // Ultimate Spider-Man,2,2025,4.19,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Citizen Hero // Legendary Creature — Spider Human Hero,L.A. Draws
+Mindbender Spores,3,1996,1.27,#087500,https://cards.scryfall.io/normal/front/f/4/f41066eb-be5e-4a6d-9156-64f5e56c7ab3.jpg?1783947062,Creature — Fungus Wall,Ian Miller
+Mine- Mine- Mine!,6,1998,1.47,#087500,https://cards.scryfall.io/normal/front/a/9/a91f28e0-867a-4713-955d-582201af63ae.jpg?1783946422,Enchantment,Heather Hudson
+Mirkwood Channeler,4,2023,1.16,#087500,https://cards.scryfall.io/normal/front/c/a/ca533454-8bea-4e08-ab0b-e2f4affffaef.jpg?1783913960,Creature — Elf Druid,Irina Nordsol
+Mirkwood Elk,6,2023,0.18,#087500,https://cards.scryfall.io/normal/front/1/c/1cf84c03-a131-451b-99ee-64330c1f2e26.jpg?1783916025,Creature — Elk,Christina Kraus
+Mirri's Guile,1,1997,32.15,#087500,https://cards.scryfall.io/normal/front/7/3/73d51a3c-95c0-4810-b847-4b8afd12fd64.jpg?1783946616,Enchantment,Brom
+Mistbreath Elder,1,2024,0.34,#087500,https://cards.scryfall.io/normal/front/e/5/e5246540-5a84-41d8-9e30-8e7a6c0e84e1.jpg?1783910806,Creature — Frog Warrior,Jason Kang
+Mistcutter Hydra,1,2013,3.75,#087500,https://cards.scryfall.io/normal/front/3/c/3c844ed7-8ed2-4a39-9134-e14e476ab0c4.jpg?1783939745,Creature — Hydra,Ryan Pancoast
+Mister Immortal,2,2026,0.79,#087500,https://cards.scryfall.io/normal/front/c/a/ca30b59b-e475-422e-8332-44144db78177.jpg?1783903036,Legendary Creature — Mutant Hero,Lucio Parrillo
+Mitotic Slime,5,2022,0.37,#087500,https://cards.scryfall.io/normal/front/8/a/8aacf055-e36f-4428-8a3c-f73fa4b4307c.jpg?1783923245,Creature — Ooze,Raymond Swanland
+Molder Slug,5,2003,0.48,#087500,https://cards.scryfall.io/normal/front/e/e/ee355d1b-5d64-4328-94d6-7a58889b99bc.jpg?1783944533,Creature — Slug Beast,Heather Hudson
+Moldgraf Monstrosity,7,2024,0.65,#087500,https://cards.scryfall.io/normal/front/7/1/714ba062-f8ae-4ae6-a1c2-8fa093cc0fb2.jpg?1783909638,Creature — Insect,Nino Is
+Mole Man- Moloid Master,3,2026,1.37,#087500,https://cards.scryfall.io/normal/front/1/b/1b406cc5-75c9-430a-83a2-de0f2a8aeae6.jpg?1783902919,Legendary Creature — Human Villain,Michele Giorgi
+Molimo- Maro-Sorcerer,7,2020,0.15,#087500,https://cards.scryfall.io/normal/front/3/2/321f68b5-42ad-4f71-8df4-78075bf68ce5.jpg?1783928706,Legendary Creature — Elemental Sorcerer,Mark Zug
+Momentous Fall,4,2020,2.94,#087500,https://cards.scryfall.io/normal/front/9/1/91a6f558-a754-4437-8328-00a6ca47f9b5.jpg?1783930359,Instant,Tomasz Jedruszek
+Moment's Peace,2,2023,14.5,#087500,https://cards.scryfall.io/normal/front/2/2/22b05002-0039-4e51-8493-37e64405e342.jpg?1783913418,Instant,Jesse LeDoux
+Mona Lisa- Ever Adaptable,4,2026,5.33,#087500,https://cards.scryfall.io/normal/front/4/1/41f1503b-b056-4f7c-94a1-1e6d78eb209b.jpg?1783904134,Legendary Creature — Lizard Mutant,April Prime
+Mongrel Pack,4,1997,0.88,#087500,https://cards.scryfall.io/normal/front/5/6/56b84315-5287-4401-a4c8-34c192423270.jpg?1783946616,Creature — Dog,Jeff Miracola
+Monster Manual // Zoological Study,4,2022,9.14,#087500,https://cards.scryfall.io/normal/front/2/7/27223ee4-970a-438a-beff-a1b13b14aff4.jpg?1783922711,Artifact — Book // Sorcery — Adventure,David Gaillet
+Mossborn Hydra,3,2024,10.27,#087500,https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg?1783909097,Creature — Elemental Hydra,Monztre
+Mossbridge Troll,7,2008,1.66,#087500,https://cards.scryfall.io/normal/front/5/3/537c39cc-44d3-4869-9e76-dd9c2c68ee90.jpg?1783942741,Creature — Troll,Jeremy Jarvis
+Mosswood Dreadknight // Dread Whispers,2,2023,0.4,#d78f42,https://cards.scryfall.io/normal/front/9/8/9869ac70-5907-45fa-952c-31aef70c5066.jpg?1783915064,Creature — Human Knight // Sorcery — Adventure,Ryan Pancoast
+Motivated Pony,5,2023,0.26,#087500,https://cards.scryfall.io/normal/front/9/b/9be4f8b6-90ef-4c77-ae70-bffae229d243.jpg?1783916026,Creature — Horse,Claudiu-Antoniu Magherusan
+Mouth // Feed,7,2017,0.29,#087500,https://cards.scryfall.io/normal/front/a/4/a47070a0-fd05-4ed9-a175-847a864478da.jpg?1783936458,Sorcery // Sorcery,Zack Stella
+Mul Daya Channelers,3,2010,0.87,#087500,https://cards.scryfall.io/normal/front/5/d/5d362c3b-f9e1-476b-b5fd-d1292bbc257c.jpg?1783941961,Creature — Elf Druid Shaman,Jason Chan
+Multani- Maro-Sorcerer,6,1999,16.69,#087500,https://cards.scryfall.io/normal/front/0/d/0d6cc98b-b376-40af-8308-198bab00b2b1.jpg?1783946229,Legendary Creature — Elemental Sorcerer,Daren Bader
+Multani- Yavimaya's Avatar,6,2025,0.28,#087500,https://cards.scryfall.io/normal/front/c/3/c37a0136-1c40-4cd1-8787-a25c377c1741.jpg?1783906034,Legendary Creature — Elemental Avatar,Ryan Yee
+Mungha Wurm,4,2000,0.31,#087500,https://cards.scryfall.io/normal/front/6/a/6addc915-2997-4b81-a026-97d4421cf17d.jpg?1783945772,Creature — Wurm,Greg Staples
+Muraganda Petroglyphs,4,2021,0.67,#087500,https://cards.scryfall.io/normal/front/b/1/b103cb22-93b2-4206-9f80-5f966155e07e.jpg?1783927775,Enchantment,Scott Altmann
+Mutable Explorer,3,2026,1.11,#087500,https://cards.scryfall.io/normal/front/8/f/8f35d95a-caea-4d5e-b98e-55da1ba7c92d.jpg?1783904425,Creature — Shapeshifter,Wayne Reynolds
+Mutagen Man- Living Ooze,2,2026,1.64,#087500,https://cards.scryfall.io/normal/front/9/f/9f9085f0-3702-462c-8c81-b4576236792d.jpg?1783904085,Legendary Creature — Ooze Mutant,Ignatius Budi
+Mwonvuli Ooze,1,1997,0.73,#087500,https://cards.scryfall.io/normal/front/a/a/aa9c6f65-93a1-4913-87e7-a17ebfcc7780.jpg?1783946719,Creature — Ooze,Zina Saunders
+Mycoloth,5,2026,0.33,#087500,https://cards.scryfall.io/normal/front/9/2/924976cf-9b46-4cbf-ab27-07ca72a21608.jpg?1783903762,Creature — Fungus,Raymond Swanland
+Myojin of Life's Web,9,2004,6.57,#087500,https://cards.scryfall.io/normal/front/e/f/efb926ad-e762-4883-8841-73e034d8e21e.jpg?1783944286,Legendary Creature — Spirit,Kev Walker
+Myojin of Towering Might,8,2022,0.29,#087500,https://cards.scryfall.io/normal/front/5/4/54803ba5-a2d7-4997-8e76-298aff6e1aff.jpg?1783923984,Legendary Creature — Spirit,Ryan Pancoast
+Mythic Proportions,7,2002,0.52,#087500,https://cards.scryfall.io/normal/front/8/2/829069cf-7e63-4443-b679-65ad15d6ca5e.jpg?1783945039,Enchantment — Aura,Jim Nelson
+Mythos of Brokkos,4,2020,0.43,#d78f42,https://cards.scryfall.io/normal/front/f/a/fa4fc5b1-6666-4c60-898f-f927212c7923.jpg?1783931031,Sorcery,Seb McKinnon
+Myth Unbound,3,2018,3.24,#087500,https://cards.scryfall.io/normal/front/b/8/b88ca71b-de1f-497c-b094-8fe954cf8223.jpg?1783934333,Enchantment,Alexander Forssberg
+Nakia- Wakandan Operative,3,2026,0.29,#087500,https://cards.scryfall.io/normal/front/6/c/6cd88c80-a445-4f88-95e3-e370620c90fc.jpg?1783903276,Legendary Creature — Human Warrior Hero,Mateus Manhanini
+Nantuko Blightcutter,3,2002,0.36,#087500,https://cards.scryfall.io/normal/front/4/2/42a6f1b6-e1ed-497a-b50e-1bfa257c18c0.jpg?1783945141,Creature — Insect Druid,Matt Cavotta
+Nantuko Cultivator,4,2002,0.37,#087500,https://cards.scryfall.io/normal/front/9/d/9d258fe7-7906-43ca-8ebd-344aa81cb85b.jpg?1783945141,Creature — Insect Druid,Darrell Riche
+Nantuko Mentor,3,2001,0.35,#087500,https://cards.scryfall.io/normal/front/4/8/48cb5283-d384-490e-a0a5-2d10c1acc8cc.jpg?1783945213,Creature — Insect Druid,John Matson
+Nantuko Shrine,3,2001,1.75,#087500,https://cards.scryfall.io/normal/front/4/b/4b66bab3-ee6f-4f74-bbc1-8099c9c4904b.jpg?1783945214,Enchantment,Rebecca Guay
+Natural Affinity,3,2005,6.58,#087500,https://cards.scryfall.io/normal/front/4/8/4847f8e8-9979-427e-999a-26711e542f82.jpg?1783943924,Instant,Pete Venters
+Natural Balance,4,1996,2.79,#087500,https://cards.scryfall.io/normal/front/b/0/b0f7c47c-416e-4f73-89ec-024a29dfb5e9.jpg?1783947062,Sorcery,John Malloy
+Natural Order,4,2016,36.66,#087500,https://cards.scryfall.io/normal/front/b/f/bfe3329c-7faa-4925-b9d2-075a1ab27e80.jpg?1783937562,Sorcery,Terese Nielsen
+Natural Selection,1,1993,80.81,#087500,https://cards.scryfall.io/normal/front/3/1/315a6bfb-5417-465f-97d9-e157f5c3cf79.jpg?1783948544,Instant,Mark Poole
+Nature's Claim,1,2025,10.21,#087500,https://cards.scryfall.io/normal/front/0/7/07b3c23e-92c4-4376-8108-f2cd15cf3e47.jpg?1783905085,Instant,Nijihayashi
+Nature's Cloak,3,1999,6.73,#087500,https://cards.scryfall.io/normal/front/8/6/86b97d7d-6a72-4663-8b09-bef306485ed6.jpg?1783946021,Sorcery,Rebecca Guay
+Nature's Lore,2,2026,30.09,#087500,https://cards.scryfall.io/normal/front/9/e/9ec73912-aa0a-475b-b22a-ad71e8d9d0a8.jpg?1783904261,Sorcery,Kathleen Neeley
+Nature's Resurgence,4,2001,0.37,#087500,https://cards.scryfall.io/normal/front/2/8/287f9f55-829d-4b29-b1d2-34d20d23b3d5.jpg?1783945420,Sorcery,Gary Ruddell
+Nature's Revolt,5,2001,5.42,#087500,https://cards.scryfall.io/normal/front/e/0/e0c9b948-63f9-458d-82ae-69ebe2ac9fe0.jpg?1783945419,Enchantment,Dave Dorman
+Nature's Rhythm,2,2025,5.11,#087500,https://cards.scryfall.io/normal/front/1/3/1397d904-c51d-451e-8505-7f3118acc1f6.jpg?1783907340,Sorcery,Liiga Smilshkalne
+Nature's Will,4,2004,8.0,#087500,https://cards.scryfall.io/normal/front/7/5/75a291a0-db0d-4ccc-b7ae-240cafa41883.jpg?1783944286,Enchantment,Mitch Cotie
+Naya Soulbeast,8,2013,0.27,#087500,https://cards.scryfall.io/normal/front/f/0/f0e4b468-096b-4f80-9e78-022fe24a7e45.jpg?1783939659,Creature — Beast,Jesper Ejsing
+Nemata- Grove Guardian,6,2001,1.16,#087500,https://cards.scryfall.io/normal/front/8/c/8c6a0ca4-5006-4c9b-91cd-e01d77e4fdc2.jpg?1783945612,Legendary Creature — Treefolk,John Avon
+Nessian Boar,5,2020,0.3,#087500,https://cards.scryfall.io/normal/front/a/a/aaf91fc2-7317-47e4-9e6c-d7d74cdf0153.jpg?1783931536,Creature — Boar,Zoltan Boros
+Nessian Wilds Ravager,6,2014,0.35,#087500,https://cards.scryfall.io/normal/front/6/5/65368cf0-7d92-4248-b930-633fd023065b.jpg?1783939532,Creature — Hydra,Richard Wright
+Neverwinter Hydra,2,2021,8.06,#087500,https://cards.scryfall.io/normal/front/e/5/e57338ac-e794-41a0-8c3c-61df9c099cfb.jpg?1783926244,Creature — Hydra,Lucas Graciano
+Nev- the Practical Dean,3,2026,0.35,#087500,https://cards.scryfall.io/normal/front/9/4/94cf1461-5e4f-4980-8ef9-293421af621f.jpg?1783903852,Legendary Creature — Merfolk Wizard,Lie Setiawan
+New Frontiers,1,2001,5.43,#087500,https://cards.scryfall.io/normal/front/f/d/fd1f6cfa-9576-4bb8-83db-33c2b147206d.jpg?1783945213,Sorcery,Ron Spencer
+Nexos,2,2022,12.58,#087500,https://cards.scryfall.io/normal/front/7/3/73ca0549-5775-4778-bd47-f5f234a71201.jpg?1783920874,Creature — Human Tyranid Advisor,Josu Hernaiz
+Next of Kin,3,2022,0.2,#087500,https://cards.scryfall.io/normal/front/5/1/51a4414b-3cab-463f-a2b5-e49104f251da.jpg?1783923356,Enchantment — Aura,Andreas Zafiratos
+Neyith of the Dire Hunt,4,2020,13.16,#d78f42,https://cards.scryfall.io/normal/front/0/c/0c1eed0f-9692-44c0-b1ad-afa691165d52.jpg?1783930499,Legendary Creature — Human Warrior,Magali Villeneuve
+Niall Silvain,3,1994,4.4,#087500,https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg?1783947931,Creature — Ouphe,Christopher Rush
+Nightpack Ambusher,4,2019,0.47,#087500,https://cards.scryfall.io/normal/front/2/c/2c9b1f70-9861-4c66-a52f-c40002679e75.jpg?1783932960,Creature — Wolf,Dan Murayama Scott
+Ninja Pizza,3,2026,2.86,#087500,https://cards.scryfall.io/normal/front/7/4/74c24ff9-d3d2-4ffb-bf8b-dba803481a99.jpg?1783904164,Enchantment,Brian Yuen
+Nissa- Ascended Animist,7,2023,2.24,#087500,https://cards.scryfall.io/normal/front/1/d/1dd64b1d-bcef-476c-bf0b-3ac7df7cbed3.jpg?1783918012,Legendary Planeswalker — Nissa,Chase Stone
+Nissa- Resurgent Animist,3,2023,26.56,#087500,https://cards.scryfall.io/normal/front/2/4/248c76d3-b5cb-4582-be17-7cd1d0cb0f58.jpg?1783916520,Legendary Creature — Elf Scout,Tuan Duong Chu
+Nissa Revane,4,2009,8.45,#087500,https://cards.scryfall.io/normal/front/1/b/1b4c26ab-0f7b-4163-b9e4-a415b91352a6.jpg?1783942134,Legendary Planeswalker — Nissa,Jaime Jones
+Nissa's Chosen,2,2009,3.85,#087500,https://cards.scryfall.io/normal/front/e/4/e45e4c8f-bb6c-471d-b14f-cc90869f341a.jpg?1783942093,Creature — Elf Warrior,Sam Wood
+Nissa's Encouragement,5,2017,0.17,#087500,https://cards.scryfall.io/normal/front/a/4/a489d5c7-ef57-4973-86ac-06234c308c3c.jpg?1783935985,Sorcery,Tommy Arnold
+Nissa's Renewal,6,2021,0.33,#087500,https://cards.scryfall.io/normal/front/9/4/9474a32d-d846-41c9-9ef4-b4caf981cf12.jpg?1783927532,Sorcery,Lius Lasahido
+Nissa's Revelation,7,2018,0.37,#087500,https://cards.scryfall.io/normal/front/a/2/a229b53f-f34b-44f5-b0b4-94239b85a15b.jpg?1783933972,Sorcery,Izzy
+Nissa- Vastwood Seer // Nissa- Sage Animist,3,2015,4.2,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elf Scout // Legendary Planeswalker — Nissa,Wesley Burt
+Nissa- Vital Force,5,2016,3.21,#087500,https://cards.scryfall.io/normal/front/b/b/bbaaa98a-ec40-4ff1-8762-a719cf1c475d.jpg?1783937176,Legendary Planeswalker — Nissa,Clint Cearley
+Nissa- Who Shakes the World,5,2019,4.48,#087500,https://cards.scryfall.io/normal/front/f/8/f857bbe4-5619-4733-a0c7-69700f2ef4f3.jpg?1783933410,Legendary Planeswalker — Nissa,Chris Rallis
+Nissa- Worldsoul Speaker,4,2025,0.21,#087500,https://cards.scryfall.io/normal/front/a/4/a471b306-4941-4e46-a0cb-d92895c16f8a.jpg?1783907750,Legendary Creature — Elf Druid,Magali Villeneuve
+Nissa- Worldwaker,5,2017,4.6,#087500,https://cards.scryfall.io/normal/front/4/a/4a37fbca-32db-40cc-9fd3-4764c7fd81e2.jpg?1783936143,Legendary Planeswalker — Nissa,Chris Rahn
+Noble Hierarch,1,2020,12.78,#d78f42,https://cards.scryfall.io/normal/front/4/0/400382a4-aea2-4827-b06a-1b0b3745908b.jpg?1783930143,Creature — Human Druid,Mark Zug
+Nostalgic Dreams,2,2002,2.7,#087500,https://cards.scryfall.io/normal/front/7/0/70f1e794-a32e-4f91-acbb-7e60dad4cf53.jpg?1783945140,Sorcery,Darrell Riche
+Nourishing Shoal,2,2018,0.57,#087500,https://cards.scryfall.io/normal/front/9/4/9472cd09-0b0a-49c9-ab10-ec5b73ddb74b.jpg?1783933789,Instant — Arcane,Greg Staples
+Noxious Revival,1,2024,15.64,#087500,https://cards.scryfall.io/normal/front/7/b/7b8c04ad-9c81-48f6-85cc-ae30a80a7989.jpg?1783909281,Instant,Javier Charro
+Nullhide Ferox,4,2018,0.25,#087500,https://cards.scryfall.io/normal/front/2/4/24c30bb0-06ba-432b-a20c-6fa79b0dc68a.jpg?1783934148,Creature — Beast,Filip Burburan
+Nut Collector,6,2023,6.97,#087500,https://cards.scryfall.io/normal/front/3/2/32980fc5-32ef-4f6d-8972-7a9e122c02e2.jpg?1783918438,Creature — Human Druid,Jesper Ejsing
+Nylea- God of the Hunt,4,2013,11.91,#087500,https://cards.scryfall.io/normal/front/f/1/f185a734-a32a-4244-88e8-dabafbfd064f.jpg?1783939744,Legendary Enchantment Creature — God,Chris Rahn
+Nylea- Keen-Eyed,4,2020,5.1,#087500,https://cards.scryfall.io/normal/front/b/d/bdf894d4-1a06-4952-a481-22786ab87a73.jpg?1783931534,Legendary Enchantment Creature — God,Chris Rahn
+Nylea's Colossus,7,2018,5.05,#087500,https://cards.scryfall.io/normal/front/5/c/5cf50d41-02ce-4a39-b3a0-82ddd7277fca.jpg?1783934333,Enchantment Creature — Giant,Grzegorz Rutkowski
+Nylea's Intervention,2,2020,0.57,#087500,https://cards.scryfall.io/normal/front/d/a/daa2f963-9d16-4224-b24e-b6a79f2b9d75.jpg?1783931532,Sorcery,Zezhou Chen
+Nyxbloom Ancient,7,2020,28.89,#087500,https://cards.scryfall.io/normal/front/a/3/a391da36-0b40-46ea-b771-50d2b920207e.jpg?1783931531,Enchantment Creature — Elemental,Filip Burburan
+Nyxborn Behemoth,12,2023,1.01,#087500,https://cards.scryfall.io/normal/front/b/9/b9f1dbdc-e590-48a4-bc52-e9e4e907fb82.jpg?1783915479,Enchantment Creature — Beast,Néstor Ossandón Leal
+Oath of Druids,2,2016,9.79,#087500,https://cards.scryfall.io/normal/front/9/d/9dad6b50-c415-4c55-8eac-bbc9d656c2fc.jpg?1783937057,Enchantment,Daren Bader
+Oath of Nissa,1,2016,0.48,#087500,https://cards.scryfall.io/normal/front/6/1/613513ea-55dd-4ae8-93b2-247e468112a6.jpg?1783937900,Legendary Enchantment,Wesley Burt
+Oath of the Ancient Wood,3,2013,0.22,#087500,https://cards.scryfall.io/normal/front/9/b/9bc42032-8727-4f78-b369-ba103d965b73.jpg?1783939902,Enchantment,Dan Murayama Scott
+Obscuring Aether,1,2024,0.33,#087500,https://cards.scryfall.io/normal/front/d/8/d8b28abe-9ff6-42aa-ade6-90b9e44d2a01.jpg?1783912990,Enchantment,Min Yum
+Obscuring Haze,3,2023,3.94,#087500,https://cards.scryfall.io/normal/front/2/1/21c8e59c-edf1-4b4d-982d-3c891e7b96ba.jpg?1783915625,Instant,Campbell White
+Obstinate Baloth,4,2017,0.37,#087500,https://cards.scryfall.io/normal/front/9/8/98d12669-ca08-4a3c-b30f-15168b75abe4.jpg?1783935517,Creature — Beast,Chris Rahn
+Ochre Jelly,1,2021,0.38,#087500,https://cards.scryfall.io/normal/front/9/f/9f23cfb7-c6b6-4f04-abba-5b2a6117ea12.jpg?1783926458,Creature — Ooze,Daarken
+Ohran Frostfang,5,2026,5.18,#087500,https://cards.scryfall.io/normal/front/5/5/55fb93e6-d057-4b70-ad12-e98291fd4a2c.jpg?1783903764,Snow Creature — Snake,Torstein Nordstrand
+Ohran Viper,3,2015,1.3,#087500,https://cards.scryfall.io/normal/front/2/d/2dd1d028-0c7c-450b-a1ae-812b1212fef6.jpg?1783938067,Snow Creature — Snake,Kev Walker
+Ojer Kaslem- Deepest Growth // Temple of Cultivation,5,2023,6.45,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Land,Ryan Pancoast
+Oko- Lorwyn Liege // Oko- Shadowmoor Scion,3,2026,0.8,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Planeswalker — Oko // Legendary Planeswalker — Oko,Kai Carpenter
+Old Fogey,2,2020,0.29,#087500,https://cards.scryfall.io/normal/front/c/c/ccae52dd-3ffd-4974-8915-61f816d29a64.jpg?1783931325,Summon — Dinosaur,Douglas Shuler
+Old Gnawbone,7,2021,52.62,#087500,https://cards.scryfall.io/normal/front/7/7/77ceba8b-de19-4db8-b5a7-f5df49bf241f.jpg?1783926458,Legendary Creature — Dragon,Filip Burburan
+Old-Growth Dryads,1,2017,0.24,#087500,https://cards.scryfall.io/normal/front/0/6/06458882-94c8-4d92-a21c-955e9d70f0d4.jpg?1783935722,Creature — Dryad,Yongjae Choi
+Old-Growth Troll,3,2021,0.38,#087500,https://cards.scryfall.io/normal/front/b/7/b759b0f6-342c-4bba-89f1-8451835d8c45.jpg?1783928208,Creature — Troll Warrior,Jesper Ejsing
+Old One Eye,6,2022,2.4,#087500,https://cards.scryfall.io/normal/front/b/5/b5aaaee0-9a61-45df-821e-cce516f8de6a.jpg?1783920874,Legendary Creature — Tyranid,Mathias Kollros
+Omenpath Journey,4,2024,1.8,#087500,https://cards.scryfall.io/normal/front/c/4/c49c9b72-61c0-4e3a-a3a6-994b149398a9.jpg?1783911999,Enchantment,Nereida
+Omnath- Locus of Mana,3,2023,4.3,#087500,https://cards.scryfall.io/normal/front/a/c/acf0cab3-da50-4561-8797-cd179af39216.jpg?1783915624,Legendary Creature — Elemental,Mike Bierek
+Omnivorous Flytrap,3,2024,0.26,#087500,https://cards.scryfall.io/normal/front/4/3/4370a197-68cc-46dd-bf0a-e9dab4ff6638.jpg?1783909450,Creature — Plant,Antonio José Manzanedo
+Once Upon a Time,2,2019,1.43,#087500,https://cards.scryfall.io/normal/front/4/0/4034e5ba-9974-43e3-bde7-8d9b4586c3a4.jpg?1783932607,Instant,Matt Stewart
+One with the Kami,4,2022,0.34,#087500,https://cards.scryfall.io/normal/front/d/7/d753c296-8cef-492d-ab41-e7ddb233d46e.jpg?1783923989,Enchantment — Aura,Justyna Dura
+On the Trail,2,2024,5.14,#087500,https://cards.scryfall.io/normal/front/e/5/e5cf1f9f-2e35-49b1-af47-75fbe11f7b7e.jpg?1783913041,Enchantment,Erikas Perl
+Ooze Flux,4,2013,0.26,#087500,https://cards.scryfall.io/normal/front/e/9/e9554369-7961-4cea-9da0-a1235805a26a.jpg?1783940116,Enchantment,Zoltan Boros
+Ooze Garden,2,2008,0.37,#087500,https://cards.scryfall.io/normal/front/6/2/623e57ed-7ed7-4283-b48f-77ecacad70b0.jpg?1783942550,Enchantment,Anthony S. Waters
+Open the Way,2,2026,0.53,#087500,https://cards.scryfall.io/normal/front/5/d/5d928e0d-a586-4de1-a469-0591122659fa.jpg?1783903763,Sorcery,Livia Prima
+Oracle of Mul Daya,4,2025,2.62,#087500,https://cards.scryfall.io/normal/front/a/b/ab19808f-a5b8-4dfd-800e-2064cd6538c8.jpg?1783906033,Creature — Elf Shaman,Vance Kovacs
+Oran-Rief Hydra,6,2017,1.88,#087500,https://cards.scryfall.io/normal/front/f/f/ff8c4bff-d37a-44b0-958f-91f4de6745c9.jpg?1783936143,Creature — Hydra,Chris Rahn
+Oran-Rief Ooze,3,2020,0.27,#087500,https://cards.scryfall.io/normal/front/f/d/fd2ad967-dd77-4c3a-b53c-2929ecf7750f.jpg?1783929334,Creature — Ooze,Daarken
+Ornery Tumblewagg,3,2024,0.38,#087500,https://cards.scryfall.io/normal/front/0/0/0020c31b-002a-4121-bc61-2c2c16e9afc8.jpg?1783911806,Creature — Brushwagg Mount,Izzy
+Ouroboroid,4,2025,31.42,#087500,https://cards.scryfall.io/normal/front/2/0/209c591a-4ab2-4e89-9523-a7b766cf4e51.jpg?1783905933,Creature — Plant Wurm,Samuel Perin
+Outcaster Trailblazer,3,2024,1.33,#087500,https://cards.scryfall.io/normal/front/3/3/33b9cd6c-d75c-4905-aa38-ff03a9c4b398.jpg?1783911804,Creature — Human Druid,Denys Tsiperko
+Outland Colossus,5,2015,0.14,#087500,https://cards.scryfall.io/normal/front/1/c/1caad298-52cb-46f1-8212-fe657ab80159.jpg?1783938318,Creature — Giant,Ryan Pancoast
+Overlaid Terrain,4,2000,1.54,#087500,https://cards.scryfall.io/normal/front/2/3/230c7926-9a4b-4ead-b4c8-889f84210545.jpg?1783945814,Enchantment,DiTerlizzi
+Overlord of the Hauntwoods,5,2024,8.01,#087500,https://cards.scryfall.io/normal/front/0/5/05d08ff1-edcc-4c76-96e0-683b3da36ebb.jpg?1783909450,Enchantment Creature — Avatar Horror,Tiffany Turrill
+Overwhelming Stampede,5,2026,0.54,#087500,https://cards.scryfall.io/normal/front/6/9/6996b9c4-e78c-4970-91c7-9025a0a4f670.jpg?1783903228,Sorcery,Daniel Landerman
+Oviya- Automech Artisan,4,2025,0.91,#087500,https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg?1783907867,Legendary Creature — Human Artificer,Julia Metzger
+Oviya Pashiri- Sage Lifecrafter,1,2016,0.23,#087500,https://cards.scryfall.io/normal/front/2/7/27eb9d40-958b-41b8-b04b-7f45adc0a862.jpg?1783937175,Legendary Creature — Human Artificer,Magali Villeneuve
+Owlbear Cub,3,2022,0.41,#087500,https://cards.scryfall.io/normal/front/b/e/be177b66-dab3-47ef-bcdf-8d99eb57e19f.jpg?1783922707,Creature — Bird Bear,Ernanda Souza
+Oxidize,1,2022,1.35,#087500,https://cards.scryfall.io/normal/front/e/7/e73eed0d-e162-4309-b367-d075aa59a32a.jpg?1783924043,Instant,Scott M. Fischer
+Ozolith- the Shattered Spire,2,2026,4.93,#087500,https://cards.scryfall.io/normal/front/1/d/1d5bab94-362e-45e6-8988-69e2b2c681b1.jpg?1783903762,Legendary Artifact,Daarken
+Pack Hunt,4,2000,0.45,#087500,https://cards.scryfall.io/normal/front/1/c/1c46caa8-efc0-4b72-b122-61e5d86a5b86.jpg?1783945814,Sorcery,Sam Wood
+Pale Bears,3,1995,3.98,#087500,https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg?1783947476,Creature — Bear,Anthony S. Waters
+Paleoloth,6,2009,10.77,#087500,https://cards.scryfall.io/normal/front/b/8/b83ad801-44e7-48d0-9f34-0d10536bb4dc.jpg?1783942474,Creature — Beast,Christopher Moeller
+Panglacial Wurm,7,2006,3.54,#087500,https://cards.scryfall.io/normal/front/0/6/063bb28b-5e32-4f31-a208-16b653edf413.jpg?1783943328,Creature — Wurm,Jim Pavelec
+Pangosaur,4,1999,0.51,#087500,https://cards.scryfall.io/normal/front/0/3/0335d282-cd1a-4be3-8eb2-82aaee91401a.jpg?1783945922,Creature — Dinosaur,Mark Tedin
+Paradise Druid,2,2024,1.49,#087500,https://cards.scryfall.io/normal/front/f/a/fa8f7b06-48cc-4b89-a3f8-27179aec9fc0.jpg?1783908595,Creature — Elf Druid,Alex Dos Diaz
+Paradox Zone,5,2021,0.89,#087500,https://cards.scryfall.io/normal/front/b/1/b1116eb3-4d16-4404-b29d-7d96d7eaa703.jpg?1783927589,Enchantment,Ryan Yee
+Parallel Evolution,5,2002,4.78,#087500,https://cards.scryfall.io/normal/front/7/3/73cce010-a8e7-477b-9179-bbad38aa6438.jpg?1783945140,Sorcery,Matt Cavotta
+Parallel Lives,4,2011,38.65,#087500,https://cards.scryfall.io/normal/front/0/1/01033dae-fec1-41f2-b7f2-cc6a43331790.jpg?1783940912,Enchantment,Steve Prescott
+Park Heights Maverick,3,2022,0.4,#087500,https://cards.scryfall.io/normal/front/f/2/f2ecac25-c187-40c6-af50-e7ce0ff9e921.jpg?1783923353,Creature — Human Soldier,Daarken
+Party Dude,1,2026,0.72,#087500,https://cards.scryfall.io/normal/front/d/2/d27b6f2a-84df-4097-a66a-8e463db47f58.jpg?1783904084,Enchantment — Class,Gabriel Rubio
+Pathbreaker Ibex,6,2017,18.93,#087500,https://cards.scryfall.io/normal/front/4/6/4608ea44-e1b2-42de-a0a2-e6d6d24d89d0.jpg?1783936252,Creature — Goat,Christopher Moeller
+Path of Discovery,4,2026,0.24,#087500,https://cards.scryfall.io/normal/front/8/0/8063528c-7347-4757-8254-5aa3e4b61c6f.jpg?1783903227,Enchantment,Rytis Sabaliauskas
+Path of the Animist,4,2023,0.37,#087500,https://cards.scryfall.io/normal/front/d/a/daf5fe01-6f27-4a78-bff0-0bfbb1bbd49f.jpg?1783917277,Sorcery,Liiga Smilshkalne
+Patron of the Orochi,8,2005,11.08,#087500,https://cards.scryfall.io/normal/front/6/d/6d6787c4-170a-45b6-8792-af3ea32ef538.jpg?1783944182,Legendary Creature — Spirit,Christopher Moeller
+Pattern of Rebirth,4,2018,5.33,#087500,https://cards.scryfall.io/normal/front/c/0/c0e34219-9fd9-4f11-a244-670fb75ef938.jpg?1783933788,Enchantment — Aura,Terese Nielsen
+Pawpatch Recruit,1,2024,0.6,#087500,https://cards.scryfall.io/normal/front/7/d/7d4d88ba-0ee4-4f66-995b-2e50614f50ee.jpg?1783910805,Creature — Rabbit Warrior,Johan Grenier
+Peema Trailblazer,3,2025,0.21,#087500,https://cards.scryfall.io/normal/front/d/5/d513e533-d3c5-45a1-a03c-2770b7b6832b.jpg?1783907749,Creature — Elephant Warrior,Michele Giorgi
+Pelakka Wurm,7,2018,0.26,#087500,https://cards.scryfall.io/normal/front/0/0/00906b47-6316-4e00-bbf5-b801ab583f4f.jpg?1783934531,Creature — Wurm,Daniel Ljunggren
+Pelt Collector,1,2018,0.41,#087500,https://cards.scryfall.io/normal/front/b/e/bee125cb-12b9-4f78-8e1d-6018d9c52275.jpg?1783934147,Creature — Elf Warrior,Zoltan Boros
+Penumbra Wurm,7,2001,0.69,#087500,https://cards.scryfall.io/normal/front/a/e/ae3dffe7-ecaf-4cf0-a43e-8e2746282992.jpg?1783945339,Creature — Wurm,Jeff Easley
+Permeating Mass,1,2016,0.32,#087500,https://cards.scryfall.io/normal/front/b/7/b71290eb-b529-4fc3-ab94-fee0ab9e2169.jpg?1783937441,Creature — Spirit,Joseph Meehan
+Pestilent Cauldron // Restorative Burst,3,2021,0.31,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact // Sorcery,Dan Murayama Scott
+Pest Infestation,1,2026,0.76,#087500,https://cards.scryfall.io/normal/front/c/9/c9b8626d-d3d8-4460-9adf-112f48f173f6.jpg?1783903762,Sorcery,Brian Valeza
+Pest Rescuer,3,2026,0.9,#087500,https://cards.scryfall.io/normal/front/1/f/1f2a066a-7bcd-4e9d-8e52-0769cd6c8124.jpg?1783903854,Creature — Dryad Druid,Justine Cruz
+Petrified Wood-Kin,7,2006,0.25,#087500,https://cards.scryfall.io/normal/front/a/5/a56fbf32-f08f-4882-b8d4-41ccb60cba63.jpg?1783943491,Creature — Elemental Warrior,Kev Walker
+Phantom Nantuko,3,2017,0.33,#087500,https://cards.scryfall.io/normal/front/2/f/2fd65594-cf66-4dd4-8d7b-b565756f2f86.jpg?1783936253,Creature — Insect Spirit,Wayne England
+Pheres-Band Warchief,4,2014,0.21,#087500,https://cards.scryfall.io/normal/front/8/4/8456730a-607c-44c0-b18e-0df8f35b0634.jpg?1783939409,Creature — Centaur Warrior,James Ryman
+Phyrexian Hydra,5,2011,4.34,#087500,https://cards.scryfall.io/normal/front/c/b/cb135aa1-9f46-4d60-a1a4-97aa0e852ced.jpg?1783941374,Creature — Phyrexian Hydra,Mike Bierek
+Phyrexian Swarmlord,6,2011,3.34,#087500,https://cards.scryfall.io/normal/front/8/a/8a91dea7-9792-4714-82b0-ba2c06cef304.jpg?1783941300,Creature — Phyrexian Insect Horror,Svetlin Velinov
+Phytotitan,6,2014,0.81,#087500,https://cards.scryfall.io/normal/front/e/0/e0e6eedf-8f5a-407e-b15b-48e19df20bed.jpg?1783939163,Creature — Plant Elemental,Marco Nelor
+Pippa- Duchess of Dice,3,2020,0.17,#d78f42,https://cards.scryfall.io/normal/front/e/2/e2f42b1a-5404-496a-b6e4-98794a4d8bee.jpg?1783931325,Legendary Creature — Human Noble,Simon Dominic
+Pir- Imaginative Rascal,3,2018,4.66,#087500,https://cards.scryfall.io/normal/front/5/a/5a7241f5-4d69-47fe-b037-95037008184c.jpg?1783934878,Legendary Creature — Human,Zoltan Boros
+Pir's Whim,4,2018,2.6,#087500,https://cards.scryfall.io/normal/front/b/8/b816ce6e-d876-4c6d-83ed-e3887dcfa5d5.jpg?1783934852,Sorcery,Jakub Kasper
+Pixie Queen,4,1994,36.15,#087500,https://cards.scryfall.io/normal/front/b/9/b9527c2a-23bb-4d33-9e72-6e0ab3de0e6b.jpg?1783948046,Creature — Faerie,Quinton Hoover
+Planar Engineering,4,2026,1.69,#087500,https://cards.scryfall.io/normal/front/c/8/c83b96a3-ddfd-4d11-8a85-5bf62087cbb9.jpg?1783903656,Sorcery,Liiga Smilshkalne
+Planeswalker's Favor,3,2001,0.47,#087500,https://cards.scryfall.io/normal/front/b/3/b3387540-93bf-451e-8e7a-fc78caab42b0.jpg?1783945612,Enchantment,Rebecca Guay
+Planewide Celebration,7,2019,0.94,#087500,https://cards.scryfall.io/normal/front/1/1/11016840-56b6-4759-bde6-3dc0e339e87e.jpg?1783933409,Sorcery,Wisnu Tan
+Plated Slagwurm,7,2014,0.44,#087500,https://cards.scryfall.io/normal/front/9/4/941fa83a-cb61-47b1-83a7-7ce7e894c338.jpg?1783938760,Creature — Wurm,Justin Sweet
+Plow Under,5,2003,1.0,#087500,https://cards.scryfall.io/normal/front/2/7/27128f26-0d89-4962-96e8-5fa343031a26.jpg?1783944659,Sorcery,Rob Alexander
+Polukranos Reborn // Polukranos- Engine of Ruin,3,2023,0.31,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Hydra // Legendary Creature — Phyrexian Hydra,David Auden Nash
+Polukranos- World Eater,4,2013,0.62,#087500,https://cards.scryfall.io/normal/front/4/9/4979cc1b-9c1a-47e4-ae37-7c41798eb89a.jpg?1783939739,Legendary Creature — Hydra,Johann Bodin
+Polygoyf,3,2024,0.37,#087500,https://cards.scryfall.io/normal/front/0/0/00b4625c-ce91-4b86-8db7-a6c2d4fb9c92.jpg?1783911419,Creature — Lhurgoyf,Helge C. Balzer
+Polyraptor,8,2018,16.37,#087500,https://cards.scryfall.io/normal/front/f/8/f8965a3a-93fe-4021-a665-b6013bdc86f7.jpg?1783935282,Creature — Dinosaur,Mark Behm
+Possessed Centaur,4,2002,0.38,#d78f42,https://cards.scryfall.io/normal/front/6/0/608e11b2-9636-48a0-8705-f5ce3bc98117.jpg?1783945140,Creature — Centaur Horror,Alex Horley-Orlandelli
+Power Fist,2,2024,16.83,#087500,https://cards.scryfall.io/normal/front/9/e/9e8f7fbc-bf2a-43c1-a88d-807c1e7dab69.jpg?1783912396,Artifact — Equipment,Campbell White
+Praetor's Counsel,8,2017,2.1,#087500,https://cards.scryfall.io/normal/front/b/6/b6d5bf06-f735-4e9f-9460-e6cdf501662f.jpg?1783936252,Sorcery,Daarken
+Predator Ooze,3,2024,0.2,#087500,https://cards.scryfall.io/normal/front/3/3/333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a.jpg?1783908916,Creature — Ooze,Ryan Yee
+Predatory Rampage,5,2012,0.18,#087500,https://cards.scryfall.io/normal/front/3/e/3e054ea5-3657-4198-9715-6acc0e362da3.jpg?1783940471,Sorcery,Wayne England
+Predatory Urge,4,2016,0.35,#087500,https://cards.scryfall.io/normal/front/1/8/18e3e459-992c-4990-8305-fa479c7870ac.jpg?1783936825,Enchantment — Aura,Scott Chou
+Preferred Selection,4,1996,0.69,#087500,https://cards.scryfall.io/normal/front/5/9/59ce9668-78ef-44a5-ba9c-49fa740b8cb5.jpg?1783947062,Enchantment,Kev Walker
+Preposterous Proportions,7,2024,1.28,#087500,https://cards.scryfall.io/normal/front/a/c/acb65189-60e4-42e0-9fb1-da6b716b91d7.jpg?1783909096,Sorcery,Ben Wootten
+Pride Sovereign,3,2017,3.43,#d78f42,https://cards.scryfall.io/normal/front/d/d/dd3d32b7-672f-4ceb-a1c9-17daefd2cb0c.jpg?1783936016,Creature — Cat,Ryan Yee
+Primal Adversary,3,2021,0.66,#087500,https://cards.scryfall.io/normal/front/b/f/bf3ce5c5-ea31-4f6d-84dd-430f52c49c4e.jpg?1783925576,Creature — Wolf,Ilse Gort
+Primal Command,5,2017,0.54,#087500,https://cards.scryfall.io/normal/front/9/2/92144021-7425-44e1-a32b-13252f1b7036.jpg?1783936631,Sorcery,Wayne England
+Primalcrux,6,2008,4.79,#087500,https://cards.scryfall.io/normal/front/1/f/1f805f7b-bb7e-436b-abd3-20a35e7ef71e.jpg?1783942679,Creature — Elemental,Wayne Reynolds
+Primal Prayers,4,2024,0.17,#087500,https://cards.scryfall.io/normal/front/c/4/c4eda3db-b47d-4f1e-a93d-e2ea747d935c.jpg?1783911257,Enchantment,Yeong-Hao Han
+Primal Surge,10,2012,5.89,#087500,https://cards.scryfall.io/normal/front/4/2/4278f7bd-afff-4a1d-a0bb-bf9ce3ad5a2e.jpg?1783940663,Sorcery,David Rapoza
+Primal Vigor,5,2013,14.42,#087500,https://cards.scryfall.io/normal/front/d/a/dafea0d1-6986-46b3-affc-1337ef564947.jpg?1783939657,Enchantment,Matt Stewart
+Primal Whisperer,5,2003,0.85,#087500,https://cards.scryfall.io/normal/front/c/7/c777432f-7965-4ad8-8d53-93919ae767d4.jpg?1783944897,Creature — Elf Soldier,Greg Staples
+Primeval Bounty,6,2024,0.28,#087500,https://cards.scryfall.io/normal/front/3/3/332c9742-dc3b-48e5-8736-7724fae1b4c4.jpg?1783908916,Enchantment,Christine Choi
+Primeval Force,5,2003,0.23,#087500,https://cards.scryfall.io/normal/front/7/0/70a4e884-b36c-4fde-84bb-a19a3ce160ae.jpg?1783944658,Creature — Elemental,Randy Gallegos
+Primeval Protector,11,2022,0.7,#087500,https://cards.scryfall.io/normal/front/1/5/15ab4c3b-323a-47c6-b675-447d16def3d5.jpg?1783923951,Creature — Avatar,Jaime Jones
+Primeval Titan,6,2017,8.2,#087500,https://cards.scryfall.io/normal/front/6/d/6d5537da-112e-4679-a113-b5d7ce32a66b.jpg?1783935516,Creature — Giant,Aleksi Briclot
+Primitive Etchings,4,2003,0.42,#087500,https://cards.scryfall.io/normal/front/e/a/eae26b8d-c3af-42d1-94f4-56950ceac1c7.jpg?1783944866,Enchantment,David Martin
+Primordial Hydra,2,2026,1.28,#087500,https://cards.scryfall.io/normal/front/2/9/29515c55-3b48-4c1d-a10b-b27fd1eb7a93.jpg?1783903761,Creature — Hydra,Aleksi Briclot
+Primordial Sage,6,2020,0.79,#087500,https://cards.scryfall.io/normal/front/4/b/4b0d8dec-e139-4565-9259-3c24c54c1d45.jpg?1783930356,Creature — Spirit,Justin Sweet
+Printlifter Ooze,2,2024,0.29,#087500,https://cards.scryfall.io/normal/front/d/b/db7fbf69-1118-446b-b5cb-02da2de42ce3.jpg?1783913040,Creature — Ooze,David Szabo
+Prismatic Omen,2,2008,6.48,#087500,https://cards.scryfall.io/normal/front/e/7/e75594cc-de47-49f2-9a8b-ba76c576368e.jpg?1783942741,Enchantment,John Avon
+Prize Pig,2,2023,0.32,#087500,https://cards.scryfall.io/normal/front/a/0/a0b202d8-3c25-467e-86ed-6bea19bb869f.jpg?1783916025,Creature — Boar,Bartłomiej Gaweł
+Prodigious Growth,6,2018,0.29,#087500,https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg?1783934530,Enchantment — Aura,Svetlin Velinov
+Professor Hojo,2,2025,0.22,#087500,https://cards.scryfall.io/normal/front/1/0/107ffe2e-47eb-43de-bc9e-c68013b62912.jpg?1783906351,Legendary Creature — Human Scientist,Danciao
+Prosperous Innkeeper,2,2025,0.56,#087500,https://cards.scryfall.io/normal/front/8/d/8dbdba5b-3014-47b9-b5c8-5f92a99df9f7.jpg?1783906779,Creature — Halfling Citizen,Brett Stenson
+Protean Hulk,7,2024,8.08,#087500,https://cards.scryfall.io/normal/front/6/9/69bf0bb7-3076-4dbf-a72e-4d91560be2fe.jpg?1783913300,Creature — Beast,Matt Cavotta
+Protean Hydra,1,2010,4.61,#087500,https://cards.scryfall.io/normal/front/f/6/f63d54c1-1b20-48c4-871d-0bb15e608996.jpg?1783941793,Creature — Hydra,Jim Murray
+Prowling Serpopard,3,2017,3.48,#087500,https://cards.scryfall.io/normal/front/9/2/92921fc1-11d0-41a9-b9b2-b44fd0913d31.jpg?1783936471,Creature — Cat Snake,Tyler Jacobson
+Puca's Covenant,3,2026,0.28,#087500,https://cards.scryfall.io/normal/front/1/9/1966dbd2-963a-4d37-ab26-c0a0715f523f.jpg?1783904602,Enchantment,Daria Aksenova
+Pugnacious Hammerskull,3,2023,0.57,#087500,https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg?1783913739,Creature — Dinosaur,Kev Walker
+Pulse of the Tangle,3,2004,0.36,#087500,https://cards.scryfall.io/normal/front/8/8/88cf1c67-9edc-42dd-ba7f-96baab25813a.jpg?1783944435,Sorcery,Wayne England
+Putrefax,5,2010,0.37,#087500,https://cards.scryfall.io/normal/front/b/2/b2b2c3f9-a831-4fd2-80e8-b67b0df3e98b.jpg?1783941717,Creature — Phyrexian Horror,Steven Belledin
+Pygmy Allosaurus,3,1995,1.28,#087500,https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg?1783947474,Creature — Dinosaur,Anson Maddocks
+Qasali Slingers,5,2017,12.87,#087500,https://cards.scryfall.io/normal/front/4/0/40e21394-146e-4648-b81e-63659c0c4764.jpg?1783935939,Creature — Cat Warrior,Izzy
+Quagnoth,6,2007,0.32,#087500,https://cards.scryfall.io/normal/front/3/3/335c3aa3-af89-44ce-955a-69e12d83175f.jpg?1783943094,Creature — Beast,Thomas M. Baxa
+Questing Beast,4,2019,4.05,#087500,https://cards.scryfall.io/normal/front/e/4/e41cf82d-3213-47ce-a015-6e51a8b07e4f.jpg?1783932604,Legendary Creature — Beast,Igor Kieryluk
+Questing Druid // Seek the Beast,2,2023,0.39,#d78f42,https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1783915063,Creature — Human Druid // Instant — Adventure,Jason A. Engle
+Quilled Greatwurm,6,2024,2.79,#087500,https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg?1783909095,Creature — Wurm,Michal Ivan
+Quirion Beastcaller,2,2022,0.34,#087500,https://cards.scryfall.io/normal/front/2/a/2a501319-59a7-45d4-a6ca-666276095f87.jpg?1783921296,Creature — Dryad Warrior,Valera Lutfullina
+Quirion Druid,3,1997,1.42,#087500,https://cards.scryfall.io/normal/front/8/c/8ca5319a-5c26-487f-ba87-d317633122ba.jpg?1783946981,Creature — Elf Druid,John Matson
+Quirion Dryad,2,2012,0.27,#087500,https://cards.scryfall.io/normal/front/4/d/4dba7f54-e49e-4f10-b5c5-46bb20871871.jpg?1783940467,Creature — Dryad,Todd Lockwood
+Radagast the Brown,4,2023,0.88,#087500,https://cards.scryfall.io/normal/front/b/3/b3988120-ebbe-4d24-9bb4-8c5331a14034.jpg?1783916261,Legendary Creature — Avatar Wizard,Alexander Mokhov
+Radioactive Spider,1,2025,0.43,#087500,https://cards.scryfall.io/normal/front/f/2/f2d267f5-7f12-45f8-8fcb-e0ba3fbdeddc.jpg?1783905323,Creature — Spider,Pavel Kolomeyets
+Railway Brawler,5,2024,5.27,#087500,https://cards.scryfall.io/normal/front/9/e/9ec1f76f-f21d-4f06-8c02-be6745183348.jpg?1783911804,Creature — Rhino Warrior,Kevin Sidharta
+Raised by Giants,6,2022,0.38,#087500,https://cards.scryfall.io/normal/front/1/1/11c93414-935e-462b-ad89-27ca21d01bf9.jpg?1783922704,Legendary Enchantment — Background,Kai Carpenter
+Rampage of the Clans,4,2019,0.48,#087500,https://cards.scryfall.io/normal/front/2/8/28ebab7d-d03d-4473-aa9b-485aebb66433.jpg?1783933668,Instant,Sidharth Chaturvedi
+Rampaging Aetherhood,5,2025,0.28,#087500,https://cards.scryfall.io/normal/front/b/d/bd923b84-067b-4041-a0f8-e2083e0debe9.jpg?1783907749,Creature — Snake Hydra,Ron Spencer
+Rampaging Baloths,6,2025,0.35,#087500,https://cards.scryfall.io/normal/front/8/4/84aa18de-6acc-46cc-8e28-3046790a6751.jpg?1783906033,Creature — Beast,Steve Prescott
+Rampaging Brontodon,7,2023,0.33,#087500,https://cards.scryfall.io/normal/front/e/a/ea3f71d6-e333-4e50-9545-deb73749413c.jpg?1783913858,Creature — Dinosaur,Lars Grant-West
+Rampaging Yao Guai,3,2024,6.63,#087500,https://cards.scryfall.io/normal/front/6/3/63619236-a27a-4fdd-add6-7a295901f906.jpg?1783912397,Creature — Bear Mutant,Christina Kraus
+Rampant Frogantua,3,2024,1.53,#087500,https://cards.scryfall.io/normal/front/8/5/8549b26f-f1fb-42d2-b20d-987e6461d191.jpg?1783911418,Creature — Frog,Filipe Pagliuso
+Rampant Rejuvenator,4,2022,1.22,#087500,https://cards.scryfall.io/normal/front/1/6/16b06b17-f256-428f-9bed-f115af270f27.jpg?1783923987,Creature — Plant Hydra,Andrey Kuzinskiy
+Rampart Architect,4,2025,0.27,#087500,https://cards.scryfall.io/normal/front/2/0/20f533fc-51d0-49bd-afcc-81b8b3ff9749.jpg?1783907165,Creature — Elephant Advisor,Eelis Kyttanen
+Ramunap Excavator,3,2024,5.7,#087500,https://cards.scryfall.io/normal/front/3/f/3f8a0a0e-81f7-40a2-b393-bdc1423549f6.jpg?1783911907,Creature — Snake Cleric,Mark Behm
+Ramunap Hydra,4,2017,0.33,#087500,https://cards.scryfall.io/normal/front/9/5/953f3722-2126-4eb3-a3d8-cff4b0703a9c.jpg?1783936014,Creature — Snake Hydra,Mike Burns
+Rancor,1,2026,1.65,#087500,https://cards.scryfall.io/normal/front/3/7/377792bf-2d72-40eb-9e47-1d4a86980fa4.jpg?1783903309,Enchantment — Aura,Marie Severin
+Ranger Class,2,2021,0.4,#087500,https://cards.scryfall.io/normal/front/7/c/7ca392ca-3219-4694-9a74-aa079c76b91e.jpg?1783926456,Enchantment — Class,Suzanne Helmigh
+Rattleclaw Mystic,2,2014,1.03,#d78f42,https://cards.scryfall.io/normal/front/4/f/4fb6c2e0-eeaa-4d60-aab7-2b8c739a9278.jpg?1783939065,Creature — Human Shaman,Tyler Jacobson
+Ravenous Baloth,4,2020,0.29,#087500,https://cards.scryfall.io/normal/front/2/f/2f48df6c-8d5d-4d8a-b98a-793f6a56184d.jpg?1783930355,Creature — Beast,Todd Lockwood
+Ravenous Gigantotherium,7,2020,0.23,#087500,https://cards.scryfall.io/normal/front/c/a/ca260253-40b8-4846-9e41-4e9cfc56d691.jpg?1783931210,Creature — Beast,Bartłomiej Gaweł
+Ravenous Slime,3,2018,1.87,#087500,https://cards.scryfall.io/normal/front/5/2/528d8f5e-2d58-4526-875b-21d199267210.jpg?1783934331,Creature — Ooze,Filip Burburan
+Razorclaw Bear,4,1998,30.36,#087500,https://cards.scryfall.io/normal/front/0/8/08c0cdbe-ca74-4edc-96ea-6db8eefe99d8.jpg?1783946450,Creature — Bear,Heather Hudson
+Reach of Branches,5,2008,0.47,#087500,https://cards.scryfall.io/normal/front/7/4/74e2215c-fdc0-4135-83ef-ddf4151318ba.jpg?1783942777,Kindred Instant — Treefolk,Scott Hampton
+Realm Seekers,6,2016,0.35,#087500,https://cards.scryfall.io/normal/front/9/3/93167de6-cbce-4bd6-bc41-c35f54f28544.jpg?1783937057,Creature — Elf Scout,Mike Sass
+Realms Uncharted,3,2010,11.2,#087500,https://cards.scryfall.io/normal/front/8/9/8967ceff-9e25-46da-926b-e05f4ee98325.jpg?1783941959,Instant,Volkan Baǵa
+Realmwalker,3,2026,1.12,#087500,https://cards.scryfall.io/normal/front/5/2/52733829-27b7-40ec-a897-cabab35b3729.jpg?1783904541,Creature — Shapeshifter,Zack Stella
+Rebirth,6,1995,0.37,#087500,https://cards.scryfall.io/normal/front/2/7/27c01d57-2bd4-433e-bea7-1acc70d14be3.jpg?1783947814,Sorcery,Mark Tedin
+Rebuking Ceremony,5,2004,0.29,#087500,https://cards.scryfall.io/normal/front/5/9/5940ed12-5224-4aed-9edc-dd4190691ee9.jpg?1783944434,Sorcery,Ittoku
+Recollect,3,2007,1.86,#087500,https://cards.scryfall.io/normal/front/b/e/be7ef1c2-a75e-47ef-8181-cb7933ac09d6.jpg?1783943174,Sorcery,Michael Sutfin
+Regal Behemoth,6,2023,0.41,#087500,https://cards.scryfall.io/normal/front/e/3/e3a8bdfa-a39c-4ca7-b591-1c6aca4cc5ac.jpg?1783913856,Creature — Dinosaur,Jakub Kasper
+Regal Force,7,2018,4.28,#087500,https://cards.scryfall.io/normal/front/9/c/9c24fe81-a8b7-4b20-b5dd-1d1c91ff057f.jpg?1783935085,Creature — Elemental,Brandon Kitkouski
+Regal Imperiosaur,3,2025,0.55,#087500,https://cards.scryfall.io/normal/front/3/6/36f569cc-ed09-4c27-b753-18b22ad7f425.jpg?1783907868,Creature — Dinosaur,Stephanie Cheung
+Reki- the History of Kamigawa,3,2005,14.88,#087500,https://cards.scryfall.io/normal/front/8/6/86317339-5a39-41eb-8aee-5ea926da8cd4.jpg?1783944138,Legendary Creature — Human Shaman,Edward P. Beard, Jr.
+Renegade Krasis,3,2013,0.34,#087500,https://cards.scryfall.io/normal/front/2/3/23b68921-0c34-4d92-83c3-21542f62c7f6.jpg?1783940034,Creature — Beast Mutant,Howard Lyon
+Reshape the Earth,9,2020,13.4,#087500,https://cards.scryfall.io/normal/front/a/d/ada14bc8-4549-4a73-8cbb-9a43698deb36.jpg?1783928786,Sorcery,Adam Paquette
+Resilient Khenra,2,2017,0.14,#087500,https://cards.scryfall.io/normal/front/0/3/033a69fb-2af9-426c-b1d6-3e5b18c78c9a.jpg?1783936014,Creature — Jackal Wizard,Svetlin Velinov
+Restock,5,2000,0.4,#087500,https://cards.scryfall.io/normal/front/1/1/11a013ff-7c99-445a-b9e0-0fc45036f068.jpg?1783945671,Sorcery,Daren Bader
+Return of the Mole Man,2,2026,9.54,#087500,https://cards.scryfall.io/normal/front/f/e/fe75cfa6-614a-43f7-9088-ec8ab00a8738.jpg?1783903035,Enchantment,Alex Horley-Orlandelli
+Return of the Wildspeaker,5,2026,0.94,#087500,https://cards.scryfall.io/normal/front/2/f/2fa1dac5-51ba-403e-b48b-d2c0d23a8146.jpg?1783904544,Instant,Chris Rallis
+Revelation,1,1995,0.93,#087500,https://cards.scryfall.io/normal/front/d/4/d467517a-1e6f-4c1f-adb5-bf60df1284e2.jpg?1783947361,World Enchantment,Kaja Foglio
+Revenge of the Hunted,6,2012,0.28,#087500,https://cards.scryfall.io/normal/front/3/6/36f7d663-115c-4ad0-a072-633df054cce4.jpg?1783940662,Sorcery,Christopher Moeller
+Reverent Hunter,3,2013,0.14,#087500,https://cards.scryfall.io/normal/front/9/7/97b4e736-d19a-42ac-8bcb-b8e6b7b7b539.jpg?1783939738,Creature — Human Archer,Wesley Burt
+Rhino- Terrible Trampler,6,2026,0.44,#087500,https://cards.scryfall.io/normal/front/4/b/4bce41d3-d59a-4d70-8df3-1cbb3a13be94.jpg?1783903035,Legendary Creature — Human Villain,Erikas Perl
+Rhonas's Last Stand,2,2017,0.19,#087500,https://cards.scryfall.io/normal/front/e/9/e991d1eb-70ab-4e2c-862d-fb8bfcefc542.jpg?1783936013,Sorcery,Winona Nelson
+Rhonas the Indomitable,3,2017,5.17,#087500,https://cards.scryfall.io/normal/front/5/0/50f23c47-278c-4188-8fb4-ae20a0c423c5.jpg?1783936470,Legendary Creature — God,Chase Stone
+Rhox,6,2007,0.55,#087500,https://cards.scryfall.io/normal/front/6/a/6aa50126-f6ec-4917-ac45-4b1f8f23ca09.jpg?1783942994,Creature — Rhino Beast,Mark Zug
+Rhys the Exiled,3,2021,1.01,#d78f42,https://cards.scryfall.io/normal/front/8/5/85004079-f9fa-4a05-904d-a77782c4165c.jpg?1783928310,Legendary Creature — Elf Warrior,Steve Prescott
+Ribtruss Roaster,5,2026,0.35,#087500,https://cards.scryfall.io/normal/front/8/2/8217100d-8244-4565-97bd-6c0f38c3e2f0.jpg?1783903852,Creature — Troll Druid,Steve Ellis
+Riding the Dilu Horse,3,1999,579.5,#087500,https://cards.scryfall.io/normal/front/6/7/676fea93-7f39-4fc7-89ab-bb3ea3f15951.jpg?1783946099,Sorcery,Hong Yan
+Ripjaw Raptor,4,2023,1.34,#087500,https://cards.scryfall.io/normal/front/e/c/ec01de20-8f78-47dd-8735-5e3981013708.jpg?1783913856,Creature — Dinosaur,Ryan Pancoast
+Rishkar- Peema Renegade,3,2023,0.41,#087500,https://cards.scryfall.io/normal/front/6/3/6310af34-e671-4974-b291-279b91585459.jpg?1783917135,Legendary Creature — Elf Druid,Todd Lockwood
+Rishkar's Expertise,6,2023,3.93,#087500,https://cards.scryfall.io/normal/front/e/f/efa9d2dc-b3b8-4475-bbfc-2db457ee4ffd.jpg?1783913855,Sorcery,Magali Villeneuve
+Rite of Passage,3,2004,4.93,#087500,https://cards.scryfall.io/normal/front/b/e/bea92a0c-f73f-4e85-9d87-6401aa1b052e.jpg?1783944389,Enchantment,Kev Walker
+Rites of Flourishing,3,2020,0.58,#087500,https://cards.scryfall.io/normal/front/a/b/ab014d5a-aec5-4ea8-bfb4-1392f43c1b30.jpg?1783929462,Enchantment,Brandon Kitkouski
+Road of Return,2,2019,0.42,#087500,https://cards.scryfall.io/normal/front/e/7/e718b21b-46d1-4844-985c-52745657b1ac.jpg?1783932803,Sorcery,Jonas De Ro
+Roaring Slagwurm,7,2004,0.35,#087500,https://cards.scryfall.io/normal/front/0/3/0338c6fe-54f6-4be0-a70d-b15e5403d842.jpg?1783944434,Creature — Wurm,David Martin
+Rocksteady- Mutant Marauder,3,2026,0.32,#087500,https://cards.scryfall.io/normal/front/a/e/ae25d91f-5489-4cd8-8634-42bcd32d4cf1.jpg?1783904165,Legendary Creature — Rhino Mutant,Kieran Yanner
+Rootcast Apprenticeship,4,2024,0.43,#087500,https://cards.scryfall.io/normal/front/0/0/00756441-a734-4960-9c69-f03a508a1522.jpg?1783910728,Sorcery,Andreia Ugrai
+Root Elemental,6,2024,0.27,#087500,https://cards.scryfall.io/normal/front/e/8/e8d6e393-7378-4113-a5ff-44e9518eff76.jpg?1783912987,Creature — Elemental,Anthony S. Waters
+Root Maze,1,2007,4.71,#087500,https://cards.scryfall.io/normal/front/7/2/727c757a-2ae5-45fd-9832-646a355a5710.jpg?1783942994,Enchantment,Rebecca Guay
+Rootpath Purifier,4,2022,10.67,#087500,https://cards.scryfall.io/normal/front/c/9/c9249743-d49e-4450-8fa6-52ed0ff6e5bb.jpg?1783919715,Creature — Elf Druid,Justyna Dura
+Rootweaver Druid,3,2020,0.31,#087500,https://cards.scryfall.io/normal/front/9/8/987e0ffe-ea75-4985-b6a3-b874bef78719.jpg?1783928787,Creature — Elf Druid,Lie Setiawan
+Rowen,4,2001,0.53,#087500,https://cards.scryfall.io/normal/front/b/b/bbc536ff-3e12-4e1b-b96f-b0c32dcb6734.jpg?1783945416,Enchantment,Franz Vohwinkel
+Rude Awakening,5,2014,1.25,#087500,https://cards.scryfall.io/normal/front/0/1/019897e4-d3ba-43b1-9bd9-2ebba6e3b349.jpg?1783938757,Sorcery,Ittoku
+Ruinous Intrusion,4,2023,0.3,#087500,https://cards.scryfall.io/normal/front/4/7/47f8c11f-8171-416a-a4a3-6530ca3ba7a6.jpg?1783913853,Instant,Johann Bodin
+Rumbleweed,11,2024,3.49,#087500,https://cards.scryfall.io/normal/front/f/e/fe1ecd63-075b-4eda-a9f7-d7f282c81d3b.jpg?1783911962,Creature — Plant Elemental,Filip Burburan
+Runadi- Behemoth Caller,3,2022,15.98,#087500,https://cards.scryfall.io/normal/front/f/4/f4f5500f-e82c-44f3-8be8-cee4c86824b1.jpg?1783919179,Legendary Creature — Cat Shaman,Billy Christian
+Runic Armasaur,3,2023,2.46,#087500,https://cards.scryfall.io/normal/front/1/7/17913fb0-ef73-4b20-8625-b84d4e62178a.jpg?1783913855,Creature — Dinosaur,Randy Vargas
+Rushwood Elemental,5,1999,0.89,#087500,https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg?1783945920,Creature — Elemental,Hannibal King
+Ruxa- Patient Professor,4,2021,4.09,#087500,https://cards.scryfall.io/normal/front/e/0/e07b8142-6a49-46e7-b862-41f89a59b894.jpg?1783927589,Legendary Creature — Bear Druid,Ilse Gort
+Rysorian Badger,3,1995,0.81,#087500,https://cards.scryfall.io/normal/front/a/b/ab87a387-678b-4913-a0c7-85f0238cee26.jpg?1783947277,Creature — Badger,Heather Hudson
+Sacellum Godspeaker,3,2008,0.32,#087500,https://cards.scryfall.io/normal/front/c/a/cad80819-22d4-43a8-97b2-7cf20f61bca5.jpg?1783942551,Creature — Elf Druid,Wayne Reynolds
+Sage of Ancient Lore // Werewolf of Ancient Hunger,5,2016,0.39,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Shaman Werewolf // Creature — Werewolf,Slawomir Maniak
+Sage of the Maze,3,2024,0.51,#087500,https://cards.scryfall.io/normal/front/d/4/d420385a-3f20-411c-b686-fecdbae29717.jpg?1783911419,Creature — Elf Wizard,Yeong-Hao Han
+Sakiko- Mother of Summer,6,2023,0.39,#087500,https://cards.scryfall.io/normal/front/8/d/8dbdb5f5-cd6e-47cd-b83d-ff71b00c369e.jpg?1783915621,Legendary Creature — Snake Shaman,Livia Prima
+Sakura-Tribe Elder,2,2026,3.43,#087500,https://cards.scryfall.io/normal/front/1/d/1db109d4-00a6-42ed-9d0d-d99eaab16e7f.jpg?1783904231,Creature — Snake Shaman,Elías Hernández
+Sanctum Weaver,2,2023,5.08,#087500,https://cards.scryfall.io/normal/front/3/c/3c9ac089-6962-48fd-bf67-f041ece27fa9.jpg?1783915420,Enchantment Creature — Dryad,Kimonas Theodossiou
+Sandman- Shifting Scoundrel,3,2025,0.38,#087500,https://cards.scryfall.io/normal/front/6/0/609ac18c-ec58-4fa7-bbee-3912a69d0ec6.jpg?1783905324,Legendary Creature — Sand Elemental Villain,Bartek Fedyczak
+Sandsteppe Mastodon,7,2015,0.14,#087500,https://cards.scryfall.io/normal/front/7/6/76ae01fb-12fa-444d-9d49-bfe195c2a5a6.jpg?1783938678,Creature — Elephant,James Zapata
+Sandsteppe War Riders,4,2023,0.19,#087500,https://cards.scryfall.io/normal/front/e/e/eed8f00b-0d77-48d4-a7b8-979a8ebc2210.jpg?1783917276,Creature — Human Warrior,Kekai Kotaki
+Sandstorm Salvager,3,2024,0.63,#087500,https://cards.scryfall.io/normal/front/1/3/13b0f27c-a359-4702-833a-82fec161eeec.jpg?1783911997,Creature — Human Artificer,Francis Tneh
+Sandwurm Convergence,8,2024,0.35,#087500,https://cards.scryfall.io/normal/front/3/a/3ad9cb61-4072-449b-9b32-83e2192cb292.jpg?1783909601,Enchantment,Slawomir Maniak
+Sapling Nursery,8,2026,1.13,#087500,https://cards.scryfall.io/normal/front/3/1/3199bea9-fef7-45fe-8777-2103d84a9347.jpg?1783904423,Enchantment,Vincent Christiaens
+Saproling Cluster,2,2000,0.56,#087500,https://cards.scryfall.io/normal/front/5/f/5f50072b-aedd-4074-b1f7-f9ce477c26c2.jpg?1783945813,Enchantment,Matt Cavotta
+Saproling Infestation,2,2000,0.37,#087500,https://cards.scryfall.io/normal/front/8/6/8642e530-914c-4149-944a-c4966ee27299.jpg?1783945671,Enchantment,Heather Hudson
+Saproling Symbiosis,4,2023,1.93,#087500,https://cards.scryfall.io/normal/front/6/4/64ae774a-c1de-4c9e-a2ec-86d71cb2d1db.jpg?1783918437,Sorcery,Ciruelo
+Saryth- the Viper's Fang,4,2024,4.1,#087500,https://cards.scryfall.io/normal/front/8/0/8050afb7-3c16-4456-aa34-4cc999fac7f5.jpg?1783912987,Legendary Creature — Human Warlock,Igor Kieryluk
+Sasaya- Orochi Ascendant // Sasaya's Essence,3,2005,3.01,#087500,https://cards.scryfall.io/normal/front/d/2/d224c50f-8146-4c91-9401-04e5bd306d02.jpg?1783944135,Legendary Creature — Snake Monk // Legendary Enchantment,Christopher Moeller
+Sauron- Dino Devotee,5,2026,14.52,#087500,https://cards.scryfall.io/normal/front/6/f/6f8f9a5d-514b-491d-a802-3a7629340bca.jpg?1783903035,Legendary Creature — Dinosaur Vampire Villain,Michal Ivan
+Savage Order,4,2023,33.59,#087500,https://cards.scryfall.io/normal/front/f/5/f571ef55-50dd-4624-aa42-fea5a0303033.jpg?1783913638,Sorcery,Jesper Ejsing
+Savage Summoning,1,2013,1.45,#087500,https://cards.scryfall.io/normal/front/b/5/b5346ed7-2e17-4d8c-9c4b-b5efdd26380d.jpg?1783939900,Instant,Johann Bodin
+Savvy Trader,4,2024,4.0,#087500,https://cards.scryfall.io/normal/front/1/1/118f25cf-faa6-4d60-a156-27bf7aedf7eb.jpg?1783911962,Creature — Human Citizen,Scott Murphy
+Sawtusk Demolisher,6,2020,2.9,#087500,https://cards.scryfall.io/normal/front/5/7/574d1a02-a403-4b6e-8ce0-a472325c9c2c.jpg?1783931210,Creature — Beast,Aaron Miller
+Sazh Katzroy,4,2025,0.62,#087500,https://cards.scryfall.io/normal/front/1/e/1e2a3566-1390-457e-8077-d776a8671319.jpg?1783906583,Legendary Creature — Human Pilot,Colin Boyer
+Scaled Nurturer,2,2026,2.52,#087500,https://cards.scryfall.io/normal/front/d/a/da3a03ad-24f7-47f8-b3b3-18b43c9e47be.jpg?1783904226,Creature — Dragon Druid,Diego Andrade
+Scapeshift,4,2018,47.06,#087500,https://cards.scryfall.io/normal/front/1/7/175e21a3-00f7-4c51-8a8e-fbfd7089efda.jpg?1783934527,Sorcery,Daniel Ljunggren
+Scavenging Ooze,2,2024,0.26,#087500,https://cards.scryfall.io/normal/front/8/c/8c504c23-1e9a-411b-9cfe-4180d0c744f6.jpg?1783909056,Creature — Ooze,Austin Hsu
+Scepter of Celebration,3,2022,3.01,#087500,https://cards.scryfall.io/normal/front/4/0/404b786c-b64c-4935-b0d3-4dd7a2d14c37.jpg?1783923353,Artifact — Equipment,Olena Richards
+Scion of Calamity,5,2023,2.84,#087500,https://cards.scryfall.io/normal/front/7/5/75db3c02-7a03-4de5-a70e-220777227dd3.jpg?1783913907,Creature — Dinosaur,Crystal Sully
+Scion of the Wild,3,2007,0.34,#087500,https://cards.scryfall.io/normal/front/8/5/85a78413-17e3-4652-91b4-708aa66a50ca.jpg?1783942992,Creature — Avatar,Kev Walker
+Scourge of Skola Vale,3,2014,0.35,#087500,https://cards.scryfall.io/normal/front/b/a/baef76dc-7cef-449b-b8a7-e038887129d9.jpg?1783939529,Creature — Hydra,Dave Kendall
+Scrapshooter,3,2024,0.4,#087500,https://cards.scryfall.io/normal/front/c/4/c42ab407-e72d-4c48-9a9e-2055b5e71c69.jpg?1783910803,Creature — Raccoon Archer,Chris Rahn
+Scurry of Squirrels,3,2024,5.65,#087500,https://cards.scryfall.io/normal/front/c/3/c343b965-af2b-45c3-babb-9242736cf1e5.jpg?1783910727,Creature — Squirrel Scout,Izzy
+Scute Mob,1,2018,0.73,#087500,https://cards.scryfall.io/normal/front/2/8/28d10cf2-c40d-4748-add0-f9cdd606030c.jpg?1783934282,Creature — Insect,Zoltan Boros & Gabor Szikszai
+Scute Swarm,3,2024,8.03,#087500,https://cards.scryfall.io/normal/front/e/a/ea630ba1-22f9-4a10-bdc6-0d03128214f4.jpg?1783909601,Creature — Insect,Alex Konstad
+Scythecat Cub,2,2024,24.08,#087500,https://cards.scryfall.io/normal/front/b/3/b3dd3c7d-4685-4579-b483-14ddaaaddf5b.jpg?1783908863,Creature — Cat,Gabor Szikszai
+Season of Gathering,6,2024,7.25,#087500,https://cards.scryfall.io/normal/front/7/1/71dd3c27-e0d5-434e-a0f3-4a95245e21c2.jpg?1783910804,Sorcery,A. M. Sartor
+Seasons Past,6,2016,2.6,#087500,https://cards.scryfall.io/normal/front/6/6/668afd78-3cf5-4daf-8dfb-fca90de0ae5a.jpg?1783937721,Sorcery,Christine Choi
+Second Harvest,4,2025,4.17,#087500,https://cards.scryfall.io/normal/front/a/a/aaecd005-b849-4e75-a8e0-24231bf2a0c9.jpg?1783908089,Instant,Matt Stewart
+Seedborn Muse,5,2025,14.72,#087500,https://cards.scryfall.io/normal/front/7/6/76f58441-5674-4f1e-af9b-94e14ab7e619.jpg?1783907041,Creature — Spirit,Adam Rex
+Seeds of Innocence,3,1996,6.61,#087500,https://cards.scryfall.io/normal/front/f/9/f9c868f5-0f90-4f7e-bafb-c45d2372fe06.jpg?1783947059,Sorcery,Junior Tomlin
+Seeds of Renewal,7,2016,0.27,#087500,https://cards.scryfall.io/normal/front/b/a/ba13b3ba-c36e-4c79-aaa6-2c2619a2d999.jpg?1783937086,Sorcery,Jesper Ejsing
+Seed the Land,4,2005,4.32,#087500,https://cards.scryfall.io/normal/front/e/c/ec1b0a4e-e52e-4d4e-9b12-24676d8571b1.jpg?1783944134,Enchantment,Anthony S. Waters
+Seedtime,2,2002,13.66,#087500,https://cards.scryfall.io/normal/front/4/f/4ffd5c52-f260-400c-b088-8792282509a5.jpg?1783945108,Instant,Rebecca Guay
+See the Unwritten,6,2014,0.6,#087500,https://cards.scryfall.io/normal/front/3/6/3689a7f1-9713-412e-a030-9cba463c170e.jpg?1783939064,Sorcery,Ryan Barger
+Seismic Tutelage,4,2025,0.83,#087500,https://cards.scryfall.io/normal/front/7/e/7e6939a5-0890-4c2f-b517-7d16f6490e76.jpg?1783904774,Enchantment — Aura,Florent Lebrun
+Sekki- Seasons' Guide,8,2005,1.7,#087500,https://cards.scryfall.io/normal/front/9/8/9883e973-54c3-4bec-91d8-22f2829cdfa2.jpg?1783944133,Legendary Creature — Spirit,Kev Walker
+Selective Adaptation,6,2020,0.32,#087500,https://cards.scryfall.io/normal/front/a/d/adbd8ffa-c7d3-4ef6-b3a7-8a967b50ce49.jpg?1783931208,Sorcery,Tomasz Jedruszek
+Selesnya Eulogist,3,2019,0.34,#087500,https://cards.scryfall.io/normal/front/3/e/3e65d501-6a11-4278-949b-53a3f3502fcc.jpg?1783932803,Creature — Centaur Druid,Tomasz Jedruszek
+Selfless Safewright,5,2026,0.43,#087500,https://cards.scryfall.io/normal/front/a/c/ac95b1c3-9eb2-4f80-bb32-72b36817d622.jpg?1783904421,Creature — Elf Warrior,Quintin Gleim
+Selvala- Heart of the Wilds,3,2026,3.68,#087500,https://cards.scryfall.io/normal/front/8/1/812856be-cf51-42de-96d2-4ac91e71d442.jpg?1783904541,Legendary Creature — Elf Scout,Tyler Jacobson
+Selvala's Stampede,6,2025,0.39,#087500,https://cards.scryfall.io/normal/front/b/8/b84e46c2-f3ea-49ff-8f8b-58aa6a1175a4.jpg?1783907040,Sorcery,Svetlin Velinov
+Sentinel of Lost Lore,3,2023,0.25,#087500,https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg?1783915078,Creature — Elf Knight,Cristi Balanescu
+Sentinel of the Nameless City,3,2023,0.39,#087500,https://cards.scryfall.io/normal/front/e/e/eeeffc0b-dc92-458e-ad58-86ff6077a508.jpg?1783913739,Creature — Merfolk Warrior Scout,Josu Hernaiz
+Sequence Engine,3,2021,0.19,#087500,https://cards.scryfall.io/normal/front/a/e/ae50172c-8896-4ad2-8c83-d349ccca2308.jpg?1783927587,Artifact,Aaron Miller
+Serpentine,0,2017,0.28,#087500,https://cards.scryfall.io/normal/front/f/2/f25a6611-db7e-48a5-8eb1-2886f8d3665a.jpg?1783935401,Creature — Wurm,Kari Christensen
+Seshiro the Anointed,6,2004,4.62,#087500,https://cards.scryfall.io/normal/front/3/8/3823e561-5a0a-4020-9322-a2b481499807.jpg?1783944282,Legendary Creature — Snake Monk,Daren Bader
+Setessan Champion,3,2023,4.87,#087500,https://cards.scryfall.io/normal/front/7/6/7680a8e1-cd59-43c5-8f06-426b918692c8.jpg?1783915420,Creature — Human Warrior,Emrah Elmasli
+Setessan Tactics,2,2014,0.48,#087500,https://cards.scryfall.io/normal/front/3/8/385a1939-15e5-4f13-b01b-7cdc6835da2a.jpg?1783939409,Instant,Mark Winters
+Seton- Krosan Protector,3,2001,3.26,#087500,https://cards.scryfall.io/normal/front/6/4/641a3bae-9146-4e70-862a-86a56f7c3816.jpg?1783945212,Legendary Creature — Centaur Druid,Greg Staples
+Shamanic Revelation,5,2022,0.99,#087500,https://cards.scryfall.io/normal/front/b/3/b3784eff-ab7b-4fd4-9a07-fbc852d116bf.jpg?1783923241,Sorcery,Cynthia Sheppard
+Shaman of Forgotten Ways,3,2015,8.05,#087500,https://cards.scryfall.io/normal/front/a/3/a3e9c8f7-2232-4a2a-8a00-0a2908bc7543.jpg?1783938576,Creature — Human Shaman,Tyler Jacobson
+Shang-Chi- Martial Mentor,5,2026,2.82,#087500,https://cards.scryfall.io/normal/front/f/b/fbc4bf7b-cd8e-4a85-9485-c190f8f8f7fb.jpg?1783903036,Legendary Creature — Human Warrior Hero,Aleksi Briclot
+Shang-Chi- Master of Kung Fu,2,2026,10.6,#087500,https://cards.scryfall.io/normal/front/2/e/2edbb62f-ad45-4422-850b-68dcc18b4c73.jpg?1783902911,Legendary Creature — Human Warrior Hero,Lee Woo-chul
+Shape of the Wiitigo,6,2006,0.38,#087500,https://cards.scryfall.io/normal/front/5/4/5436d55d-d2d0-4f22-b399-93f1d48e080f.jpg?1783943326,Enchantment — Aura,Ron Spencer
+Shapers' Sanctuary,1,2017,0.79,#087500,https://cards.scryfall.io/normal/front/9/3/930240dc-9c8c-4857-b6ce-85f1689c60e5.jpg?1783935719,Enchantment,Zezhou Chen
+Shared Roots,2,2026,3.22,#087500,https://cards.scryfall.io/normal/front/6/3/63a74a85-b57e-46a8-a485-69f07000dfe7.jpg?1783903509,Sorcery — Lesson,Ryohei Shimazaki
+Shared Summons,5,2019,2.52,#087500,https://cards.scryfall.io/normal/front/1/e/1e1e49b6-ed0f-42f5-af22-6f4aa23ce4ef.jpg?1783932958,Instant,Aaron Miller
+Sharp-Eyed Rookie,2,2024,0.15,#087500,https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg?1783912862,Creature — Human Detective,Jake Murray
+Shifting Ceratops,4,2023,0.26,#087500,https://cards.scryfall.io/normal/front/8/b/8be37115-b4aa-437a-9b72-01af0cf0a0cd.jpg?1783913853,Creature — Dinosaur,Izzy
+Shigeki- Jukai Visionary,2,2025,0.31,#087500,https://cards.scryfall.io/normal/front/e/d/ed8ea0da-c9d4-4158-aaa7-ebe2fe2b1e15.jpg?1783907041,Legendary Enchantment Creature — Snake Druid,Anna Podedworna
+Shisato- Whispering Hunter,4,2004,0.55,#087500,https://cards.scryfall.io/normal/front/5/c/5cc79c9c-f776-4c55-a7d1-9fac33f14630.jpg?1783944282,Legendary Creature — Snake Warrior,John Bolton
+Shizuko- Caller of Autumn,3,2005,4.05,#087500,https://cards.scryfall.io/normal/front/d/a/dab9407d-9389-4ec9-963c-80de095a6812.jpg?1783944180,Legendary Creature — Snake Shaman,Michael Sutfin
+Shriekwood Devourer,7,2024,0.38,#087500,https://cards.scryfall.io/normal/front/b/d/bd73c214-f6b6-49e9-b6e8-af6b1f1fb0f0.jpg?1783909653,Creature — Treefolk,David Astruga
+Shroofus Sproutsire,3,2024,4.97,#087500,https://cards.scryfall.io/normal/front/d/2/d29839f0-afe0-4caa-9628-655738aecce4.jpg?1783908855,Legendary Creature — Saproling,Yukihiro Maruo
+Siege Behemoth,7,2017,7.67,#087500,https://cards.scryfall.io/normal/front/4/6/46440515-7923-45ba-ad80-052999eaeaac.jpg?1783936246,Creature — Beast,Jason A. Engle
+Sigardian Zealot,5,2021,0.28,#087500,https://cards.scryfall.io/normal/front/9/8/98adcc86-debd-4aa8-86e5-c51ec08dab5a.jpg?1783925373,Creature — Human Cleric,Justyna Dura
+Silkguard,1,2026,0.34,#087500,https://cards.scryfall.io/normal/front/2/b/2b5fbcb8-9023-4a1c-b082-db44be8d8325.jpg?1783903761,Instant,Dan Murayama Scott
+Silklash Spider,5,2017,0.89,#087500,https://cards.scryfall.io/normal/front/0/e/0edd614b-f85f-476c-bf55-ad2db5c30cd7.jpg?1783936246,Creature — Spider,Iain McCaig
+Silverback Elder,5,2022,7.3,#087500,https://cards.scryfall.io/normal/front/b/9/b987664f-0b74-4c0a-b306-14767a55559a.jpg?1783921295,Creature — Ape Shaman,Alexander Mokhov
+Silverfur Partisan,3,2016,0.57,#087500,https://cards.scryfall.io/normal/front/a/2/a20f5392-5cde-4326-a322-7463ec4b0515.jpg?1783937721,Creature — Wolf Warrior,Izzy
+Silvos- Rogue Elemental,6,2016,0.31,#087500,https://cards.scryfall.io/normal/front/f/1/f1175357-01fe-438c-93bc-09e29ed8c9cb.jpg?1783937559,Legendary Creature — Elemental,Carl Critchlow
+Singing Tree,4,1993,140.08,#087500,https://cards.scryfall.io/normal/front/3/0/3003bf1e-8085-45d8-882b-c449109e7631.jpg?1783948380,Creature — Plant,Rob Alexander
+Sisterhood of Karn,2,2023,0.21,#087500,https://cards.scryfall.io/normal/front/4/b/4b94f939-5f3b-4b55-8514-b7d296509ac1.jpg?1783914642,Creature — Cleric,Yuliya Litvinova
+Six,3,2024,4.95,#087500,https://cards.scryfall.io/normal/front/f/9/f9246b68-580f-4f53-883d-7900880e4b0d.jpg?1783911256,Legendary Creature — Treefolk,Andrew Mar
+Skalla Wolf,5,2018,0.42,#087500,https://cards.scryfall.io/normal/front/f/3/f320e9f2-963d-468a-bf7a-726ef11e886d.jpg?1783934481,Creature — Wolf Spirit,Lius Lasahido
+Skarrg Goliath,8,2013,0.2,#087500,https://cards.scryfall.io/normal/front/2/b/2b2dcafd-eb72-4f3a-9c1c-ba17fe30bf0f.jpg?1783940116,Creature — Beast,Scott Chou
+Skinshifter,2,2011,0.35,#087500,https://cards.scryfall.io/normal/front/d/5/d56c82ad-5eb1-4653-8f02-e9bb1f6f3154.jpg?1783941054,Creature — Human Shaman,Matt Stewart
+Skullmulcher,5,2008,0.17,#087500,https://cards.scryfall.io/normal/front/b/5/b5178576-573d-4da8-97ae-a684e1e95fa4.jpg?1783942550,Creature — Elemental,Michael Ryan
+Skylasher,2,2013,0.2,#087500,https://cards.scryfall.io/normal/front/4/f/4f4c2069-deb1-4e56-8069-170c4f495944.jpg?1783940034,Creature — Insect,Dan Murayama Scott
+Skyshroud Behemoth,7,2000,0.39,#087500,https://cards.scryfall.io/normal/front/1/c/1c01d17e-45a2-4b6f-aaa5-2af9c8f26181.jpg?1783945813,Creature — Beast,Eric Peterson
+Skyshroud Claim,4,2026,7.27,#087500,https://cards.scryfall.io/normal/front/a/6/a6d2d79b-bef8-440f-a262-34349cf9fe5c.jpg?1783904262,Sorcery,Roman Klonek
+Skyshroud Poacher,4,2000,6.95,#087500,https://cards.scryfall.io/normal/front/0/f/0fb4e44e-656e-4294-a53b-1f7aa96fab31.jpg?1783945812,Creature — Human Rebel,Ron Spencer
+Skyshroud War Beast,2,1998,0.39,#087500,https://cards.scryfall.io/normal/front/1/9/19d809c1-e674-40b8-816d-c45d77c66722.jpg?1783946502,Creature — Beast,Jim Nelson
+Slashing Tiger,4,1999,73.99,#087500,https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg?1783946099,Creature — Cat,Yang Jun Kwon
+Sledge-Class Seedship,3,2025,0.3,#087500,https://cards.scryfall.io/normal/front/d/c/dc0cb4b6-cc20-49ea-84b2-2f3af3b0a19e.jpg?1783905930,Artifact — Spacecraft,Leon Tukker
+Slinza- the Spiked Stampede,5,2024,0.38,#d78f42,https://cards.scryfall.io/normal/front/9/c/9c442742-902c-49ae-813e-38a21ff8a78f.jpg?1783908854,Legendary Creature — Beast,Ishikawa Kenta
+Slippery Bogbonder,4,2022,4.43,#087500,https://cards.scryfall.io/normal/front/f/9/f9fc4f93-398c-4d11-a393-dd35e16ac1cc.jpg?1783923241,Creature — Human Druid,Mila Pesic
+Slumbering Trudge,1,2026,0.4,#087500,https://cards.scryfall.io/normal/front/3/a/3a925370-58ac-4181-9acc-db7b0e0abf17.jpg?1783903653,Creature — Plant Beast,Tuan Duong Chu
+Smuggler's Surprise,1,2024,4.57,#087500,https://cards.scryfall.io/normal/front/e/7/e7fbb489-e2b5-4278-8162-86802cf124d8.jpg?1783911803,Instant,Jonas De Ro
+Snowblind,4,1995,0.76,#087500,https://cards.scryfall.io/normal/front/5/f/5f62c376-487a-42bc-bd85-ab8b0480f7dc.jpg?1783947471,Enchantment — Aura,Douglas Shuler
+Sole Performer,4,2022,0.12,#087500,https://cards.scryfall.io/normal/front/e/6/e65e8d13-10b1-4d0b-813f-c45058560e5c.jpg?1783920547,Creature — Elf Performer,Anna Christenson
+Somberwald Beastmaster,7,2021,0.36,#087500,https://cards.scryfall.io/normal/front/5/a/5a4ba28b-a6c6-4268-8dc2-542d203f91a6.jpg?1783925373,Creature — Human Ranger,Marta Nael
+Somberwald Sage,3,2021,0.56,#087500,https://cards.scryfall.io/normal/front/6/0/6090c799-6cc3-4fc3-b5e6-8920678c67c1.jpg?1783925328,Creature — Human Druid,Steve Argyle
+Song of Inspiration,5,2021,0.34,#087500,https://cards.scryfall.io/normal/front/a/2/a231a41f-1609-420f-9a9b-3c8358591da1.jpg?1783926242,Instant,Lie Setiawan
+Song of the Dryads,3,2023,5.72,#087500,https://cards.scryfall.io/normal/front/1/6/161e66e3-0339-495c-bd06-0a799a254906.jpg?1783915619,Enchantment — Aura,Lars Grant-West
+Soul of the Harvest,6,2020,1.13,#087500,https://cards.scryfall.io/normal/front/d/7/d7ce9104-0ad3-4d3d-bb2c-c456c25030f6.jpg?1783930351,Creature — Elemental,Eytan Zana
+Soul of Zendikar,6,2019,0.29,#087500,https://cards.scryfall.io/normal/front/1/0/108a4330-d9dd-429d-a2f8-c355ff914883.jpg?1783932740,Creature — Avatar,Eytan Zana
+Soul's Majesty,5,2022,2.46,#087500,https://cards.scryfall.io/normal/front/9/f/9fe03ee0-50e4-4893-84ed-0d099be21d4e.jpg?1783923948,Sorcery,Jesper Ejsing
+Soul Swallower,4,2016,0.26,#087500,https://cards.scryfall.io/normal/front/2/2/22fbc045-2c86-4816-8622-db56929ae94d.jpg?1783937721,Creature — Wurm,Marco Nelor
+Spawning Grounds,8,2018,0.22,#087500,https://cards.scryfall.io/normal/front/4/6/46106777-e366-47da-b8ba-b010ac96f1fe.jpg?1783934281,Enchantment — Aura,Vincent Proce
+Spawnwrithe,3,2014,0.35,#087500,https://cards.scryfall.io/normal/front/5/b/5ba6ee29-fc77-4300-9c5e-1557cabd05e5.jpg?1783939482,Creature — Elemental,Daarken
+Spearbreaker Behemoth,7,2022,0.73,#087500,https://cards.scryfall.io/normal/front/d/7/d7f5cae6-5f1d-4537-9cc5-46d727d1beb1.jpg?1783923948,Creature — Beast,Christopher Moeller
+Spectral Force,5,2006,0.26,#087500,https://cards.scryfall.io/normal/front/d/7/d7dff1c4-6297-46f6-9c70-544c67319dd0.jpg?1783943208,Creature — Elemental Spirit,Dan Murayama Scott
+Spellbane Centaur,3,2001,0.43,#087500,https://cards.scryfall.io/normal/front/7/2/72194a6e-481d-4b07-922b-53f919bfa316.jpg?1783945210,Creature — Centaur,Rick Farrell
+Spelling Bee,3,2022,0.12,#087500,https://cards.scryfall.io/normal/front/4/0/40ceb595-33cd-4b5c-8a23-83b1cd5709d0.jpg?1783920546,Creature — Alien Insect,Caroline Gariba
+Sphere Grid,2,2025,8.71,#087500,https://cards.scryfall.io/normal/front/5/1/51188b1d-cb45-40f7-a3c2-5652b0679e02.jpg?1783906351,Enchantment,KOHEI YAMADA
+Spider-Ham- Peter Porker,2,2025,1.41,#087500,https://cards.scryfall.io/normal/front/4/1/41f18f42-b86b-4a12-9f0d-76b761571195.jpg?1783905324,Legendary Creature — Spider Boar Hero,Filipe Pagliuso
+Spider-Man- Miles Morales,6,2025,7.53,#087500,https://cards.scryfall.io/normal/front/6/1/61c17573-437e-4ffb-811f-8390d388d5a7.jpg?1783905368,Legendary Creature — Spider Human Hero,InHyuk Lee
+Spike Breeder,4,1998,0.28,#087500,https://cards.scryfall.io/normal/front/f/7/f7e11ef7-18a9-4ab1-981e-b337b1488ebd.jpg?1783946548,Creature — Spike,Adam Rex
+Spike Tiller,5,2006,0.26,#087500,https://cards.scryfall.io/normal/front/c/a/caf3643a-502f-4736-8063-5b567bdfbcc4.jpg?1783943207,Creature — Spike,Tony Szczudlo
+Spike Weaver,4,1998,4.99,#087500,https://cards.scryfall.io/normal/front/9/c/9c561a2a-91c6-4d4b-9f96-bffd43a00478.jpg?1783946500,Creature — Spike,Mike Raabe
+Spinner of Souls,3,2024,0.38,#087500,https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg?1783909094,Creature — Spider Spirit,Xavier Ribeiro
+Spirit of the Hunt,3,2016,0.52,#087500,https://cards.scryfall.io/normal/front/5/c/5c5f7b11-49ac-4078-aab7-efe3aff746b2.jpg?1783937439,Creature — Wolf Spirit,Bastien L. Deharme
+Splendid Reclamation,4,2025,0.36,#087500,https://cards.scryfall.io/normal/front/6/3/63c7f172-0aec-4629-967c-37253aed0f0d.jpg?1783906030,Sorcery,Uriah Voth
+Splinterfright,3,2022,0.39,#087500,https://cards.scryfall.io/normal/front/0/3/032ac9fc-b8b3-43f1-8579-62171ca976cf.jpg?1783921863,Creature — Elemental,Eric Deschamps
+Splintering Wind,4,1996,0.62,#087500,https://cards.scryfall.io/normal/front/0/a/0afa94e5-fef6-4f3a-9196-d7aa6dd841c2.jpg?1783947168,Enchantment,Ron Spencer
+Splitting Slime,5,2016,0.74,#087500,https://cards.scryfall.io/normal/front/c/9/c940f17e-7ddd-4a1a-8d6b-a012ced97cf9.jpg?1783937341,Creature — Ooze,James Paick
+Spontaneous Generation,4,1999,3.59,#087500,https://cards.scryfall.io/normal/front/c/e/ce5765cb-00cd-4920-9fe8-68791048ec4a.jpg?1783945919,Sorcery,Alan Pollack
+Spore Frog,1,2021,5.99,#087500,https://cards.scryfall.io/normal/front/7/a/7a0d52a9-8694-46b4-aa0e-7b42b45b11db.jpg?1783924573,Creature — Frog,Riot Games
+Sporeweb Weaver,3,2020,0.53,#087500,https://cards.scryfall.io/normal/front/e/6/e6ab63c8-0adc-4d74-aee5-a58ce5c0dad8.jpg?1783930666,Creature — Spider,Slawomir Maniak
+Sporocyst,1,2022,13.57,#087500,https://cards.scryfall.io/normal/front/7/2/72101d5f-f3a4-4490-a6f5-c320f3aeb242.jpg?1783920872,Creature — Tyranid,Fajareka Setiawan
+Sporogenesis,4,1998,3.49,#087500,https://cards.scryfall.io/normal/front/8/3/839d969b-b1f7-4978-b00c-db0766161f63.jpg?1783946311,Enchantment,Ron Spencer
+Springheart Nantuko,2,2024,5.35,#087500,https://cards.scryfall.io/normal/front/5/4/54a3ea87-005e-4985-b2a5-21711d0b71c0.jpg?1783911255,Enchantment Creature — Insect Monk,Valera Lutfullina
+Spring-Leaf Avenger,5,2022,0.34,#087500,https://cards.scryfall.io/normal/front/7/4/74b1ba9c-ee62-461f-8422-f791274e2f1c.jpg?1783923840,Creature — Insect Ninja,Wisnu Tan
+Springleaf Parade,2,2026,8.92,#087500,https://cards.scryfall.io/normal/front/4/4/44265489-645a-43b0-bc1f-726905b06876.jpg?1783904601,Enchantment,Cory Godbey
+Sproutback Trudge,9,2021,0.36,#087500,https://cards.scryfall.io/normal/front/d/b/dbf26e54-bdfe-4da8-acbb-4f1a98faba49.jpg?1783927585,Creature — Fungus Beast,Filip Burburan
+Sprouting Phytohydra,5,2006,3.51,#087500,https://cards.scryfall.io/normal/front/6/a/6a478eaa-2658-49db-965f-db25fc1d720e.jpg?1783943407,Creature — Plant Hydra,Heather Hudson
+Spry and Mighty,5,2026,0.34,#087500,https://cards.scryfall.io/normal/front/1/5/152b7374-e991-443f-b6ca-914415635c4a.jpg?1783904420,Sorcery,Pete Venters
+Squall Line,2,2006,2.09,#087500,https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg?1783943206,Instant,Lars Grant-West
+Squirrel Farm,3,2020,0.34,#087500,https://cards.scryfall.io/normal/front/c/c/cc67b0f2-c36d-4ad8-b2ec-08934568526b.jpg?1783931324,Enchantment,Ron Spencer
+Squirrel Mob,3,2021,2.23,#087500,https://cards.scryfall.io/normal/front/f/a/fa6bfc95-ec7e-46dd-88fd-b0e1ba48bfbc.jpg?1783926781,Creature — Squirrel,Carl Critchlow
+Squirrel Wrangler,4,2000,4.15,#087500,https://cards.scryfall.io/normal/front/7/0/7094be2a-454e-4e4d-a540-c5c80e37468a.jpg?1783945770,Creature — Human Druid,Carl Critchlow
+Stag Beetle,5,2002,0.69,#087500,https://cards.scryfall.io/normal/front/7/2/72cc64b9-f5b9-42d3-9921-564c4c9f2c77.jpg?1783945036,Creature — Insect,Anthony S. Waters
+Stampede,3,1997,0.45,#087500,https://cards.scryfall.io/normal/front/f/c/fcec8997-bc9b-42c0-bac1-5644e9915fa2.jpg?1783946889,Instant,Jeff A. Menges
+Steelbane Hydra,2,2026,0.35,#087500,https://cards.scryfall.io/normal/front/c/9/c9889a59-519c-4adb-9002-dbed400a0d33.jpg?1783903760,Creature — Turtle Hydra,Nicholas Gregory
+Steel Leaf Champion,3,2018,0.54,#087500,https://cards.scryfall.io/normal/front/2/4/24d8a688-79d4-49b9-ab0c-c7f5c9b551f4.jpg?1783934974,Creature — Elf Knight,Chris Rahn
+Steely Resolve,2,2002,19.55,#087500,https://cards.scryfall.io/normal/front/b/8/b88c530a-abc3-4cc4-8a48-5b76e1504a3c.jpg?1783945037,Enchantment,Greg Staples
+Steward of the Harvest,4,2025,0.27,#087500,https://cards.scryfall.io/normal/front/6/e/6e6ddbf5-e282-48ae-ba86-d15589d96e36.jpg?1783907166,Creature — Human Druid,Marie Magny
+Stonehoof Chieftain,8,2023,3.24,#087500,https://cards.scryfall.io/normal/front/3/4/3451dd0f-8cea-409f-8d56-f13e6aa424f6.jpg?1783915620,Creature — Centaur Warrior,Camille Alquier
+Stone-Tongue Basilisk,7,2001,0.42,#087500,https://cards.scryfall.io/normal/front/9/3/938d5157-154c-4300-82d4-0e23d934d436.jpg?1783945209,Creature — Basilisk,Wayne England
+Stonewood Invocation,4,2006,1.1,#087500,https://cards.scryfall.io/normal/front/1/b/1b300e67-04d2-4c69-b516-c5cc0a6ff2e7.jpg?1783943205,Instant,Pete Venters
+Storm the Festival,6,2021,0.32,#087500,https://cards.scryfall.io/normal/front/b/4/b4f1f69c-122d-472a-b82d-fed7c253a4cd.jpg?1783925572,Sorcery,Yigit Koroglu
+Strength of the Tajuru,2,2020,0.31,#087500,https://cards.scryfall.io/normal/front/1/f/1f123e02-eb74-4cc1-bc06-54989aeab784.jpg?1783931157,Instant,Christopher Moeller
+Strength of Will,2,2025,1.33,#087500,https://cards.scryfall.io/normal/front/6/8/68f985c7-7765-46c3-ad31-edae3abb9fbf.jpg?1783905321,Instant,Ryan Pancoast
+Strong Back,3,2024,1.74,#087500,https://cards.scryfall.io/normal/front/3/f/3f65afa5-e4f7-49c2-97f9-47ad5dbcacfa.jpg?1783912396,Enchantment — Aura,Elizabeth Peiró
+Strong- the Brutish Thespian,6,2024,0.34,#087500,https://cards.scryfall.io/normal/front/2/b/2bc79ed6-057b-439f-b2cd-58d5bcd8b551.jpg?1783912395,Legendary Creature — Mutant Berserker,Jason Rainville
+Stumpsquall Hydra,3,2020,0.56,#087500,https://cards.scryfall.io/normal/front/8/f/8fe8096b-332a-4832-b957-7a35bb350e4e.jpg?1783928734,Creature — Hydra,Grzegorz Rutkowski
+Summer Bloom,2,1999,5.88,#087500,https://cards.scryfall.io/normal/front/4/3/438ac149-e372-43f6-a47a-f536754adb1f.jpg?1783946019,Sorcery,Kaja Foglio
+Summoner's Grimoire,4,2025,0.32,#087500,https://cards.scryfall.io/normal/front/d/9/d9fda3fc-569d-49f8-a2ed-e0b1d6668426.jpg?1783906580,Artifact — Book Equipment,Daniel Correia
+Summoner's Pact,0,2021,5.15,#087500,https://cards.scryfall.io/normal/front/e/e/ee0f88ac-8a90-4057-b0e6-c15fbd02da38.jpg?1783927768,Instant,Chippy
+Summoning Materia,3,2025,0.27,#087500,https://cards.scryfall.io/normal/front/1/7/176401fb-f87c-4085-9dac-e6c8a843e32e.jpg?1783906350,Artifact — Equipment,Ryu Fujinaka
+Summoning Trap,6,2017,0.47,#087500,https://cards.scryfall.io/normal/front/5/5/55b71fb4-27ea-4846-87e4-efd2190faf36.jpg?1783936629,Instant — Trap,Kieran Yanner
+Summon: Magus Sisters,5,2025,0.32,#087500,https://cards.scryfall.io/normal/front/7/6/76a8cae7-e6ea-45eb-be8d-0e6a29b98aa6.jpg?1783906350,Enchantment Creature — Saga Faerie,Rui Maruyama
+Summon: Titan,5,2025,2.31,#087500,https://cards.scryfall.io/normal/front/5/c/5ce6ea96-7293-496d-b9c8-8ed6d6109a4d.jpg?1783906580,Enchantment Creature — Saga Giant,Andreia Ugrai
+Sunbringer's Touch,4,2015,0.16,#087500,https://cards.scryfall.io/normal/front/a/d/ad4d33ea-0193-4ea5-92ea-5f50a533bf6b.jpg?1783938574,Sorcery,Lucas Graciano
+Sunfrill Imitator,3,2023,0.9,#087500,https://cards.scryfall.io/normal/front/f/1/f1ac22a3-6edb-4f3e-b473-8166529eb769.jpg?1783913907,Creature — Dinosaur,Brian Valeza
+Super Combo,2,2026,0.38,#087500,https://cards.scryfall.io/normal/front/5/2/52bed0d4-3bcf-4770-b9c9-2a1d0666d220.jpg?1783904166,Sorcery,Caroline Gariba
+Surgeon General Commander,4,2020,0.32,#d78f42,https://cards.scryfall.io/normal/front/b/1/b1e21568-5474-4406-ad54-9e9330e5ff5c.jpg?1783931322,Legendary Creature — Wombat Bat Chameleon,Simon Dominic
+Surrak and Goreclaw,6,2023,9.92,#087500,https://cards.scryfall.io/normal/front/9/c/9c10934d-9016-43c4-a7ab-56cc7d8f671f.jpg?1783916899,Legendary Creature — Human Bear,Lucas Graciano
+Surrak- Elusive Hunter,3,2025,1.26,#087500,https://cards.scryfall.io/normal/front/e/4/e4775a26-0b66-40e9-8f64-41d9308ca032.jpg?1783907332,Legendary Creature — Human Warrior,Dan Murayama Scott
+Surrak- the Hunt Caller,4,2026,0.25,#087500,https://cards.scryfall.io/normal/front/d/e/deb328c7-fdda-4d63-9fe4-0482c1de6098.jpg?1783903944,Legendary Creature — Human Warrior,Wesley Burt
+Susan Foreman,2,2023,0.27,#087500,https://cards.scryfall.io/normal/front/a/d/ad40ec4f-37e7-4e6d-b47b-8b13ea2c9157.jpg?1783914640,Legendary Creature — Time Lord,Wangjie Li
+Suspicious Stowaway // Seafaring Werewolf,2,2021,0.15,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Rogue Werewolf // Creature — Werewolf,Jake Murray
+Swampbenders,6,2025,1.02,#087500,https://cards.scryfall.io/normal/front/b/0/b0a8ee49-7bb0-48e2-bc43-a2cfa0a7196c.jpg?1783904840,Creature — Human Druid Ally,Fahmi Fauzi
+Swarm Shambler,1,2020,0.27,#087500,https://cards.scryfall.io/normal/front/7/a/7a7e4f99-ece4-473e-b712-40e4c53558e8.jpg?1783929330,Creature — Fungus Beast,Nicholas Gregory
+Sweet-Gum Recluse,6,2022,0.45,#087500,https://cards.scryfall.io/normal/front/2/d/2d3c6325-450d-47f3-a69b-cdfc25ae65e6.jpg?1783922403,Creature — Spider,Jehan Choo
+Sylvan Advocate,2,2020,0.33,#087500,https://cards.scryfall.io/normal/front/7/f/7f5ac7ee-52e0-4c30-83cd-d27c29c19dbc.jpg?1783929461,Creature — Elf Druid Ally,Volkan Baǵa
+Sylvan Anthem,2,2021,1.41,#087500,https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg?1783926824,Enchantment,Franz Vohwinkel
+Sylvan Awakening,3,2018,1.21,#087500,https://cards.scryfall.io/normal/front/9/3/93ac4d3d-064e-459d-b3a4-6c0872a2da8c.jpg?1783934971,Sorcery,Adam Paquette
+Sylvan Basilisk,5,1999,1.07,#087500,https://cards.scryfall.io/normal/front/6/5/65707330-6808-458b-9550-13f9abc438af.jpg?1783946019,Creature — Basilisk,Ron Spencer
+Sylvan Caryatid,2,2025,1.11,#087500,https://cards.scryfall.io/normal/front/2/6/2662837c-3837-4da9-80b4-79edb0b6c289.jpg?1783907037,Creature — Plant,Chase Stone
+Sylvan Library,2,2023,29.15,#087500,https://cards.scryfall.io/normal/front/6/a/6ada256f-2e55-4c1f-b4d3-d7b10b498956.jpg?1783918436,Enchantment,Yeong-Hao Han
+Sylvan Offering,1,2022,0.4,#087500,https://cards.scryfall.io/normal/front/c/d/cd68c02d-aa09-47ee-b989-65965e82b9f3.jpg?1783923239,Sorcery,Zoltan Boros
+Sylvan Primordial,7,2013,1.54,#087500,https://cards.scryfall.io/normal/front/0/4/0483c869-38dc-4b0b-82f3-dd08a1ab985f.jpg?1783940114,Creature — Avatar,Stephan Martiniere
+Sylvan Safekeeper,1,2024,5.61,#087500,https://cards.scryfall.io/normal/front/8/3/83036e21-21ea-4324-aa07-11757f80c417.jpg?1783911211,Creature — Human Wizard,Magali Villeneuve
+Sylvan Scavenging,3,2024,0.26,#087500,https://cards.scryfall.io/normal/front/c/3/c35b683c-d3b2-46a1-876a-81b34e8ba2fc.jpg?1783909094,Enchantment,Josiah "Jo" Cameron
+Sylvan Tutor,1,1997,56.58,#087500,https://cards.scryfall.io/normal/front/2/8/287ba07e-6434-4850-940f-454fcab3f535.jpg?1783946801,Sorcery,Kaja Foglio
+Sylvan Yeti,4,1999,1.58,#087500,https://cards.scryfall.io/normal/front/0/9/096e7d5a-d998-4ef7-b34f-986aa69c526b.jpg?1783946020,Creature — Yeti,Brom
+Symbiotic Deployment,3,2001,0.55,#087500,https://cards.scryfall.io/normal/front/a/6/a6e2b7e9-d52b-478e-b118-e890a81fd471.jpg?1783945338,Enchantment,Kev Walker
+Symbiotic Wurm,8,2011,2.16,#087500,https://cards.scryfall.io/normal/front/a/5/a5c748cb-6386-4479-8f4d-248cae98d2b8.jpg?1783941187,Creature — Wurm,Matt Cavotta
+Tail Swipe,1,2023,0.45,#087500,https://cards.scryfall.io/normal/front/e/1/e1db87c8-9376-42ce-b377-b1dd26c68097.jpg?1783914765,Instant,Edgar Sánchez Hidalgo
+Tajuru Paragon,2,2020,0.21,#087500,https://cards.scryfall.io/normal/front/a/0/a045dd0f-953a-4022-8f29-0758f2b6ccaa.jpg?1783929330,Creature — Elf,Cristi Balanescu
+Tajuru Preserver,2,2010,3.71,#087500,https://cards.scryfall.io/normal/front/c/8/c8d03346-0802-4058-b89e-1b6076963c8e.jpg?1783941958,Creature — Elf Shaman,rk post
+Talara's Battalion,2,2018,0.31,#087500,https://cards.scryfall.io/normal/front/3/6/366c5992-e97f-4f15-bea9-8a62675e46a5.jpg?1783935085,Creature — Elf Warrior,Todd Lockwood
+Tale of Katara and Toph,3,2025,1.62,#087500,https://cards.scryfall.io/normal/front/8/f/8fe2bd89-a7cc-4e8e-98b4-69f196bd1024.jpg?1783904811,Enchantment,Ichiko Milk Tei
+Tamiyo's Safekeeping,1,2025,20.72,#087500,https://cards.scryfall.io/normal/front/9/d/9dab2792-02b0-482a-9225-9eed5465dfd8.jpg?1783905157,Instant,Evyn Fong
+Tangle,2,2025,6.51,#087500,https://cards.scryfall.io/normal/front/1/0/10c51d68-9a69-4784-9ce1-d6beaafa3ed3.jpg?1783905379,Instant,Humberto Ramos & Edgar Delgado
+Tangleweave Armor,4,2023,0.35,#087500,https://cards.scryfall.io/normal/front/6/7/67e766ee-b5e9-469b-81ad-65b5970723fb.jpg?1783918153,Artifact — Equipment,Johann Bodin
+Tanuki Transplanter,4,2022,1.77,#087500,https://cards.scryfall.io/normal/front/4/5/45ea5ead-9fd8-4909-96aa-d4e970891c93.jpg?1783923988,Artifact Creature — Equipment Dog,Oleksandr Kozachenko
+Taoist Mystic,3,1999,49.99,#087500,https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg?1783946097,Creature — Human Mystic,Qu Xin
+Tarmogoyf,2,2021,5.2,#087500,https://cards.scryfall.io/normal/front/6/9/69daba76-96e8-4bcc-ab79-2f00189ad8fb.jpg?1783927768,Creature — Lhurgoyf,Justin Murray
+Tarmogoyf Nest,3,2024,0.3,#087500,https://cards.scryfall.io/normal/front/1/a/1a906132-19ab-4b7c-95de-08f8a5fa3aea.jpg?1783911405,Kindred Enchantment — Lhurgoyf Aura,Filipe Pagliuso
+Tato Farmer,3,2024,0.66,#087500,https://cards.scryfall.io/normal/front/9/0/907bade4-7232-4808-af5c-2dbed4d5bf07.jpg?1783912395,Creature — Zombie Mutant Peasant,Xavier Ribeiro
+Taunting Challenge,3,1999,50.59,#087500,https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg?1783946096,Sorcery,Gao Yan
+Tchotchke Elemental,1,2022,0.09,#087500,https://cards.scryfall.io/normal/front/6/5/658d1a66-27dc-45fa-9b2a-91b012b1a86f.jpg?1783920545,Creature — Elemental,Sean Murray
+Teachings of the Kirin // Kirin-Touched Orochi,2,2022,0.3,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Snake Monk,Sam Burley
+Tectonic Split,6,2025,1.91,#087500,https://cards.scryfall.io/normal/front/7/0/704b3385-bd73-4479-9579-4d9e38711529.jpg?1783904811,Enchantment,Mengxuan Li
+Teething Wurmlet,1,2022,0.33,#087500,https://cards.scryfall.io/normal/front/2/3/2350027a-f3a4-4cba-9dfc-27e33bddb3be.jpg?1783920039,Creature — Wurm,Jesper Ejsing
+Tempting Wurm,2,2002,9.61,#087500,https://cards.scryfall.io/normal/front/8/5/857c2b6c-cfdf-4c88-a334-2937cb7db603.jpg?1783945035,Creature — Wurm,Bob Petillo
+Tempt with Discovery,4,2019,3.2,#087500,https://cards.scryfall.io/normal/front/7/9/79248b68-4fab-46da-ab15-5c71c1f68d4b.jpg?1783932741,Sorcery,William Wu
+Temur War Shaman,6,2024,0.21,#087500,https://cards.scryfall.io/normal/front/2/4/24824ccd-d470-49eb-a07d-2fc0de817766.jpg?1783909601,Creature — Human Shaman,Raymond Swanland
+Tendershoot Dryad,5,2026,1.37,#087500,https://cards.scryfall.io/normal/front/d/e/def3571c-01dd-4eee-8f60-0ac4d1928d33.jpg?1783903820,Creature — Dryad,Evyn Fong
+Tender Wildguide,2,2024,0.46,#087500,https://cards.scryfall.io/normal/front/6/b/6b8bfa91-adb0-4596-8c16-d8bb64fdb26d.jpg?1783910802,Creature — Possum Druid,Jakob Eirich
+Terastodon,8,2021,0.35,#087500,https://cards.scryfall.io/normal/front/6/3/63195796-197e-47ec-85f0-d4ec0065f6e6.jpg?1783927528,Creature — Elephant,Lars Grant-West
+Termagant Swarm,1,2022,2.53,#087500,https://cards.scryfall.io/normal/front/3/1/31079fcb-49bf-41a2-a9b4-07c96f93399d.jpg?1783920871,Creature — Tyranid,Nikola Matkovic
+Terra Stomper,6,2015,0.12,#087500,https://cards.scryfall.io/normal/front/6/5/652db782-cf79-4626-9eb2-ad214cb39c86.jpg?1783938296,Creature — Beast,Goran Josic
+Terrasymbiosis,3,2025,7.92,#087500,https://cards.scryfall.io/normal/front/2/6/26008c7d-5dbe-4da2-b475-4dd307e7bc68.jpg?1783905928,Enchantment,Viko Menezes
+Terravore,3,2001,26.04,#087500,https://cards.scryfall.io/normal/front/c/3/c39c412b-2f21-483a-b744-5d55bc007c0d.jpg?1783945208,Creature — Lhurgoyf,Jim Nelson
+Territorial Allosaurus,4,2018,0.34,#087500,https://cards.scryfall.io/normal/front/3/d/3d8ac2b0-47ea-4aa3-bf24-c78227a0c913.jpg?1783934971,Creature — Dinosaur,Jonathan Kuo
+Tervigon,2,2022,4.56,#087500,https://cards.scryfall.io/normal/front/5/0/50909e0e-0bed-423a-beb4-a24b14e95edc.jpg?1783920869,Creature — Tyranid,Xavier Ribeiro
+The Cabbage Merchant,3,2025,24.39,#087500,https://cards.scryfall.io/normal/front/2/f/2fea0356-6684-4730-9eb4-0262856bc1f9.jpg?1783904816,Legendary Creature — Human Citizen,Patrick Gañas
+The Dragon-Kami Reborn // Dragon-Kami's Egg,3,2022,0.24,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Egg,Alix Branwyn
+The Earth Crystal,4,2025,11.94,#087500,https://cards.scryfall.io/normal/front/d/5/d585e218-3dc8-4fbd-8ad2-795fbc9b2155.jpg?1783906588,Legendary Artifact,Pablo Mendoza
+The Earth King,4,2025,1.23,#087500,https://cards.scryfall.io/normal/front/a/8/a8d5dca6-381a-4361-b265-27de8d04335c.jpg?1783904945,Legendary Creature — Human Noble Ally,Ryota Murayama
+The First Iroan Games,3,2020,0.36,#087500,https://cards.scryfall.io/normal/front/4/b/4b05ada5-8e5f-4158-bd28-e6c24e4a2299.jpg?1783931539,Enchantment — Saga,Noah Bradley
+The Five Doctors,6,2023,0.2,#087500,https://cards.scryfall.io/normal/front/a/d/ada5e97f-c079-445c-8071-1c2a6dd00001.jpg?1783914645,Sorcery,JB Casacop
+The Foretold Soldier,4,2023,0.33,#087500,https://cards.scryfall.io/normal/front/9/3/93391c14-a22c-4223-a980-5f98350c6a99.jpg?1783914644,Creature — Alien Zombie Soldier,Fajareka Setiawan
+The Great Aurora,9,2015,0.64,#087500,https://cards.scryfall.io/normal/front/b/1/b1d0eb3b-00b9-42ca-9f7d-5543bffc3480.jpg?1783938322,Sorcery,Sam Burley
+The Great Henge,9,2023,64.0,#087500,https://cards.scryfall.io/normal/front/6/3/6340e0f3-7f9c-4d71-8daf-e1be5505eb5b.jpg?1783915629,Legendary Artifact,Adam Paquette
+The Huntsman's Redemption,3,2023,0.35,#087500,https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg?1783915080,Enchantment — Saga,Magali Villeneuve
+The Legend of Kyoshi // Avatar Kyoshi,6,2025,4.96,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Legendary Creature — Avatar,Thanh Tuấn
+Thelonite Hermit,4,2024,0.28,#087500,https://cards.scryfall.io/normal/front/4/2/4271f5b2-32ca-4349-9a09-afffbdacf636.jpg?1783912986,Creature — Elf Shaman,Chippy
+Thelonite Monk,4,1994,0.61,#087500,https://cards.scryfall.io/normal/front/5/4/5400ff25-c70e-4095-a228-190601b86043.jpg?1783947883,Creature — Insect Monk Cleric,Bryon Wackwitz
+Thelon of Havenwood,2,2021,0.41,#d78f42,https://cards.scryfall.io/normal/front/7/8/783f1b9f-9866-4ead-96cf-88babf459ce2.jpg?1783927768,Legendary Creature — Elf Druid,Kev Walker
+Thelon's Curse,2,1994,0.69,#d78f42,https://cards.scryfall.io/normal/front/9/b/9b868846-cc3c-4756-a5dd-2335bb380567.jpg?1783947884,Enchantment,Pete Venters
+The Mending of Dominaria,5,2024,0.38,#087500,https://cards.scryfall.io/normal/front/6/8/6887f55f-7ac0-49b3-a3ed-6cdbd0ce7fe0.jpg?1783911910,Enchantment — Saga,Adam Paquette
+The Pride of Hull Clade,11,2024,1.46,#d78f42,https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg?1783912862,Legendary Creature — Crocodile Elk Turtle,Brent Hollowell
+The Ring Goes South,4,2023,0.35,#087500,https://cards.scryfall.io/normal/front/3/c/3c8a4c7d-527c-49ea-a115-a9e747c0fd03.jpg?1783916261,Sorcery,Wangjie Li
+The Sea Devils,3,2023,0.24,#087500,https://cards.scryfall.io/normal/front/9/6/96fcb0cb-0df9-4a45-beab-08dc39cf6b3b.jpg?1783914642,Enchantment — Saga,Miklós Ligeti
+The Skullspore Nexus,8,2023,11.12,#087500,https://cards.scryfall.io/normal/front/b/5/b56a7631-5f94-468d-aab7-7e9e129c5f49.jpg?1783913740,Legendary Artifact,Daarken
+The Tarrasque,9,2021,4.11,#087500,https://cards.scryfall.io/normal/front/8/a/8a26fa15-d81f-4152-ae33-e91aa276b3fc.jpg?1783926454,Legendary Creature — Dinosaur,Filip Burburan
+The Thing,6,2026,1.21,#d78f42,https://cards.scryfall.io/normal/front/b/a/ba5167e4-27b1-4f55-8282-7b5bd6de611a.jpg?1783903304,Legendary Creature — Human Hero,Darius Zablockis
+The Unbeatable Squirrel Girl,4,2026,4.94,#087500,https://cards.scryfall.io/normal/front/d/8/d8b94ebb-0b3a-4e68-8c0c-3a61ac32f3ef.jpg?1783902911,Legendary Creature — Squirrel Human Hero,Kim Dingwall
+The World Spell,7,2022,0.47,#087500,https://cards.scryfall.io/normal/front/f/3/f3a9112a-6a1d-4d89-9866-189b55cd326d.jpg?1783921290,Enchantment — Saga,Adam Paquette
+Thickest in the Thicket,5,2024,0.37,#087500,https://cards.scryfall.io/normal/front/8/2/821f01e4-082e-424a-ae77-4053da893eb2.jpg?1783910727,Enchantment,Michele Giorgi
+Thicket Elemental,5,2016,0.22,#087500,https://cards.scryfall.io/normal/front/c/5/c5a462ca-0632-410d-9999-a096b71fc3ea.jpg?1783937269,Creature — Elemental,Ron Spencer
+Thorn Elemental,7,2003,0.38,#087500,https://cards.scryfall.io/normal/front/1/2/12fa0c8c-f069-4f3b-b049-90e1089346ef.jpg?1783944650,Creature — Elemental,rk post
+Thorn Lieutenant,2,2018,0.2,#087500,https://cards.scryfall.io/normal/front/0/8/0812e942-eb78-48c8-857e-5f0ff1bd777b.jpg?1783934528,Creature — Elf Warrior,Uriah Voth
+Thornling,5,2009,0.92,#087500,https://cards.scryfall.io/normal/front/1/6/16691f25-8d6f-4edd-84ad-3209e8a74cf3.jpg?1783942472,Creature — Elemental Shapeshifter,Kev Walker
+Thorn Mammoth,7,2019,1.35,#087500,https://cards.scryfall.io/normal/front/8/0/80138656-b2e2-43bf-9fe6-7a852f53f9e9.jpg?1783932548,Creature — Elephant,Svetlin Velinov
+Thornscape Master,4,2000,0.32,#d78f42,https://cards.scryfall.io/normal/front/7/e/7e8f164d-3782-4eaa-a4db-ab7082d45ee7.jpg?1783945670,Creature — Human Wizard,Larry Elmore
+Thornvault Forager,2,2024,3.29,#087500,https://cards.scryfall.io/normal/front/8/c/8c2d6b02-a453-40f9-992a-5c5542987cfb.jpg?1783910802,Creature — Squirrel Ranger,Mark Behm
+Thragtusk,5,2022,0.27,#087500,https://cards.scryfall.io/normal/front/b/e/beda7acd-e970-4222-9577-5133765d6052.jpg?1783923239,Creature — Beast,Nils Hamm
+Thrasta- Tempest's Roar,12,2021,0.71,#087500,https://cards.scryfall.io/normal/front/6/1/6172da14-9a87-4cf9-aff5-aca3470a67ef.jpg?1783926824,Legendary Creature — Dinosaur,Andrew Mar
+Threats Undetected,3,2022,0.36,#087500,https://cards.scryfall.io/normal/front/9/9/99545c3e-0710-48d3-8558-046bd66f225c.jpg?1783921293,Sorcery,Randy Vargas
+Three Visits,2,2025,16.62,#087500,https://cards.scryfall.io/normal/front/6/7/67786575-7ad6-40a9-adac-5626f407f5b1.jpg?1783905573,Sorcery,Lucas Werneck
+Thriss- Nantuko Primus,7,2002,0.35,#087500,https://cards.scryfall.io/normal/front/a/d/ad9e647d-903f-4a77-a56c-cd5c0c2f12cf.jpg?1783945107,Legendary Creature — Insect Druid,John Avon
+Thrun- Breaker of Silence,5,2023,0.31,#087500,https://cards.scryfall.io/normal/front/6/d/6d9f51dd-0393-4b3c-bea5-8f74634ab0e5.jpg?1783918008,Legendary Creature — Troll Shaman,Simon Dominic
+Thrun- the Last Troll,4,2011,0.83,#087500,https://cards.scryfall.io/normal/front/5/d/5d393da0-4cb6-4ae8-b747-8e6d0fa7f55a.jpg?1783941373,Legendary Creature — Troll Shaman,Jason Chan
+Thunderfoot Baloth,6,2024,0.7,#087500,https://cards.scryfall.io/normal/front/8/0/80c1b1ea-2459-4986-8846-4db916d6b771.jpg?1783909599,Creature — Beast,Nicholas Gregory
+Thundering Mightmare,5,2021,0.41,#087500,https://cards.scryfall.io/normal/front/a/3/a37fbffb-4ed0-4c61-9cef-2cd55ad67f9c.jpg?1783924995,Creature — Horse Spirit,Lorenzo Mastroianni
+Thundering Wurm,3,1997,1.71,#087500,https://cards.scryfall.io/normal/front/8/b/8b0ba623-d17f-4f0e-b914-da139a3971df.jpg?1783946801,Creature — Wurm,Paolo Parente
+Thunderous Debut,8,2023,0.26,#087500,https://cards.scryfall.io/normal/front/d/9/d98f51ec-8eae-434a-ab62-85bdb6586fa2.jpg?1783915075,Sorcery,Aldo Domínguez
+Thunderous Velocipede,3,2025,1.15,#087500,https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg?1783907865,Artifact — Vehicle,Adrián Rodríguez Pérez
+Tifa Lockhart,2,2025,2.51,#087500,https://cards.scryfall.io/normal/front/f/b/fb781323-2746-405d-a9b2-e778c037a6e9.jpg?1783906580,Legendary Creature — Human Monk,Laurel Austin
+Timbermare,4,2007,0.35,#087500,https://cards.scryfall.io/normal/front/2/d/2d604bac-58b7-4479-8ab8-2e0680746e0e.jpg?1783943138,Creature — Elemental Horse,Dan Dos Santos
+Timber Paladin,2,2023,0.39,#087500,https://cards.scryfall.io/normal/front/1/e/1edfd4d2-c492-4bec-9bb0-c5b7cb01818f.jpg?1783914984,Artifact Creature — Knight,Johan Grenier
+Timber Protector,5,2007,22.18,#087500,https://cards.scryfall.io/normal/front/1/4/14b93784-cbe5-437a-8235-f6864e413b41.jpg?1783942856,Creature — Treefolk Warrior,Terese Nielsen & Philip Tan
+Timber Wolves,1,1995,0.76,#087500,https://cards.scryfall.io/normal/front/d/8/d8f84fc8-69b4-4756-9634-4d6c17ec88a1.jpg?1783947811,Creature — Wolf,Melissa A. Benson
+Timmy- Power Gamer,4,2020,0.27,#087500,https://cards.scryfall.io/normal/front/3/f/3fa57822-8bca-4cdd-916f-261dae494228.jpg?1783931322,Legendary Creature — Human Gamer,Karl Kopinski
+Tireless Tracker,3,2025,0.35,#087500,https://cards.scryfall.io/normal/front/6/6/66444549-ad9b-49c6-a7c6-34e977c1085d.jpg?1783906030,Creature — Human Scout,Eric Deschamps
+Titania- Nature's Force,6,2024,1.17,#087500,https://cards.scryfall.io/normal/front/1/2/1230be09-8436-4023-bb8b-d325456c0914.jpg?1783909598,Legendary Creature — Elemental,Heonhwa
+Titania- Protector of Argoth,5,2025,0.38,#087500,https://cards.scryfall.io/normal/front/7/3/732c208b-cd9e-48a9-9b9d-aba63066ba53.jpg?1783906029,Legendary Creature — Elemental,Magali Villeneuve
+Titania's Command,6,2022,0.82,#087500,https://cards.scryfall.io/normal/front/7/5/753567c7-c484-4c0d-8128-7710e23c428f.jpg?1783920039,Sorcery,Dominik Mayer
+Titania- Voice of Gaea,3,2022,5.86,#087500,https://cards.scryfall.io/normal/front/d/e/deeb6a21-23b0-44f1-b70e-5899bb9d4a84.jpg?1783920039,Legendary Creature — Elemental,Cristi Balanescu
+Titan of Industry,7,2026,0.37,#087500,https://cards.scryfall.io/normal/front/4/3/432f2b57-4e7e-4717-8707-8cdbc1aae154.jpg?1783904541,Creature — Elemental,Lucas Staniec
+Tlincalli Hunter // Retrieve Prey,7,2022,0.66,#087500,https://cards.scryfall.io/normal/front/4/5/45b5d677-ff77-47ce-8612-bae70c326e4e.jpg?1783922499,Creature — Scorpion Scout // Sorcery — Adventure,Helge C. Balzer
+Tooth and Nail,7,2023,3.08,#087500,https://cards.scryfall.io/normal/front/d/f/df359b98-9f8f-4f32-82c6-f10ca0f81032.jpg?1783915618,Sorcery,Greg Hildebrandt
+Toph- Earthbending Master,4,2025,34.83,#087500,https://cards.scryfall.io/normal/front/2/2/22d1b078-9175-45ab-8fbe-ed4af2abde1f.jpg?1783904811,Legendary Creature — Human Warrior Ally,Phima
+Topiary Stomper,3,2023,0.72,#087500,https://cards.scryfall.io/normal/front/e/8/e8b92271-4412-4165-a4a6-e8653e755107.jpg?1783913853,Creature — Plant Dinosaur,Robin Olausson
+Topography Tracker,3,2023,0.28,#087500,https://cards.scryfall.io/normal/front/0/f/0f1686aa-6b34-4eb7-9811-bc1a8d8b46e9.jpg?1783913907,Creature — Merfolk Scout,Lindsey Look
+Tornado Elemental,7,2017,0.37,#087500,https://cards.scryfall.io/normal/front/9/8/9859d07b-d7df-4fc3-895a-6b2749c562ad.jpg?1783936241,Creature — Elemental,Richard Wright
+Toski- Bearer of Secrets,4,2024,9.12,#087500,https://cards.scryfall.io/normal/front/e/8/e82e61d1-488d-4627-a54c-d8496a967814.jpg?1783912984,Legendary Creature — Squirrel,Jason Rainville
+Tovolar's Huntmaster // Tovolar's Packleader,6,2021,0.28,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Cristi Balanescu
+Towering Titan,6,2025,0.35,#087500,https://cards.scryfall.io/normal/front/2/f/2f75be32-0e5a-4d4f-93b4-149892df381c.jpg?1783907035,Creature — Giant,Victor Adame Minguez
+Tower Winder,2,2024,8.91,#087500,https://cards.scryfall.io/normal/front/9/7/97bf6a6a-e377-4f42-84dd-baf6055c0fb1.jpg?1783911961,Creature — Snake,Kekai Kotaki
+Toxicrene,4,2022,0.63,#087500,https://cards.scryfall.io/normal/front/a/9/a9b0fe26-18af-4b2e-861e-568d2f6208fd.jpg?1783920868,Creature — Tyranid,Logan Feliciano
+Tracker,3,1994,4.78,#087500,https://cards.scryfall.io/normal/front/3/5/35ffc69e-26f2-434f-8c89-2df108dd984a.jpg?1783947929,Creature — Human,Jeff A. Menges
+Trailblazer,4,1995,0.6,#087500,https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg?1783947471,Instant,Julie Baroh
+Trail of Mystery,2,2024,0.28,#087500,https://cards.scryfall.io/normal/front/5/6/56271ec9-5e41-47d3-ac76-d0743fb399cc.jpg?1783909598,Enchantment,Raymond Swanland
+Trailtracker Scout,2,2024,0.38,#087500,https://cards.scryfall.io/normal/front/3/6/36ee967a-3cac-4fff-b616-ec2557c676f2.jpg?1783910727,Creature — Raccoon Scout,Henry Peters
+Tranquil Frillback,3,2023,1.24,#087500,https://cards.scryfall.io/normal/front/5/b/5b647377-d47e-4630-8ccc-933ef6127880.jpg?1783916519,Creature — Dinosaur,Caio Monteiro
+Tranquil Grove,2,1999,1.85,#087500,https://cards.scryfall.io/normal/front/1/1/1177118a-6455-4177-8a6d-a43a03160ab3.jpg?1783946154,Enchantment,Dylan Martens
+Transdimensional Bovine,3,2026,0.36,#087500,https://cards.scryfall.io/normal/front/d/e/de124563-205c-4f40-8c13-4ae203599912.jpg?1783904081,Creature — Ox Avatar,Lius Lasahido
+Traveling Chocobo,3,2025,18.68,#087500,https://cards.scryfall.io/normal/front/2/4/2462df62-fc35-47ed-9571-40452074dc6d.jpg?1783906576,Creature — Bird,Ashley Mackenzie
+Travel Through Caradhras,6,2023,0.24,#087500,https://cards.scryfall.io/normal/front/9/5/955058b2-9758-4797-8ffc-c5fbee619309.jpg?1783916025,Sorcery,Constantin Marin
+Traverse the Outlands,5,2022,4.83,#087500,https://cards.scryfall.io/normal/front/e/f/ef192364-713a-42ff-8249-69a73ae61bd8.jpg?1783922701,Sorcery,Chuck Lukacs
+Traverse the Ulvenwald,1,2025,0.62,#087500,https://cards.scryfall.io/normal/front/7/7/77b459cb-994c-430d-b0a6-59a8dd20adbd.jpg?1783908086,Sorcery,Vincent Proce
+Tree of Redemption,4,2025,0.49,#087500,https://cards.scryfall.io/normal/front/4/f/4f55dae2-e6b4-4498-8abd-86d9717691f4.jpg?1783907139,Creature — Plant,Chris Rahn
+Treeshaker Chimera,7,2022,0.39,#087500,https://cards.scryfall.io/normal/front/5/f/5f73b249-be19-4a51-8759-648a2f122e6d.jpg?1783923238,Creature — Chimera,Vincent Proce
+Treetop Defense,2,1997,0.56,#087500,https://cards.scryfall.io/normal/front/f/5/f5e134b3-e8af-41e9-928d-c217ea7b2b13.jpg?1783946800,Instant,Zina Saunders
+Tribal Forcemage,2,2003,0.59,#087500,https://cards.scryfall.io/normal/front/1/0/104735d7-6cea-4d4a-8cc8-e1934883da97.jpg?1783944897,Creature — Elf Wizard,Greg Staples
+Tributary Instructor,4,2023,0.22,#087500,https://cards.scryfall.io/normal/front/a/f/af57728e-6f64-4df1-bdf8-55137b8d129e.jpg?1783913907,Creature — Merfolk Shaman,Christina Kraus
+Tribute to the World Tree,3,2023,14.68,#087500,https://cards.scryfall.io/normal/front/c/0/c0cdeaba-fc21-44e6-bf99-aa1ff379401b.jpg?1783916960,Enchantment,Kristina Carroll
+Triumph of the Hordes,4,2026,14.07,#087500,https://cards.scryfall.io/normal/front/5/a/5a0bc9d4-d99d-48e1-aeca-d2e5b1c99a84.jpg?1783903916,Sorcery,Aitor Sebastián
+Troll Ascetic,3,2018,0.32,#087500,https://cards.scryfall.io/normal/front/4/3/430fa067-cecd-4958-851b-5908a0765063.jpg?1783934727,Creature — Troll Shaman,Puddnhead
+Tromell- Seymour's Butler,3,2025,0.4,#087500,https://cards.scryfall.io/normal/front/0/f/0f4f6de2-1c3d-4f3b-b999-70879f9cbb26.jpg?1783906349,Legendary Creature — Elf Advisor,Kotetsu Kinoshita
+Trudge Garden,3,2026,0.27,#087500,https://cards.scryfall.io/normal/front/8/0/80dd8180-668a-41e4-a4e9-ebdd71345841.jpg?1783903759,Enchantment,Adam Paquette
+Trystan- Callous Cultivator // Trystan- Penitent Culler,3,2026,0.24,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elf Druid // Legendary Creature — Elf Warlock,Annie Stegg
+Tug of War,5,2022,0.16,#087500,https://cards.scryfall.io/normal/front/d/b/db51cafc-7177-4644-b149-4bef3b73fea8.jpg?1783920545,Sorcery,Gaboleps
+Turntimber Ranger,5,2009,2.2,#087500,https://cards.scryfall.io/normal/front/a/2/a24bba56-3256-489b-82a2-22748388e110.jpg?1783942129,Creature — Elf Scout Ranger Ally,Wayne Reynolds
+Turntimber Sower,3,2024,0.38,#087500,https://cards.scryfall.io/normal/front/1/1/11bdff1d-4542-4c71-af00-731d6651b492.jpg?1783911905,Creature — Elf Druid,Craig J Spearing
+Turntimber Symbiosis // Turntimber- Serpentine Wood,7,2020,4.32,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Land,Randy Vargas
+Turtle Power!,3,2026,0.29,#087500,https://cards.scryfall.io/normal/front/4/0/4079ca90-dcc3-4184-9dfc-a626e0776332.jpg?1783904081,Enchantment,Hokyoung Kim
+Twitching Doll,2,2024,2.22,#087500,https://cards.scryfall.io/normal/front/4/1/416c025b-e40e-4d95-a774-ba3961f43808.jpg?1783909449,Artifact Creature — Spider Toy,Warren Mahy
+Typhoon,3,1994,17.4,#087500,https://cards.scryfall.io/normal/front/2/5/254e0403-67d8-4e73-8d89-c901ebeba49f.jpg?1783948043,Sorcery,Anson Maddocks
+Tyrant Guard,3,2022,5.05,#087500,https://cards.scryfall.io/normal/front/4/e/4e785abe-ae43-4e6b-9d6d-56e39ea348ef.jpg?1783920867,Creature — Tyranid,Xavier Ribeiro
+Tyrranax Rex,7,2023,6.07,#087500,https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg?1783918007,Creature — Phyrexian Dinosaur,Tuan Duong Chu
+Tyvar Kell,4,2021,6.24,#d78f42,https://cards.scryfall.io/normal/front/8/d/8d18008f-10d2-4cdf-b4b5-7675782a8b0d.jpg?1783928203,Legendary Planeswalker — Tyvar,Chris Rallis
+Tyvar- the Pummeler,3,2024,3.65,#087500,https://cards.scryfall.io/normal/front/5/f/5f7687b1-630a-4e95-89c7-eaf456d8cb68.jpg?1783909447,Legendary Creature — Elf Warrior,Olivier Bernard
+Uktabi Kong,8,2004,20.56,#087500,https://cards.scryfall.io/normal/front/b/d/bd6d8520-0a7c-489c-8ae9-aed07c7df6df.jpg?1783944235,Creature — Ape,Una Fricker
+Uktabi Wildcats,5,2001,0.52,#087500,https://cards.scryfall.io/normal/front/7/0/700bb560-5a4a-4422-9158-1c2edad1913f.jpg?1783945408,Creature — Cat,Thomas Gianni
+Ulvenwald Hydra,6,2020,0.51,#087500,https://cards.scryfall.io/normal/front/0/7/0700d1c1-faab-4a1a-b55d-a2fa4582a2b4.jpg?1783930349,Creature — Hydra,Raymond Swanland
+Ulvenwald Observer,6,2016,0.35,#087500,https://cards.scryfall.io/normal/front/7/a/7a9d23d5-2f94-48e6-824f-f1de8f742989.jpg?1783937435,Creature — Treefolk,Jaime Jones
+Ulvenwald Oddity // Ulvenwald Behemoth,4,2021,0.43,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Beast // Creature — Beast Horror,Brent Hollowell
+Ulvenwald Tracker,1,2017,4.92,#087500,https://cards.scryfall.io/normal/front/4/d/4da9e7d8-5f01-4d55-a0a8-afe5e7d5f8e4.jpg?1783936626,Creature — Human Shaman,Christopher Moeller
+Unbound Flourishing,3,2026,2.03,#087500,https://cards.scryfall.io/normal/front/a/a/aa5931c8-e453-4bfd-98b2-0baf5c55f1cb.jpg?1783903816,Enchantment,Madeline Boni
+Uncage the Menagerie,2,2017,1.09,#087500,https://cards.scryfall.io/normal/front/b/c/bc4aa918-53b9-4177-a859-f5a8eff09fe5.jpg?1783936013,Sorcery,Simon Dominic
+Uncle's Musings,4,2025,0.75,#087500,https://cards.scryfall.io/normal/front/5/5/55724dab-93c8-4a7f-89c2-13e94820635b.jpg?1783904837,Sorcery,Brian Yuen
+Undergrowth Champion,3,2015,0.61,#087500,https://cards.scryfall.io/normal/front/d/5/d53104d8-5b9a-45b6-a2f9-b2c5d231a03d.jpg?1783938183,Creature — Elemental,Tyler Jacobson
+Undergrowth Recon,3,2024,1.52,#087500,https://cards.scryfall.io/normal/front/4/b/4b8a22b8-368f-41e4-8d49-432c6c2ed11e.jpg?1783912858,Enchantment,Ryan Pancoast
+Undermountain Adventurer,4,2022,0.51,#087500,https://cards.scryfall.io/normal/front/5/4/541f53a3-521f-4463-a0b6-758a45d8f661.jpg?1783922701,Creature — Giant Warrior,Michal Ivan
+Unlucky Cabbage Merchant,2,2025,0.57,#087500,https://cards.scryfall.io/normal/front/f/6/f6415bd7-8585-4dc5-a183-4499e54fa42f.jpg?1783905117,Creature — Human Citizen,Thanh Tuấn
+Unnatural Growth,5,2025,3.34,#087500,https://cards.scryfall.io/normal/front/0/8/08fa38c0-353c-4f6a-b87e-3f6366af44d8.jpg?1783908086,Enchantment,Svetlin Velinov
+Unstoppable Ash,4,2008,1.14,#087500,https://cards.scryfall.io/normal/front/c/9/c9de6380-6203-41ae-b134-8633eb5df076.jpg?1783942777,Creature — Treefolk Warrior,Brian Snõddy
+Unyaro Bees,3,2006,0.38,#087500,https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg?1783943204,Creature — Insect,Tom Wänerstrand
+Upwelling,4,2007,1.89,#087500,https://cards.scryfall.io/normal/front/d/5/d5c47cac-679f-4b48-977f-2fa149a6c3c3.jpg?1783942989,Enchantment,Chippy
+Urborg Lhurgoyf,2,2022,0.3,#d78f42,https://cards.scryfall.io/normal/front/a/6/a6f97236-1497-4811-8189-0545707451da.jpg?1783921291,Creature — Lhurgoyf,Andrey Kuzinskiy
+Ursapine,5,2005,0.27,#087500,https://cards.scryfall.io/normal/front/b/a/ba547810-c82a-498b-81eb-e81a8dcbbd42.jpg?1783943628,Creature — Beast,Jim Murray
+Ursine Monstrosity,3,2024,0.36,#087500,https://cards.scryfall.io/normal/front/7/3/73cc6df4-3564-4ace-bf8a-eac3e62d725a.jpg?1783909653,Creature — Bear Mutant,Carlos Palma Cruchaga
+Utopia Tree,2,2005,1.7,#087500,https://cards.scryfall.io/normal/front/4/9/49bed540-da8d-4148-8794-8e8d01ed5387.jpg?1783943911,Creature — Plant,Gary Ruddell
+Valentin- Dean of the Vein // Lisette- Dean of the Root,1,2021,1.06,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Vampire Warlock // Legendary Creature — Human Druid,Jesper Ejsing
+Valgavoth's Onslaught,1,2024,0.31,#087500,https://cards.scryfall.io/normal/front/7/d/7d4ba274-3c6f-4e12-ba2c-a81c3da3f7e2.jpg?1783909447,Sorcery,Lie Setiawan
+Valley Mightcaller,1,2024,1.44,#087500,https://cards.scryfall.io/normal/front/7/2/7256451f-0122-452a-88e8-0fb0f6bea3f3.jpg?1783910800,Creature — Frog Warrior,Matt Stewart
+Varis- Silverymoon Ranger,3,2021,0.34,#087500,https://cards.scryfall.io/normal/front/e/3/e3bd3ea9-f06d-4df7-8b8d-ac6a0e591b09.jpg?1783926453,Legendary Creature — Human Elf Ranger,Jesper Ejsing
+Vastlands Scavenger // Bind to Life,3,2026,0.28,#087500,https://cards.scryfall.io/normal/front/4/7/476b6a4d-cc05-4e98-8a45-a5c6582ec514.jpg?1783903652,Creature — Bear Druid // Instant,Bryan Sola
+Vastwood Hydra,2,2020,1.52,#087500,https://cards.scryfall.io/normal/front/b/f/bfe7139a-3fd5-4574-a26b-75b1b17b2c2f.jpg?1783931156,Creature — Hydra,Slawomir Maniak
+Vaultborn Tyrant,7,2024,32.05,#087500,https://cards.scryfall.io/normal/front/6/2/62b3f560-262b-4bc3-9aef-535fd7082c28.jpg?1784634289,Creature — Dinosaur,Loïc Canavaggia
+Veil of Summer,1,2026,14.91,#087500,https://cards.scryfall.io/normal/front/1/1/111c175b-f994-4501-b046-eaa07707f23a.jpg?1783903468,Instant,Wayne Reynolds
+Venerated Rotpriest,1,2023,4.6,#087500,https://cards.scryfall.io/normal/front/d/1/d1b032e3-14e3-48ba-ab8a-d2b4f8d31a7d.jpg?1783918006,Creature — Phyrexian Druid,Brian Valeza
+Vengeful Regrowth,6,2024,0.32,#087500,https://cards.scryfall.io/normal/front/c/c/cccb3db6-6ab2-4ce9-beaa-99b352116676.jpg?1783911961,Sorcery,Olivier Bernard
+Vengevine,4,2020,6.2,#087500,https://cards.scryfall.io/normal/front/5/6/5631668d-75f2-4d2d-b644-90c073c7be21.jpg?1783930140,Creature — Elemental,Raymond Swanland
+Venom Blast,4,2025,0.6,#087500,https://cards.scryfall.io/normal/front/4/e/4e88f2d0-d014-49cf-bb3c-fadbfc12765d.jpg?1783905367,Sorcery,Toni Infante
+Venture Forth,4,2022,0.39,#087500,https://cards.scryfall.io/normal/front/b/b/bb4db814-3821-47ea-9e33-0e9f49128a36.jpg?1783922497,Sorcery,Gaboleps
+Verdant Command,2,2021,1.27,#087500,https://cards.scryfall.io/normal/front/8/3/83031ea8-a6c9-4318-af16-bba701dd76bb.jpg?1783926823,Instant,Mark Poole
+Verdant Confluence,6,2023,0.26,#087500,https://cards.scryfall.io/normal/front/5/1/512f3b28-ea20-4bad-8fab-5996e0fc1b62.jpg?1783915619,Sorcery,Kieran Yanner
+Verdant Crescendo,4,2016,0.1,#087500,https://cards.scryfall.io/normal/front/e/a/ea890019-f48f-4164-b057-773499ef273f.jpg?1783937135,Sorcery,Zack Stella
+Verdant Embrace,5,2021,0.36,#087500,https://cards.scryfall.io/normal/front/5/7/57233676-f03f-4739-a1fb-8fed7e6c649f.jpg?1783926188,Enchantment — Aura,Stephen Tappin
+Verdant Force,8,2018,0.36,#087500,https://cards.scryfall.io/normal/front/1/d/1d972f97-1945-440b-8bd3-63038db22257.jpg?1783934970,Creature — Elemental,Viktor Titov
+Verdant Mastery,6,2021,0.33,#087500,https://cards.scryfall.io/normal/front/1/9/197455e5-7929-47b8-ad00-8d3918949eb7.jpg?1783927333,Sorcery,Cristi Balanescu
+Verdant Succession,5,2001,1.84,#087500,https://cards.scryfall.io/normal/front/b/d/bd3c78de-0c2a-441e-8912-ff920fc563ef.jpg?1783945208,Enchantment,Edward P. Beard, Jr.
+Verdant Sun's Avatar,7,2023,0.45,#087500,https://cards.scryfall.io/normal/front/e/8/e8fce06a-56f7-4d0c-b094-ff147fec8256.jpg?1783913852,Creature — Dinosaur Avatar,Izzy
+Verdant Touch,2,1998,0.39,#087500,https://cards.scryfall.io/normal/front/7/0/7079bf55-4827-4b8b-a178-8c7b903d93b9.jpg?1783946546,Sorcery,M. W. Kaluta & DiTerlizzi
+Verdeloth the Ancient,6,2013,0.5,#087500,https://cards.scryfall.io/normal/front/0/5/05c2fce4-32b4-40cd-b467-a3ba3bf1fa10.jpg?1783939971,Legendary Creature — Treefolk,Daren Bader
+Verduran Enchantress,3,2023,4.17,#087500,https://cards.scryfall.io/normal/front/7/2/722a73a1-9497-4d8d-850c-ec6c6ab1b8d3.jpg?1783915420,Creature — Human Druid,Rob Alexander
+Verdurous Gearhulk,5,2021,0.35,#087500,https://cards.scryfall.io/normal/front/3/f/3f3eb5d0-7a99-4f66-b0b8-a0d8acc3bc9e.jpg?1783925326,Artifact Creature — Construct,Jaime Jones
+Vernal Bloom,4,2003,4.14,#087500,https://cards.scryfall.io/normal/front/b/a/baabb73c-e3d9-4ba1-9963-986e09ef49a7.jpg?1783944648,Enchantment,Bob Eggleton
+Vernal Equinox,4,1999,1.51,#087500,https://cards.scryfall.io/normal/front/3/b/3bed69d2-f5fb-4173-b939-5abdb48b82b4.jpg?1783945916,Enchantment,Rebecca Guay
+Vexing Beetle,5,2003,0.25,#087500,https://cards.scryfall.io/normal/front/d/5/d599d35f-1b73-498b-9a21-831c908a95d8.jpg?1783944896,Creature — Insect,Matt Thompson
+Vigor,6,2018,15.25,#087500,https://cards.scryfall.io/normal/front/e/a/ea7047d8-8d32-48a3-829b-7eb5427ed53a.jpg?1783934797,Creature — Elemental Incarnation,Jim Murray
+Vine Dryad,4,1999,1.23,#087500,https://cards.scryfall.io/normal/front/f/c/fc9c9158-faed-42ae-9f6b-71dee49ff79f.jpg?1783945916,Creature — Dryad,Jeff Laubenstein
+Vinelasher Kudzu,2,2014,0.35,#087500,https://cards.scryfall.io/normal/front/b/c/bcae0517-f7d1-4b67-9ca3-608f2d8a70f9.jpg?1783939483,Creature — Plant,Mark Tedin
+Viridian Zealot,2,2017,0.43,#087500,https://cards.scryfall.io/normal/front/4/c/4c2052ce-0c60-4baa-8bac-4a479a7368e2.jpg?1783936239,Creature — Elf Warrior,Kev Walker
+Virtue of Strength // Garenbrig Growth,7,2023,4.37,#087500,https://cards.scryfall.io/normal/front/f/f/ff857d41-767d-4e99-83cc-444738341b92.jpg?1783915075,Enchantment // Sorcery — Adventure,Piotr Dura
+Visions of Dominance,3,2021,0.89,#087500,https://cards.scryfall.io/normal/front/1/5/15947810-9a38-417f-84dc-5a83446deb81.jpg?1783925369,Sorcery,Andrew Mar
+Vitalizing Wind,9,2000,4.83,#087500,https://cards.scryfall.io/normal/front/0/f/0fbd7c20-d527-4d97-9630-896d5e7bf1de.jpg?1783945770,Instant,Jeff Easley
+Vivid Revival,5,2018,0.26,#087500,https://cards.scryfall.io/normal/front/9/e/9e67fcfd-0e9e-4b88-8c65-2125fac10a3d.jpg?1783934144,Sorcery,Yeong-Hao Han
+Vivien- Arkbow Ranger,4,2019,1.0,#087500,https://cards.scryfall.io/normal/front/5/9/592c5e27-c538-425e-b41f-1d6708428853.jpg?1783932954,Legendary Planeswalker — Vivien,Yongjae Choi
+Vivien- Champion of the Wilds,3,2022,0.76,#087500,https://cards.scryfall.io/normal/front/e/1/e11dc967-ae38-4c19-bf54-b3209e203b39.jpg?1783922400,Legendary Planeswalker — Vivien,Magali Villeneuve
+Vivien- Monsters' Advocate,5,2020,2.84,#087500,https://cards.scryfall.io/normal/front/5/0/504ebb84-7e7b-4119-a128-a9c183c5d9de.jpg?1783931029,Legendary Planeswalker — Vivien,Lius Lasahido
+Vivien on the Hunt,6,2022,0.63,#087500,https://cards.scryfall.io/normal/front/5/e/5edfb119-abc9-4d4d-bc46-33cce1a0922d.jpg?1783923096,Legendary Planeswalker — Vivien,Jake Murray
+Vivien Reid,5,2024,0.4,#087500,https://cards.scryfall.io/normal/front/3/8/38769247-42a1-4571-9071-6d59fe28650a.jpg?1783909055,Legendary Planeswalker — Vivien,Anna Steinbauer
+Vivien's Arkbow,2,2019,0.27,#087500,https://cards.scryfall.io/normal/front/e/e/eecc846f-5b78-4d54-8d29-642ad7a852bc.jpg?1783933404,Legendary Artifact,Zack Stella
+Vivien's Invocation,7,2018,0.24,#087500,https://cards.scryfall.io/normal/front/7/8/784c4711-223d-4b95-a163-87e57f87b8db.jpg?1783934524,Sorcery,Johannes Voss
+Vivien's Stampede,6,2022,0.37,#087500,https://cards.scryfall.io/normal/front/d/e/de108ae1-7201-4849-9f68-92edff66649c.jpg?1783923352,Sorcery,Olena Richards
+Vivien's Talent,3,2023,0.28,#087500,https://cards.scryfall.io/normal/front/3/6/36dc7851-795b-4d59-bcd9-16d2c87d3e19.jpg?1783917245,Enchantment — Aura,Eli Minaya
+Vizier of the Menagerie,4,2026,0.37,#087500,https://cards.scryfall.io/normal/front/1/4/14ab742a-89dc-4c01-99e3-21fc609128f2.jpg?1783903944,Creature — Snake Cleric,Victor Adame Minguez
+Voice of the Woods,5,2021,0.28,#087500,https://cards.scryfall.io/normal/front/d/7/d7a6315c-aa6f-4be1-a002-d7824bfad622.jpg?1783928307,Creature — Elf,Néstor Ossandón Leal
+Volrath's Gardens,2,1998,0.32,#087500,https://cards.scryfall.io/normal/front/7/d/7d74f7d8-10eb-4082-9b07-41de13359b8c.jpg?1783946546,Enchantment,Rob Alexander
+Voracious Hydra,2,2019,4.36,#087500,https://cards.scryfall.io/normal/front/7/4/74bbe44f-864a-446c-bfc9-5f5188e663b8.jpg?1783932954,Creature — Hydra,Wayne Reynolds
+Vorapede,5,2020,0.4,#087500,https://cards.scryfall.io/normal/front/f/2/f20ad28c-80a0-47c4-a5b6-685569d6a718.jpg?1783931156,Creature — Insect,Slawomir Maniak
+Vorinclex- Monstrous Raider,6,2021,57.35,#087500,https://cards.scryfall.io/normal/front/9/2/92613468-205e-488b-930d-11908477e9f8.jpg?1783928202,Legendary Creature — Phyrexian Praetor,Daarken
+Vorinclex // The Grand Evolution,5,2023,6.41,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Phyrexian Praetor // Enchantment — Saga,Daarken
+Vorinclex- Voice of Hunger,8,2017,14.03,#087500,https://cards.scryfall.io/normal/front/9/f/9fe3af8c-109d-486c-aa34-3f023abda5b7.jpg?1783935514,Legendary Creature — Phyrexian Praetor,Karl Kopinski
+Waiting in the Weeds,3,1999,1.7,#087500,https://cards.scryfall.io/normal/front/7/e/7e2d5a77-6ee8-463d-9e6a-fdb1cc6d70e6.jpg?1783946152,Sorcery,Susan Van Camp
+Wakanda Forever!,6,2026,0.28,#087500,https://cards.scryfall.io/normal/front/8/b/8b893d46-25f0-4c6a-b9a3-ff25277be918.jpg?1783903274,Sorcery,Eli Minaya
+Waker of the Wilds,4,2020,0.18,#087500,https://cards.scryfall.io/normal/front/4/1/4124807b-15f9-46d7-8b0b-d4f1b3587d99.jpg?1783929461,Creature — Merfolk Shaman,Shreya Shetty
+Wakeroot Elemental,6,2019,0.19,#087500,https://cards.scryfall.io/normal/front/0/2/02c9396d-28f2-40b7-908e-51db51da57a7.jpg?1783932955,Creature — Elemental,Filip Burburan
+Walk-In Closet // Forgotten Cellar,8,2024,6.41,#087500,https://cards.scryfall.io/normal/front/0/a/0adcd4e5-d542-4293-8774-ace2305ef820.jpg?1783909446,Enchantment — Room // Enchantment — Room,Miklós Ligeti
+Warden of the First Tree,1,2015,0.35,#d78f42,https://cards.scryfall.io/normal/front/2/e/2e0c6628-04f1-4800-baa8-bcaefe64f59f.jpg?1783938676,Creature — Human,Ryan Alexander Lee
+Warden of the Grove,3,2025,2.11,#087500,https://cards.scryfall.io/normal/front/2/4/2414db96-0e2b-4f7c-9b97-41f8e310b752.jpg?1783907330,Creature — Hydra,Alexander Ostrowski
+Watchful Radstag,3,2024,1.39,#087500,https://cards.scryfall.io/normal/front/b/e/be4151d4-4d35-48d2-9e72-c87014f79137.jpg?1783912393,Creature — Elk Mutant,Alexander Ostrowski
+Wave of Vitriol,7,2017,1.79,#087500,https://cards.scryfall.io/normal/front/1/7/17328391-a510-42a0-8a00-4f61dd873c13.jpg?1783936237,Sorcery,Zoltan Boros
+Wayward Swordtooth,3,2023,4.22,#087500,https://cards.scryfall.io/normal/front/9/5/95a5d742-187a-4eba-82e4-7a4cc5c4e6f3.jpg?1783913852,Creature — Dinosaur,Chris Rahn
+Weatherseed Treefolk,5,1999,1.58,#087500,https://cards.scryfall.io/normal/front/f/4/f42cce45-3b6a-43e2-8329-68c30135c5c1.jpg?1783946226,Creature — Treefolk,Heather Hudson
+Weaver of Harmony,2,2022,2.06,#087500,https://cards.scryfall.io/normal/front/d/1/d1682673-e947-44e2-b9c9-cbcb9a16892b.jpg?1783923838,Enchantment Creature — Snake Druid,Tuan Duong Chu
+Web,1,1995,0.47,#087500,https://cards.scryfall.io/normal/front/0/5/0547a390-ceee-4b8a-9d0e-36d8778ec693.jpg?1783947808,Enchantment — Aura,Rob Alexander
+Web of Life and Destiny,8,2025,1.39,#087500,https://cards.scryfall.io/normal/front/3/b/3b3c609e-f7c9-4fe5-84d9-4f4c76020a4b.jpg?1783905321,Enchantment,Jonas De Ro
+Webstrike Elite,2,2025,0.33,#087500,https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg?1783907863,Creature — Insect Archer,Andrew Mar
+Weird Harvest,2,2005,1.42,#087500,https://cards.scryfall.io/normal/front/8/9/89bd2c25-049a-4df2-bf8f-198d1b41b01e.jpg?1783943908,Sorcery,Bob Petillo
+Welcome to . . . // Jurassic Park,3,2023,29.79,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Legendary Land,Villarrte
+Werewolf Pack Leader,2,2021,0.41,#087500,https://cards.scryfall.io/normal/front/e/8/e88e6b39-bb4d-4d69-8007-d42f31bcbc29.jpg?1783926452,Creature — Human Werewolf,Miranda Meeks
+Whiptongue Hydra,6,2022,0.74,#087500,https://cards.scryfall.io/normal/front/5/7/57cfa420-306d-4d2c-8e83-fa9b46f2aa27.jpg?1783923947,Creature — Lizard Hydra,Tomasz Jedruszek
+Whirlwind,4,2017,0.78,#087500,https://cards.scryfall.io/normal/front/8/5/855d40de-e9b8-4bb5-a030-a36242324abf.jpg?1783936236,Sorcery,John Matson
+Whisperwood Elemental,5,2024,0.25,#087500,https://cards.scryfall.io/normal/front/f/5/f522f32d-e510-4128-98ae-d3c0f684b899.jpg?1783909598,Creature — Elemental,Raymond Swanland
+Wicked Wolf,4,2019,0.3,#087500,https://cards.scryfall.io/normal/front/0/9/09476eac-55d2-4955-8951-ae4ce117c98b.jpg?1783932601,Creature — Wolf,Tomasz Jedruszek
+Wild Beastmaster,3,2021,0.33,#087500,https://cards.scryfall.io/normal/front/b/c/bc52bf91-a8fc-43de-9e28-3b40cd08445a.jpg?1783925326,Creature — Human Shaman,Kev Walker
+Wildborn Preserver,2,2024,0.16,#087500,https://cards.scryfall.io/normal/front/8/a/8a249d1c-a5fe-48e5-bd9b-e50d8eea391b.jpg?1783908914,Creature — Elf Archer,Lius Lasahido
+Wildcall,2,2015,0.17,#087500,https://cards.scryfall.io/normal/front/0/6/065fc4d8-c097-4d0e-81cf-22a0b694be9a.jpg?1783938675,Sorcery,Adam Paquette
+Wild Defiance,3,2012,0.68,#087500,https://cards.scryfall.io/normal/front/7/e/7eaa6be7-2c6f-4442-85d1-ae31ad87fd98.jpg?1783940657,Enchantment,Slawomir Maniak
+Wild Endeavor,6,2021,0.35,#087500,https://cards.scryfall.io/normal/front/3/4/349d0255-52b9-4998-ad4b-909a593c3071.jpg?1783926242,Sorcery,Uriah Voth
+Wildest Dreams,1,2016,0.44,#087500,https://cards.scryfall.io/normal/front/9/f/9fedd63c-22e4-4c36-8a7a-a167a070678f.jpg?1783937172,Sorcery,Daniel Ljunggren
+Wild Growth,1,2025,2.57,#087500,https://cards.scryfall.io/normal/front/c/2/c2a0d555-8ebe-4bce-994f-42e6a123f826.jpg?1783905121,Enchantment — Aura,Alexander Mokhov
+Wildgrowth Archaic,4,2026,0.35,#087500,https://cards.scryfall.io/normal/front/0/e/0e6e2188-7203-4d10-a838-27233f283cd5.jpg?1783903652,Creature — Avatar,Loïc Canavaggia
+Wild Mongrel,2,2022,0.71,#087500,https://cards.scryfall.io/normal/front/8/4/8476adaa-fd09-41c3-beda-0e2d654cb204.jpg?1783920231,Creature — Dog,Crocodile Jackson
+Wild Pair,6,2016,1.4,#087500,https://cards.scryfall.io/normal/front/f/3/f3153d2c-9168-4889-9179-23faa9c48721.jpg?1783937289,Enchantment,Lars Grant-West
+Wildwood Mentor,3,2023,0.41,#087500,https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg?1783915037,Creature — Treefolk,Piotr Foksowicz
+Will of the Sultai,5,2025,1.05,#087500,https://cards.scryfall.io/normal/front/3/7/37155f69-1d72-4fcb-80b3-548b7d78f9ec.jpg?1783907165,Sorcery,Cristi Balanescu
+Willow Geist,1,2021,0.28,#087500,https://cards.scryfall.io/normal/front/1/c/1c40c71c-4cdc-4a28-8ea3-4636c936f8aa.jpg?1783925568,Creature — Treefolk Spirit,Ryan Yee
+Willow Priestess,4,1995,8.12,#087500,https://cards.scryfall.io/normal/front/c/6/c636a608-26d7-4154-8052-a093b11362b1.jpg?1783947276,Creature — Faerie Druid,Susan Van Camp
+Windswift Slice,3,2023,0.46,#087500,https://cards.scryfall.io/normal/front/f/8/f8097193-1d32-4235-afd4-f6839602e4fb.jpg?1783916024,Instant,Narendra Bintara Adi
+Winter Blast,1,1994,20.55,#087500,https://cards.scryfall.io/normal/front/f/b/fb846366-2105-4999-8af1-a11687f42e17.jpg?1783948043,Sorcery,Kaja Foglio
+Witchstalker,3,2013,0.27,#087500,https://cards.scryfall.io/normal/front/5/a/5a5ce47d-ea4f-4e15-adb6-5bb66981ed24.jpg?1783939897,Creature — Wolf,Christopher Moeller
+Witherscale Wurm,6,2008,0.8,#087500,https://cards.scryfall.io/normal/front/5/1/5187fc71-e4d3-4071-9ea1-d4513f30c529.jpg?1783942738,Creature — Wurm,Thomas M. Baxa
+W'Kabi- Shield of the Nation,2,2026,0.2,#087500,https://cards.scryfall.io/normal/front/9/f/9fb292a4-cf71-4aeb-b92e-eab2e3177653.jpg?1783903276,Legendary Creature — Human Warrior Hero,Ovidio Cartagena
+Wolfbitten Captive // Krallenhorde Killer,1,2012,0.39,#087500,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Zoltan Boros
+Wolfbriar Elemental,4,2017,0.41,#087500,https://cards.scryfall.io/normal/front/6/0/60da801e-c47c-4aac-928c-2e7eab2d24c6.jpg?1783936238,Creature — Elemental,Chippy
+Wolfcaller's Howl,4,2017,2.44,#087500,https://cards.scryfall.io/normal/front/4/7/47f3f7bc-1dea-4c84-88b6-a36b23af82ff.jpg?1783936239,Enchantment,Ralph Horsley
+Wolfir Silverheart,5,2012,0.43,#087500,https://cards.scryfall.io/normal/front/8/6/8629c598-11c8-4911-acfb-0643e5feffa8.jpg?1783940656,Creature — Wolf Warrior,Raymond Swanland
+Wolverine- Claws Out,4,2026,10.78,#087500,https://cards.scryfall.io/normal/front/5/3/534a044c-a4a9-478c-ad74-060185b3cb01.jpg?1783903033,Legendary Creature — Mutant Berserker Hero,Ryan Pancoast
+Wolverine Riders,6,2021,12.25,#087500,https://cards.scryfall.io/normal/front/7/0/70fd0439-294b-454c-b2af-e814b85f4590.jpg?1783928337,Creature — Elf Warrior,Jesper Ejsing
+Wood Elves,3,1997,29.98,#087500,https://cards.scryfall.io/normal/front/b/7/b7f1fb90-5c85-46a5-802d-248cc0250921.jpg?1783946800,Creature — Elf Scout,Rebecca Guay
+Woodfall Primus,8,2022,0.4,#087500,https://cards.scryfall.io/normal/front/9/7/97914abe-71d5-4bd6-87d7-8e7379abf1aa.jpg?1783923235,Creature — Treefolk Shaman,Adam Rex
+Woodland Bellower,6,2015,4.75,#087500,https://cards.scryfall.io/normal/front/a/7/a706d4bb-0b44-4e43-b340-7de799c086b8.jpg?1783938315,Creature — Beast,Jasper Sandner
+Woodland Wanderer,4,2015,0.11,#087500,https://cards.scryfall.io/normal/front/c/c/cc1e6db8-5093-44e4-95d7-3fdf8c55c1dd.jpg?1783938183,Creature — Elemental,Vincent Proce
+Words of Wilding,3,2002,2.63,#087500,https://cards.scryfall.io/normal/front/f/d/fdb9565f-5b09-4127-b169-3146079dab84.jpg?1783945032,Enchantment,Wayne England
+Workshop Warchief,5,2022,0.28,#087500,https://cards.scryfall.io/normal/front/2/7/27851834-688f-4929-967d-dfa015194f7f.jpg?1783923096,Creature — Rhino Warrior,Zoltan Boros
+Worldly Tutor,1,2023,27.07,#087500,https://cards.scryfall.io/normal/front/f/3/f39aa2e9-e294-4ce6-bf5e-e1f579101a7a.jpg?1783918434,Instant,Volkan Baǵa
+World Shaper,4,2024,9.38,#087500,https://cards.scryfall.io/normal/front/c/c/cc765da4-4bca-4250-80e4-05575d6fa98c.jpg?1783911904,Creature — Merfolk Shaman,Raymond Swanland
+Worldspine Wurm,11,2024,3.09,#087500,https://cards.scryfall.io/normal/front/e/d/edb684f3-7787-4e54-96a2-61f95b6494a8.jpg?1783909598,Creature — Wurm,Richard Wright
+World War Hulk,5,2026,1.06,#087500,https://cards.scryfall.io/normal/front/9/0/9032f05b-5c21-4996-90c1-268dc6dffbaa.jpg?1784182994,Enchantment — Saga,Serena Malyon
+Wormwood Treefolk,5,1994,4.52,#d78f42,https://cards.scryfall.io/normal/front/2/f/2fa20173-e88a-4b14-9c54-14567ca5571c.jpg?1783947928,Creature — Treefolk,Jesper Myrfors
+Wrenn and Realmbreaker,3,2023,5.41,#087500,https://cards.scryfall.io/normal/front/6/f/6f807d91-b157-44e8-a431-49782184f876.jpg?1783916956,Legendary Planeswalker — Wrenn,Cristi Balanescu
+Wrenn and Seven,5,2025,2.85,#087500,https://cards.scryfall.io/normal/front/3/0/302f0dc1-88ab-4961-b78c-fbe7980dca18.jpg?1783908083,Legendary Planeswalker — Wrenn,Heonhwa
+Wren's Run Packmaster,4,2017,1.02,#087500,https://cards.scryfall.io/normal/front/a/4/a44a2d69-df93-475b-8233-f73d8402594a.jpg?1783936235,Creature — Elf Warrior,Mark Zug
+Wurmcalling,1,2006,5.77,#087500,https://cards.scryfall.io/normal/front/8/5/85402aef-3fb1-4e78-9103-e2e47e5f3c65.jpg?1783943203,Sorcery,Jeff Easley
+Wurmquake,6,2023,0.41,#087500,https://cards.scryfall.io/normal/front/9/4/94f0a15e-9437-4aa9-86c5-482008124617.jpg?1783918157,Sorcery,Xavier Ribeiro
+Wurmweaver Coil,6,2006,0.27,#087500,https://cards.scryfall.io/normal/front/6/6/661580bc-b5e5-48ce-b855-c177f1c61742.jpg?1783943487,Enchantment — Aura,Mitch Cotie
+Wyluli Wolf,2,1999,1.44,#087500,https://cards.scryfall.io/normal/front/5/a/5a24af58-5d75-4b41-a226-60abc415ff71.jpg?1783946151,Creature — Wolf,Susan Van Camp
+Xantid Swarm,1,2016,3.9,#087500,https://cards.scryfall.io/normal/front/0/2/022ab408-3292-40b6-b35e-ac1b7f06dffa.jpg?1783937556,Creature — Insect,David Martin
+Yasova Dragonclaw,3,2015,0.22,#d78f42,https://cards.scryfall.io/normal/front/4/9/490994c6-9fef-482b-835d-a64350bfaa8d.jpg?1783938674,Legendary Creature — Human Warrior,Winona Nelson
+Yavimaya Bloomsage // Channel,3,2026,0.42,#087500,https://cards.scryfall.io/normal/front/f/c/fc962e45-ab71-47e2-b736-644901ffe7d6.jpg?1783903851,Creature — Dryad Druid // Sorcery,Justyna Dura
+Yedora- Grave Gardener,5,2024,0.23,#087500,https://cards.scryfall.io/normal/front/5/5/552ddba8-e1e3-44d8-b341-441c2b4cd937.jpg?1783912983,Legendary Creature — Treefolk Druid,Svetlin Velinov
+Yeva- Nature's Herald,4,2024,1.3,#087500,https://cards.scryfall.io/normal/front/6/7/67ff9ba3-cd2b-4970-b4da-22104b10a4a4.jpg?1783913297,Legendary Creature — Elf Shaman,Eric Deschamps
+Yisan- the Wanderer Bard,3,2023,0.34,#087500,https://cards.scryfall.io/normal/front/9/4/94e3a130-deeb-4bf4-a1f6-9219c3d8c373.jpg?1783915616,Legendary Creature — Human Rogue Bard,Chase Stone
+Yorvo- Lord of Garenbrig,3,2019,0.34,#087500,https://cards.scryfall.io/normal/front/a/e/ae2998a1-1713-467e-a08e-0efd8720aa5b.jpg?1783932599,Legendary Creature — Giant Noble,Zack Stella
+Young Wolf,1,2025,4.19,#087500,https://cards.scryfall.io/normal/front/c/c/cc608dff-ea3d-4c56-a112-25373c0d1047.jpg?1783907462,Creature — Wolf,Desmuncubic
+Yuna's Decision,4,2025,0.21,#087500,https://cards.scryfall.io/normal/front/5/0/5044eedb-f7d9-4b65-aa5b-fb494d00facd.jpg?1783906349,Sorcery,Yuu Fujiki
+Yuna's Whistle,3,2025,0.23,#087500,https://cards.scryfall.io/normal/front/8/e/8e591a23-15c3-4a65-a9d2-d1ce0f83552c.jpg?1783906349,Instant,Norikatsu Miyoshi
+Zask- Skittering Swarmlord,5,2022,30.89,#d78f42,https://cards.scryfall.io/normal/front/4/e/4eafc507-973a-4aec-91b9-c29d70b0e25d.jpg?1783919177,Legendary Creature — Insect,Alexander Ostrowski
+Zendikar Resurgent,7,2017,2.38,#087500,https://cards.scryfall.io/normal/front/3/3/33f64032-1e87-4d22-a211-c37e11ffa247.jpg?1783935887,Enchantment,Chris Rallis
+Zoologist,4,2001,0.46,#087500,https://cards.scryfall.io/normal/front/b/e/be645675-d263-42c4-9e71-f98cf4c2aab5.jpg?1783945207,Creature — Human Druid,Alex Horley-Orlandelli
+Zopandrel- Hunger Dominus,7,2023,12.49,#087500,https://cards.scryfall.io/normal/front/f/b/fb419d9d-e06f-48c8-a4f8-a57f9be39e50.jpg?1783918004,Legendary Creature — Phyrexian Horror,Antonio José Manzanedo
+Zuo Ci- the Mocking Sage,3,1999,39.82,#087500,https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg?1783946093,Legendary Creature — Human Advisor,Wang Yuqun
+Zuri- Warrior of Wakanda,2,2026,0.25,#087500,https://cards.scryfall.io/normal/front/b/8/b8225b51-d5a4-4b46-9a10-b581362b6a11.jpg?1783903275,Legendary Creature — Human Warrior Hero,Andreas Zafiratos

--- a/magic_card_csv_files_by_color/R.csv
+++ b/magic_card_csv_files_by_color/R.csv
@@ -1,0 +1,1627 @@
+name,cmc,release_year,price,color,image,type_line,artist
+Abbot of Keral Keep,2,2022,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/c/d/cd94f624-9b35-4468-829f-106366f61c1a.jpg?1783921894,Creature — Human Monk,Deruchenko Alexander
+Abomination- World Ravager,8,2026,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fddd2e68-8e1e-4162-a2c7-49da2c86d471.jpg?1783903286,Legendary Creature — Gamma Berserker Villain,Pavel Kolomeyets
+Abrade,2,2026,6.67,#ff1a1a,https://cards.scryfall.io/normal/front/3/1/31af49a8-e655-4670-b035-58171a6a57b9.jpg?1783903509,Instant,Hagiya Kaoru
+Adamaro- First to Desire,3,2005,0.76,#ff1a1a,https://cards.scryfall.io/normal/front/d/2/d2fa85ea-f5d5-4be3-a874-ce246c3e4245.jpg?1783944150,Legendary Creature — Spirit,Paolo Parente
+Advanced Reconstruction,4,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/c/c/cc912fec-827d-4deb-8430-79f5ea31ca9b.jpg?1783903856,Enchantment — Class,Randy Gallegos
+Aether Refinery,6,2024,0.88,#ff1a1a,https://cards.scryfall.io/normal/front/9/4/94553de8-52e8-4209-919a-cdf9289af116.jpg?1783911422,Artifact,Daniel Ljunggren
+Aether Revolt,4,2024,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/b/8/b8732e62-cdee-4d32-82a8-8a71a04be7a1.jpg?1783911274,Enchantment,Filipe Pagliuso
+Agate Instigator,2,2024,9.35,#ff1a1a,https://cards.scryfall.io/normal/front/9/f/9f838603-f7cd-497d-8d2b-d4cca03c1af7.jpg?1783910732,Creature — Lizard Rogue,Quintin Gleim
+Aggravated Assault,3,2002,35.99,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c99c5707-d5f2-4675-bfca-e801e6b0f627.jpg?1783945060,Enchantment,Greg Staples
+Aggressive Mining,4,2014,0.53,#ff1a1a,https://cards.scryfall.io/normal/front/e/1/e15a3f1a-83af-4541-8d1c-bf7844f969c9.jpg?1783939177,Enchantment,Franz Vohwinkel
+Agitator Ant,3,2024,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bc63ff71-ff42-4baf-977b-55f69c8e122f.jpg?1783913001,Creature — Insect,Igor Kieryluk
+Aisha of Sparks and Smoke,3,2023,0.67,#d78f42,https://cards.scryfall.io/normal/front/0/9/093aa76d-2154-4e71-a2bf-461d1afb887b.jpg?1783917774,Legendary Creature — Human Warrior,Evyn Fong
+Akki Battle Squad,6,2022,4.33,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca624ce6-5b99-41af-8e26-b952f5a30916.jpg?1783923994,Creature — Goblin Samurai,Steve Prescott
+Akki Lavarunner // Tok-Tok- Volcano Born,4,2004,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6ee6cd34-c117-4d7e-97d1-8f8464bfaac8.jpg?1783944304,Creature — Goblin Warrior // Legendary Creature — Goblin Shaman,Matt Cavotta
+Akoum Firebird,4,2015,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/3/0/304a2e4c-da2c-43fb-b44d-9db55ff94f04.jpg?1783938196,Creature — Phoenix,Chris Rahn
+Akoum Hellkite,6,2019,0.56,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f6ba0c10-6707-40f4-8f01-387532df9958.jpg?1783931655,Creature — Dragon,Jaime Jones
+Akroma- Angel of Fury,8,2024,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/2/a/2a81f0b5-5116-4946-89fc-18479bf85305.jpg?1783913000,Legendary Creature — Angel,Daren Bader
+Alchemist's Gambit,3,2021,0.26,#d78f42,https://cards.scryfall.io/normal/front/a/8/a8fbf5d3-4677-4bf0-891f-57d6dcddaff7.jpg?1783924845,Sorcery,Zoltan Boros
+Alchemist's Talent,4,2024,4.64,#ff1a1a,https://cards.scryfall.io/normal/front/2/f/2fb8dace-c604-40fc-bbd4-5add5deb041a.jpg?1783910731,Enchantment — Class,Milivoj Ćeran
+Alesha- Who Smiles at Death,3,2022,0.17,#d78f42,https://cards.scryfall.io/normal/front/7/a/7ae9ff8c-1cc8-4b10-9641-2c79648fd6c2.jpg?1783921427,Legendary Creature — Human Warrior,Anastasia Ovchinnikova
+All Will Be One,5,2023,15.27,#ff1a1a,https://cards.scryfall.io/normal/front/6/d/6d75e1f4-bd63-428e-8e6e-131594b3ba44.jpg?1783918036,Enchantment,Chris Rahn
+Alpha Brawl,8,2012,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e2ec168a-3e4f-4527-901a-bc28cc28d125.jpg?1783940822,Sorcery,Randy Gallegos
+Alpine Moon,1,2018,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/2435c810-2baf-4e3b-80ce-542b94694901.jpg?1783934557,Enchantment,Alayna Danner
+Amok,2,1998,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5c5bdb8c-2a2e-47cf-a502-2d62f9ada3fa.jpg?1783946559,Enchantment,Dermot Power
+Amplifire,4,2019,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7a58c77f-7c15-44f4-8011-6046482a2d08.jpg?1783933686,Creature — Elemental,Dan Murayama Scott
+Amy Pond,3,2023,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/e/5/e50a2faa-91e3-4e89-ba8d-2cbf7ac005c0.jpg?1783914655,Legendary Creature — Human,Greg Staples
+Anaba Ancestor,2,1995,0.94,#ff1a1a,https://cards.scryfall.io/normal/front/c/4/c4d33cc0-525d-4e25-927b-b6b18087c27b.jpg?1783947286,Creature — Minotaur Spirit,Anson Maddocks
+Anaba Spirit Crafter,4,1995,0.89,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e9aaabc2-1dab-4f9c-8ed3-60bc1aa995ba.jpg?1783947285,Creature — Minotaur Shaman,Anson Maddocks
+Ancient Copper Dragon,6,2022,109.29,#ff1a1a,https://cards.scryfall.io/normal/front/3/8/3836dddd-a7e4-499f-ad49-ce298aa65720.jpg?1783922745,Creature — Elder Dragon,Antonio José Manzanedo
+Ancient Grudge,2,2020,12.29,#d78f42,https://cards.scryfall.io/normal/front/7/d/7d8adb0c-a322-4447-bf2e-7a74e3b735c4.jpg?1783929770,Instant,AlbaBG
+Ancient Hellkite,7,2010,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/9/6/96cede38-0f02-4ce0-b947-ce3d7d7c2882.jpg?1783941809,Creature — Dragon,Jason Chan
+Anger,4,2026,9.42,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/dd2c39c5-e3d1-421b-b14e-a28e6810a1d1.jpg?1783904213,Creature — Incarnation,Yuko Shimizu & Scott Okumura
+Anger of the Gods,3,2022,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f92088c2-74c2-4e63-8a54-83d39f9d6ad6.jpg?1783921892,Sorcery,Yigit Koroglu
+Angrath's Marauders,7,2024,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/c/f/cf0a0bef-ed72-4fdf-9799-6f6430c8a8a7.jpg?1783911923,Creature — Human Pirate,Victor Adame Minguez
+Anje's Ravager,3,2021,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/4230560e-51b2-459d-86b9-8509a8b5b99d.jpg?1783924951,Creature — Vampire Berserker,Antonio José Manzanedo
+Antagonism,4,1998,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6b9db511-089e-413f-8005-ccb05ec3b06e.jpg?1783946334,Enchantment,Donato Giancola
+Anzrag's Rampage,5,2024,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9dc52b53-3e4f-4d7d-851f-86c6e0ac67b2.jpg?1783912887,Sorcery,Lucas Graciano
+Apex of Power,10,2021,0.96,#ff1a1a,https://cards.scryfall.io/normal/front/d/c/dc922e89-c816-476a-82c3-3c6b9fd196a9.jpg?1783926211,Sorcery,Svetlin Velinov
+Apocalypse,5,1997,7.92,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7ff23780-d183-4cca-ad0c-448ef325bf36.jpg?1783946633,Sorcery,Allen Williams
+Arcane Bombardment,6,2024,7.11,#ff1a1a,https://cards.scryfall.io/normal/front/e/f/ef7e6e2d-d984-483e-b117-b1c5d640dc23.jpg?1783911924,Enchantment,Marta Nael
+Arcbond,3,2015,1.34,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9bc397d1-50a8-46cd-98b2-7104f2241420.jpg?1783938692,Instant,Slawomir Maniak
+Archangel Avacyn // Avacyn- the Purifier,5,2025,3.47,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Angel // Legendary Creature — Angel,James Ryman
+Archwing Dragon,4,2012,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/6/c/6c6f1a8b-329e-4094-8141-6bc88311a08c.jpg?1783940691,Creature — Dragon,Daarken
+Arclight Phoenix,4,2024,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/def7f05b-6e63-4828-a92c-ce7921bbdf4e.jpg?1783913318,Creature — Phoenix,Slawomir Maniak
+Arc-Slogger,5,2003,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg?1783944543,Creature — Beast,Jeff Easley
+Ardoz- Cobbler of War,2,2022,6.11,#ff1a1a,https://cards.scryfall.io/normal/front/2/a/2a012f05-0009-42cf-8a69-07140b2a2aef.jpg?1783919185,Legendary Creature — Goblin Shaman,Kev Walker
+Aria of Flame,3,2019,0.66,#ff1a1a,https://cards.scryfall.io/normal/front/9/5/95a96eb1-f87c-4b1d-82c7-f239bcbc62b8.jpg?1783933117,Enchantment,Greg Staples
+Arni Brokenbrow,3,2021,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/f/f/ff334bba-0805-4d5d-86c4-99185fe9a77a.jpg?1783928237,Legendary Creature — Human Berserker,Dmitry Burmak
+Arni Metalbrow,3,2023,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/aeb3069f-5f5a-4e11-8a63-46399eb85a95.jpg?1783916524,Legendary Creature — Human Berserker,Tyler Jacobson
+Arterial Alchemy,3,2021,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/afe2dba0-55f4-460c-aa89-3921414e7ea1.jpg?1783925000,Enchantment,Caio Monteiro
+Artist's Talent,2,2024,5.49,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8b9e51d9-189b-4dd6-87cb-628ea6373e81.jpg?1783910825,Enchantment — Class,Lars Grant-West
+Ashcloud Phoenix,4,2024,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f628c7de-516b-4907-a3c8-b6361f2bd071.jpg?1783913000,Creature — Phoenix,Howard Lyon
+Ashen Firebeast,8,2001,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/e/b/ebaef0bd-8288-49ba-a889-d897a4aae64c.jpg?1783945235,Creature — Elemental Beast,Mark Tedin
+Ashling- Flame Dancer,4,2024,5.58,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/40463be5-89e2-410b-9a4b-770f70d14293.jpg?1783911273,Legendary Creature — Elemental Shaman,Michal Ivan
+Ashling- Rekindled // Ashling- Rimebound,2,2026,1.15,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elemental Sorcerer // Legendary Creature — Elemental Wizard,Ilse Gort
+Ashling's Prerogative,2,2007,0.67,#ff1a1a,https://cards.scryfall.io/normal/front/d/8/d850d95e-ba27-49cc-aa7a-42508852fe20.jpg?1783942880,Enchantment,Warren Mahy
+Ashling- the Limitless,3,2026,0.48,#d78f42,https://cards.scryfall.io/normal/front/5/9/5924c01f-2815-4e37-b700-3ba6cc81e0e4.jpg?1783904607,Legendary Creature — Elemental Sorcerer,Kai Carpenter
+Ashling the Pilgrim,2,2023,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/4/c/4c687123-6c34-4aef-8350-70a72b5fb58f.jpg?1783915659,Legendary Creature — Elemental Shaman,Wayne Reynolds
+Ash Zealot,2,2012,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/1/f/1f61b1a3-4b3b-4490-a9dc-17aac258cbda.jpg?1783940358,Creature — Human Warrior,Eric Deschamps
+Aspiring Champion,4,2022,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/7/7/77a2d9f6-0750-403d-879f-e3a98c36c3bb.jpg?1783920895,Creature — Astartes Warrior,Miguel Sacristan
+Assault on Osgiliath,3,2023,1.25,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/2549b70a-6bd0-4c9b-96b7-4ab775a30cd3.jpg?1783916220,Sorcery,Warren Mahy
+Assaultron Dominator,2,2024,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/4112fadb-da03-441a-beeb-1dc90425e3f3.jpg?1783912406,Artifact Creature — Robot,Viko Menezes
+Assembled Alphas,6,2016,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/8603c493-afb0-47a1-b4e3-9848b3824840.jpg?1783937466,Creature — Wolf,Christopher Moeller
+Assquatch,5,2004,2.33,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9b13248b-5abb-4246-b639-1a8a6681a157.jpg?1783944248,Creature — Donkey,Jeremy Jarvis
+Atsushi- the Blazing Sky,4,2026,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/06658540-0104-428f-91b1-40552826e781.jpg?1783903777,Legendary Creature — Dragon Spirit,Victor Adame Minguez
+Audacious Reshapers,3,2021,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/e/c/ec593c8a-b5ef-45a1-ac19-45937a876038.jpg?1783927595,Creature — Human Artificer,Justyna Dura
+Audacious Swap,4,2022,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/8/1/816cb69f-8c9f-4a1e-90d4-8c304501876c.jpg?1783923364,Instant,Igor Grechanyi
+Auntie Blyte- Bad Influence,3,2022,10.39,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85c18d01-62cd-45c2-94b8-a63a4239311d.jpg?1783919186,Legendary Creature — Devil Advisor,Tatiana Kirgetova
+Aurora Phoenix,6,2022,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f9a9e74f-8090-4314-9361-97777fb7b63a.jpg?1783922434,Creature — Phoenix,Caio Monteiro
+Avacyn's Judgment,2,2021,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/2/6/2642eb44-becf-4e99-934f-7241fcc32dee.jpg?1783924949,Sorcery,Victor Adame Minguez
+Avalanche of Sector 7,3,2025,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/2/0/20a87dbc-5deb-42ae-9097-806e9a27466f.jpg?1783906357,Legendary Creature — Human Rebel,Arif Wijaya
+Avaricious Dragon,4,2015,3.07,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/354255d7-dc29-403b-aa90-9044cde669d0.jpg?1783938333,Creature — Dragon,Chris Rahn
+Avatar of Fury,8,2017,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f137e17e-6856-49c5-9878-8c5c8f3c1518.jpg?1783936154,Creature — Avatar,rk post
+Avatar of Slaughter,8,2023,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c93dd6cc-53e8-4c67-8838-180b19f02088.jpg?1783915659,Creature — Avatar,Jason A. Engle
+Avatar Roku- Firebender,6,2025,8.98,#ff1a1a,https://cards.scryfall.io/normal/front/b/1/b1fced2b-eba2-4e70-8f1c-6d3c973b6a8d.jpg?1783904824,Legendary Creature — Human Avatar,Toni Infante
+Avengers Disassembled,3,2026,1.02,#ff1a1a,https://cards.scryfall.io/normal/front/7/2/72d3e750-870b-497d-80d7-e3df097db554.jpg?1783902933,Sorcery,David Szabo
+Awaken the Ancient,4,2013,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/e/4/e4125304-fd68-4051-96d5-625ffa9b0d3c.jpg?1783939917,Enchantment — Aura,Jaime Jones
+Awaken the Sky Tyrant,4,2015,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5c3d57d1-1031-45e0-97d1-8e8e3e6ab516.jpg?1783938111,Enchantment,Adam Paquette
+Backdraft Hellkite,5,2022,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fb3f1cb-7180-4c5f-8e04-58bb9bf45733.jpg?1783921892,Creature — Dragon,Rudy Siswanto
+Balefire Dragon,7,2025,15.02,#ff1a1a,https://cards.scryfall.io/normal/front/e/4/e4510ee2-8a2e-4fe5-94af-df420a6a35a0.jpg?1783907975,Creature — Dragon,Eric Deschamps
+Ball Lightning,3,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5f27dbf0-6818-40ea-832d-10686b4c2900.jpg?1783908925,Creature — Elemental,Trevor Claxton
+Balor,5,2022,4.84,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/60c1b3da-e8e6-4118-a268-1e3871e6ffee.jpg?1783922744,Creature — Demon,Uriah Voth
+Balthor the Stout,3,2002,0.57,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e81ecdc5-d2c7-4292-9b59-fd6bf3ba29d5.jpg?1783945151,Legendary Creature — Dwarf Barbarian,Ron Spears
+Banefire,1,2018,0.75,#ff1a1a,https://cards.scryfall.io/normal/front/5/b/5b012532-1186-4dc8-9d42-867e418b0280.jpg?1783934556,Sorcery,Raymond Swanland
+Barbflare Gremlin,4,2024,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/825f509c-272e-4c91-a139-da3c67bd6b33.jpg?1783909657,Creature — Gremlin,Matt Stewart
+Barreling Attack,4,1996,0.57,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a3a2955e-e714-419e-9e3d-7ae3d7fae041.jpg?1783947082,Instant,Ian Miller
+Battle Hymn,2,2026,3.65,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d0be7e34-13a3-414b-b097-aeb9f5b1d9e1.jpg?1783903469,Instant,Ralph Horsley
+Battlemage's Bracers,3,2021,3.54,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1a14aad2-47f0-4d21-9fcf-5ca171faffaf.jpg?1783927595,Artifact — Equipment,David Gaillet
+Battle Squadron,5,1999,0.96,#ff1a1a,https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg?1783945942,Creature — Goblin,Mark Tedin
+Bazaar Trader,2,2010,5.85,#ff1a1a,https://cards.scryfall.io/normal/front/9/2/9235ef13-a363-4cab-b69d-39093a621a5c.jpg?1783942051,Creature — Goblin,Matt Cavotta
+Beacon of Destruction,5,2017,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1ece7e7d-615b-42da-8bab-80f24ad7c4d8.jpg?1783936567,Instant,Greg Hildebrandt
+Bearer of the Heavens,8,2014,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/061d9fa5-a8e0-4263-9804-22d648554eba.jpg?1783939428,Creature — Giant,Ryan Alexander Lee
+Bedlam,4,2001,9.03,#ff1a1a,https://cards.scryfall.io/normal/front/2/7/2788ec1a-930e-4a19-ad69-ea456c1390fd.jpg?1783945474,Enchantment,Ron Spencer
+Bedlam Reveler,8,2025,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/4780d9d6-b5a2-4646-bd63-48ec58fea6b2.jpg?1783908127,Creature — Devil Horror,Jama Jurabaev
+Ben-Ben- Akki Hermit,4,2004,0.91,#ff1a1a,https://cards.scryfall.io/normal/front/d/7/d7c015a6-4d7d-421b-84fa-30bf070cff83.jpg?1783944304,Legendary Creature — Goblin Shaman,Greg Staples
+Bend or Break,4,2000,1.82,#ff1a1a,https://cards.scryfall.io/normal/front/b/7/b76b6660-d4b2-44de-a1a7-8d00811f90f6.jpg?1783945687,Sorcery,Arnie Swekel
+Berserker's Frenzy,3,2021,1.49,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/36b50ed5-321f-4840-82d7-54fec200984d.jpg?1783926246,Instant,Caio Monteiro
+Berserkers' Onslaught,5,2015,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee571a78-16b2-40ba-92b2-87c1bf4b39bc.jpg?1783938591,Enchantment,Zoltan Boros
+Big Score,4,2026,1.41,#ff1a1a,https://cards.scryfall.io/normal/front/c/7/c7b698a1-dff1-413f-ba4f-0298c686999a.jpg?1783903923,Instant,Zuzanna Wużyk
+Bill Potts,4,2023,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/7/4/74185710-3877-4080-b1d2-014fabbc7186.jpg?1783914657,Legendary Creature — Human,Kieran Yanner
+Birgi- God of Storytelling // Harnfel- Horn of Bounty,3,2021,32.77,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact,Eric Deschamps
+Bitter Feud,5,2018,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/2/6/26387ab4-74da-49d7-965e-352da48d6a90.jpg?1783934750,Enchantment,Aaron Miller
+Blaster Hulk,8,2024,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/7853d27d-e860-42ba-b925-8b57dc451059.jpg?1783911422,Artifact Creature — Pirate,Lie Setiawan
+Blast from the Past,3,2020,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/a/7/a784dde5-cfce-464f-a134-8894ba3faf5b.jpg?1783931332,Instant,Douglas Shuler
+Blast-Furnace Hellkite,9,2022,4.47,#ff1a1a,https://cards.scryfall.io/normal/front/0/4/04c349f2-69b1-48dd-a547-f2b55f542700.jpg?1783919718,Creature — Dragon,Aldo Domínguez
+Blazing Rootwalla,1,2024,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fb3e1d1-ab89-4bdc-8a34-fc45fa477419.jpg?1783911696,Creature — Lizard,Brian Valeza
+Blazing Shoal,2,2005,5.43,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8b915daa-d239-4460-bd6b-e1327fdf7f51.jpg?1783944191,Instant — Arcane,Glen Angus
+Blazing Sunsteel,2,2020,3.58,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69d276fe-5f2b-41aa-80fa-64d3b60fd54f.jpg?1783928737,Artifact — Equipment,Tyler Jacobson
+Blistering Firecat,4,2002,7.09,#ff1a1a,https://cards.scryfall.io/normal/front/e/0/e0ddcf4a-1943-49dd-a02c-75804ce4bc3e.jpg?1783945058,Creature — Elemental Cat,Arnie Swekel
+Bloodbraid Marauder,2,2021,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/6/2/6286fd93-bb97-4721-8a40-1c5a884c2edb.jpg?1783926849,Creature — Human Berserker,Kari Christensen
+Bloodfeather Phoenix,2,2023,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/e/d/ed97bf6f-726c-40aa-bc1c-14fa801da96a.jpg?1783916997,Creature — Phoenix,Rudy Siswanto
+Bloodfire Colossus,8,2012,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/088f00a5-95b5-4892-9572-9e022b0eb01f.jpg?1783940760,Creature — Giant,Greg Staples
+Bloodhall Ooze,1,2009,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e8b7208e-aa64-43fa-b7f8-8d40d7005358.jpg?1783942481,Creature — Ooze,Jaime Jones
+Blood Hound,3,1999,0.53,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/baa1e796-809c-49af-a84e-ec088f7f48f8.jpg?1783945942,Creature — Dog,Bradley Williams
+Blood Knight,2,2007,11.32,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/64d02c9b-7362-4479-b26d-7de843bd2ac3.jpg?1783943130,Creature — Human Knight,Matt Cavotta
+Blood Moon,3,2020,8.24,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d072e9ca-aae7-45dc-8025-3ce590bae63f.jpg?1783930171,Enchantment,Franz Vohwinkel
+Blood Oath,4,1999,1.19,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f1556a12-ff45-4a12-988a-63615b3799a9.jpg?1783945941,Instant,Mike Ploog
+Bloodshot Cyclops,6,2003,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/b/0/b021f1ea-4db1-40fb-a5dc-af13be53ad15.jpg?1783944731,Creature — Cyclops Giant,Daren Bader
+Blood Sun,3,2018,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/8/7/875832f4-e541-4c87-8479-731e0eab2cc6.jpg?1783935303,Enchantment,Emrah Elmasli
+Bloodsworn Steward,4,2021,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/4023f86a-91af-439b-b591-8bb621255eee.jpg?1783924948,Creature — Vampire Knight,Daarken
+Bloodthirster,6,2022,32.09,#ff1a1a,https://cards.scryfall.io/normal/front/c/c/ccbb3a6d-7e75-46c7-a91f-db4cf8d003af.jpg?1783920894,Creature — Demon,Games Workshop
+Bloodthirsty Adversary,2,2024,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1d6d5c4b-01ec-407f-b3b6-854ab5127bdc.jpg?1783911923,Creature — Vampire,Heonhwa
+Bloody Betrayal,3,2026,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/9/4/9460ca4f-aea4-4c38-8e36-7467178986cc.jpg?1783904238,Sorcery,Cabrol
+Bludgeon Brawl,3,2011,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a30fa96d-64d1-423e-a62e-d43453ea838d.jpg?1783941309,Enchantment,Kev Walker
+Bogardan Hellkite,8,2021,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/2/2/22dd2242-2fd8-4752-886c-fc6dbabcf89a.jpg?1783926211,Creature — Dragon,Scott M. Fischer
+Bogardan Phoenix,5,1997,1.4,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/253db28a-3873-4364-80d7-a8164000ea9e.jpg?1783946990,Creature — Phoenix,David O'Connor
+Boldwyr Heavyweights,4,2008,2.44,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/88d90bc4-7f70-4203-b554-800c70c775ef.jpg?1783942788,Creature — Giant Warrior,Wayne Reynolds
+Boltbender,4,2024,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/f/0/f0a18bd1-1741-4231-a312-aed1373a96dd.jpg?1783913044,Creature — Goblin Wizard,Lars Grant-West
+Bomb Squad,4,2001,1.14,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e9535a5-29ea-4085-a36b-4905d85e97ac.jpg?1783945233,Creature — Dwarf,Greg Hildebrandt & Tim Hildebrandt
+Bonecrusher Giant // Stomp,3,2022,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5b71cd2-de35-451f-b16e-2e3936169407.jpg?1783922435,Creature — Giant // Instant — Adventure,Victor Adame Minguez
+Bonehoard Dracosaur,5,2023,13.29,#ff1a1a,https://cards.scryfall.io/normal/front/2/2/2220ed60-3f8f-4dd2-8319-6a06896a5350.jpg?1783913768,Creature — Dinosaur Dragon,Mark Zug
+Bonfire of the Damned,1,2017,2.03,#ff1a1a,https://cards.scryfall.io/normal/front/c/f/cf4f47a9-1c23-4d63-bb89-83c889615e50.jpg?1783936648,Sorcery,James Paick
+Bonus Round,3,2018,8.19,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e21aa266-4264-4e02-9403-02930e641573.jpg?1783934859,Sorcery,Lake Hurwitz
+Boom // Bust,8,2021,1.31,#ff1a1a,https://cards.scryfall.io/normal/front/8/f/8ffdee1b-bb5d-44e6-a90d-6f9e9266d4fd.jpg?1783927802,Sorcery // Sorcery,John Avon
+Boommobile,4,2025,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg?1783907886,Artifact — Vehicle,Alexandr Leskinen
+Boomstacker,3,2020,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/7/4/747788b4-42ab-4e3e-bdbe-eb5040432db1.jpg?1783931333,Creature — Goblin Artificer,Jesper Ejsing
+Borderland Behemoth,7,2018,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/e/4/e4cbde6a-fbc8-403a-98ad-769d25aa4732.jpg?1783934748,Creature — Giant Warrior,Jesper Ejsing
+Bothersome Quasit,3,2022,14.12,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6e9a0a23-cd62-4762-b751-ac0159a1b3c5.jpg?1783922501,Creature — Demon,Mathias Kollros
+Braid of Fire,2,2006,24.11,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/41bab8de-6e0f-4ccd-a303-01e9c8c82d3f.jpg?1783943342,Enchantment,Cyril Van Der Haegen
+Brallin- Skyshark Rider,4,2020,8.03,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9b4fdcd5-5346-46a8-b1a4-84ddb74089e0.jpg?1783931233,Legendary Creature — Human Shaman,Paul Scott Canavan
+Brand,1,1998,5.06,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/bafbd034-c8a0-4798-a680-555c13bdd251.jpg?1783946334,Instant,Donato Giancola
+Brand of Ill Omen,4,1995,1.42,#ff1a1a,https://cards.scryfall.io/normal/front/c/e/ceeb7bbc-2d41-4709-95be-1ceb952ed1fb.jpg?1783947492,Enchantment — Aura,Rob Alexander
+Brash Taunter,5,2024,2.89,#ff1a1a,https://cards.scryfall.io/normal/front/2/7/275f8721-a6e5-489b-851f-1676aad5ec39.jpg?1783909612,Creature — Goblin,Edgar Sánchez Hidalgo
+Brass's Bounty,7,2024,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/6/5/65fe7127-b0ec-400f-97f1-6e17ab8e319d.jpg?1783909069,Sorcery,Grzegorz Rutkowski
+Brass's Tunnel-Grinder // Tecutlan- the Searing Rift,3,2023,3.22,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact // Legendary Land — Cave,Cristi Balanescu
+Brawl,5,1999,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/3/f/3f4e783c-0717-4127-bd7b-885ca617ca29.jpg?1783945942,Instant,Edward P. Beard, Jr.
+Brazen Cannonade,4,2022,3.87,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bbcbad10-475e-41cf-b3fb-68c1ca6c2caa.jpg?1783919184,Enchantment,Ralph Horsley
+Breaking Point,3,2013,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/7/3/73e348dd-2d8a-4ee6-a834-2d5861566043.jpg?1783940062,Sorcery,Matthew D. Wilson
+Breath of Fury,4,2016,25.64,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a1fce58d-d754-4532-b4d0-4bb3cf108090.jpg?1783937066,Enchantment — Aura,Kev Walker
+Breeches- Eager Pillager,3,2023,0.77,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aadf5028-8dfe-40d3-89b4-22bd7ed0aae6.jpg?1783913765,Legendary Creature — Goblin Pirate,Josu Hernaiz
+Breya's Apprentice,3,2021,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/c/3/c32b5b2e-dabf-4672-b476-4873781f636e.jpg?1783926848,Artifact Creature — Human Artificer,Aleksi Briclot
+Bringer of the Red Dawn,9,2004,1.96,#d78f42,https://cards.scryfall.io/normal/front/1/6/16a58bb1-4c4d-41f2-9c69-d3c3a8a8ab09.jpg?1783944396,Creature — Bringer,Christopher Moeller
+Broadcast Takeover,5,2026,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e640e930-0907-40f2-9015-88f8c1e8ee5c.jpg?1783904100,Sorcery,Hokyoung Kim
+Broadside Bombardiers,3,2023,3.04,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/9721f8da-39ed-4ada-a571-61e08a86032b.jpg?1783913908,Creature — Goblin Pirate,Tomek Larek
+Brotherhood's End,3,2022,1.52,#ff1a1a,https://cards.scryfall.io/normal/front/5/0/50f7666d-0d60-4fe5-b144-286d4e47b704.jpg?1783920075,Sorcery,Bryan Sola
+Brutal Cathar // Moonrage Brute,3,2021,0.31,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Soldier Werewolf // Creature — Werewolf,Karl Kopinski
+Bulwark,5,1998,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a2041b95-ec5b-4512-b012-f875ca686669.jpg?1783946333,Enchantment,Brian Snõddy
+Burn at the Stake,5,2012,1.04,#ff1a1a,https://cards.scryfall.io/normal/front/d/4/d46e9902-81fb-4a3c-9f2f-d3faf031631d.jpg?1783940688,Sorcery,Zoltan Boros
+Burn Down the House,5,2021,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/2/0/20ded7af-8086-465e-a980-3099217d324c.jpg?1783925604,Sorcery,Campbell White
+Burn from Within,1,2016,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/f/8/f8bdc165-4c6f-47e6-8bda-877c0be3613b.jpg?1783937758,Sorcery,James Ryman
+Burning Anger,5,2014,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/2/0/2058a7eb-0f78-46a4-bea5-afdfe920264f.jpg?1783939176,Enchantment — Aura,Anthony Palumbo
+Burning Cinder Fury of Crimson Chaos Fire,4,1998,4.53,#ff1a1a,https://cards.scryfall.io/normal/front/1/7/17ed4800-dc0f-4681-9ae6-74bd0018e8dc.jpg?1783946428,Enchantment,Richard Kane Ferguson
+Burning Earth,4,2013,2.96,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1df3a7c9-5c8d-438c-a5ad-3c9754c6ea5d.jpg?1783939917,Enchantment,rk post
+Burning Sands,5,2001,2.49,#ff1a1a,https://cards.scryfall.io/normal/front/9/a/9a5d5eef-6e3c-4907-a277-a13de2916e2b.jpg?1783945233,Enchantment,Ron Spencer
+Burning Sun's Avatar,6,2017,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/146c0cab-5f6b-425d-9f50-33d8da266235.jpg?1783935749,Creature — Dinosaur Avatar,Randy Vargas
+Burning Wish,2,2016,0.94,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3abb0b65-b3de-4193-ae60-9b8ba55636b4.jpg?1783937306,Sorcery,Scott M. Fischer
+Burnout Bashtronaut,1,2025,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4db66e7b-cb7a-4d86-a563-d570946aeb0d.jpg?1783907886,Creature — Goblin Warrior,Andrea Piparo
+Butcher Orgg,7,2002,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7f2a29cf-4b2e-44c0-af73-512d6fed0dae.jpg?1783945058,Creature — Orgg,Kev Walker
+By Force,1,2022,6.29,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/baa8c556-2d3e-4f29-8457-e2162def7353.jpg?1783918775,Sorcery,Volta Creation
+Byway Barterer,3,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f41fc718-641b-4f32-a8c1-3e5591a05bf8.jpg?1783910824,Creature — Raccoon Rogue,Ryan Pancoast
+Cait Sith- Fortune Teller,4,2025,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/3/e/3e0f6c53-6bbf-4d4c-bbbf-4dab22297527.jpg?1783906357,Legendary Artifact Creature — Cat Moogle,Kevin Sidharta
+Calamity Bearer,4,2021,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a15edad1-ff68-4f20-95f6-99fe549bea98.jpg?1783928234,Creature — Giant Berserker,Simon Dominic
+Calamity- Galloping Inferno,6,2024,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/e/7/e7a70f5a-2056-4c26-b6ea-9f751b5d0d8c.jpg?1783911823,Legendary Creature — Horse Mount,Artur Nakhodkin
+Calamity of Cinders,7,2024,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/97c72d4b-a5d4-4f68-bbcd-b7ed0326fc1c.jpg?1783910732,Sorcery,Xabi Gaztelua
+Caldera Hellion,5,2008,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg?1783942563,Creature — Hellion,Raymond Swanland
+Caldera Pyremaw,5,2025,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f5fab7a4-3612-4b79-b2f5-8a1e52ebe409.jpg?1783907175,Creature — Dragon,Johann Bodin
+Calibrated Blast,3,2021,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/3/7/37962700-e4d9-419e-8972-d3fd955ff40e.jpg?1783926848,Instant,Evan Shipard
+Call for Aid,5,2023,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/7072b75a-64ab-4894-943e-fc0b779ca60e.jpg?1783916029,Sorcery,Nino Is
+Callous Giant,6,2000,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/3/3/330028c4-8e91-4fe3-a87d-1660dfd2507e.jpg?1783945686,Creature — Giant,Mark Brill
+Canyon Drake,4,1997,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/2/2/22f84143-5912-43ca-a274-f26ed0dbadd0.jpg?1783946632,Creature — Drake,Quinton Hoover
+Capricious Efreet,6,2013,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/4/8/48d3c44d-1a2f-4e2a-8d5a-592719cb92f4.jpg?1783939670,Creature — Efreet,Justin Sweet
+Capricious Hellraiser,6,2023,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/23afca1a-62a8-497f-994f-ceb479d020ba.jpg?1783918033,Creature — Phyrexian Dragon,Durion
+Capricious Sliver,4,2023,0.65,#ff1a1a,https://cards.scryfall.io/normal/front/4/8/48938cd4-9158-4eb8-acb7-21ce7a11cfa7.jpg?1783915481,Creature — Sliver,Brent Hollowell
+Captain Lannery Storm,3,2024,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/60a457e2-6cc7-47f0-9a24-df5459395358.jpg?1783911922,Legendary Creature — Human Pirate,Chris Rallis
+Captivating Crew,4,2024,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/1/3/13710c49-496d-41f9-87a4-5794dea9145d.jpg?1783911922,Creature — Human Pirate,Winona Nelson
+Carnival Barker,3,2022,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/f/7/f7c29dab-5cd4-4158-9a12-f14004e08484.jpg?1783920571,Creature — Dog Employee,Dave Greco
+Case of the Crimson Pulse,3,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bb18b1de-bc08-4522-b891-6117a8271534.jpg?1783912887,Enchantment — Case,Adam Paquette
+Casey Jones- Asphalt Hooligan,3,2026,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a2754751-031f-4682-86fd-ea9a60a33a05.jpg?1783904137,Legendary Creature — Human Berserker,Jason Kiantoro
+Casey Jones- Back Alley Brute,4,2026,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/416d888d-2699-49bd-830b-bf5bda25c91f.jpg?1783904167,Legendary Creature — Human Berserker,Kieran Yanner
+Casey Jones- Vigilante,3,2026,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/a/6/a6a3258d-2e9b-4862-b2e3-bbfae9bd4d33.jpg?1783904098,Legendary Creature — Human Berserker,Xavier Ribeiro
+Casey & Raph- Hotheads,5,2026,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bc235c57-b263-418a-8d33-094d9ba1f5e6.jpg?1783904136,Legendary Creature — Mutant Ninja Human Turtle,Leonardo Santanna
+Cataclysmic Prospecting,2,2024,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/149829e6-94bd-49a0-be35-51f37bea7ffb.jpg?1783911968,Sorcery,PINDURSKI
+Cathartic Reunion,2,2025,2.29,#ff1a1a,https://cards.scryfall.io/normal/front/a/5/a58e3838-6c90-4c5e-bfaf-ef47c1df5a64.jpg?1783905147,Sorcery,Stephen Andrade
+Cavalier of Flame,5,2019,2.44,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0c18c541-758b-4237-9961-9637e996e8a5.jpg?1783932984,Creature — Elemental Knight,Wesley Burt
+Cave-In,5,1999,14.33,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/440d9d26-f304-467d-af79-914cc65f082e.jpg?1783945942,Sorcery,Mark Tedin
+Caverns of Despair,4,1994,108.01,#ff1a1a,https://cards.scryfall.io/normal/front/2/0/209f7479-b3a0-4c27-9602-78babb8d2e99.jpg?1783948059,World Enchantment,Harold McNeill
+Caves of Chaos Adventurer,4,2022,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/0/9/09abb6df-2aa1-4999-b550-db2892faa8c7.jpg?1783922743,Creature — Human Barbarian,Marcela Medeiros
+Cemetery Gatekeeper,2,2021,2.74,#ff1a1a,https://cards.scryfall.io/normal/front/4/5/457086c4-1b4e-4f79-8f2a-10b16174c8bb.jpg?1783924842,Creature — Vampire,Tyler Jacobson
+Cerebral Eruption,4,2010,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/7/7/77161159-ee2c-485d-8674-d8590ccc62e1.jpg?1783941726,Sorcery,Kev Walker
+Chain Lightning,1,2025,2.4,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/111282a0-28be-40f0-a0e7-2f362268c0a3.jpg?1783906752,Sorcery,Adam Volker
+Chain Reaction,4,2026,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/6/f/6f34d11e-8452-448f-be4f-838e0ace9904.jpg?1783903818,Sorcery,Gustavo Pelissari
+Chainsaw,2,2024,1.17,#ff1a1a,https://cards.scryfall.io/normal/front/5/4/54e0c2cd-fa5f-427d-8e15-6066f002a8e3.jpg?1783909471,Artifact — Equipment,J.P. Targete
+Champion of the Path,4,2026,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/e/3/e369cd31-3e22-47eb-bf6a-00d823651710.jpg?1783904447,Creature — Elemental Sorcerer,Tyler Walpole
+Chance Encounter,4,2021,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/49a4b0c9-a35b-4b55-ab27-7246bbca0d16.jpg?1783926785,Enchantment,Steven Belledin
+Chancellor of the Forge,7,2011,0.93,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/dd3520a7-a55f-4c00-b4f1-c1c154adfc8f.jpg?1783941309,Creature — Phyrexian Giant,Chippy
+Chandra Ablaze,6,2009,4.13,#ff1a1a,https://cards.scryfall.io/normal/front/4/3/43da8995-77da-4ec4-94a5-5e7932a3c969.jpg?1783942147,Legendary Planeswalker — Chandra,Steve Argyle
+Chandra- Acolyte of Flame,3,2019,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/2/c/2cabfcfe-012e-4cab-bba2-24052eac0946.jpg?1783932984,Legendary Planeswalker — Chandra,Anna Steinbauer
+Chandra- Awakened Inferno,6,2023,9.85,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0d4fb926-fe8c-4640-ac8d-ef418b8945d5.jpg?1783915432,Legendary Planeswalker — Chandra,Chris Rahn
+Chandra- Dressed to Kill,3,2025,1.59,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/640b112d-fe82-4294-a632-efbb7f2467f5.jpg?1783908124,Legendary Planeswalker — Chandra,Viktor Titov
+Chandra- Fire Artisan,4,2019,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/d/2/d21a7b23-8827-49f2-ade4-75a602d17743.jpg?1783933433,Legendary Planeswalker — Chandra,Yongjae Choi
+Chandra- Fire of Kaladesh // Chandra- Roaring Flame,3,2015,3.55,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Shaman // Legendary Planeswalker — Chandra,Eric Deschamps
+Chandra- Flamecaller,6,2020,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a83ca3a1-82a9-4f47-b0b8-21687afd705b.jpg?1783931174,Legendary Planeswalker — Chandra,Jason Rainville
+Chandra- Flameshaper,7,2024,0.65,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg?1783909105,Legendary Planeswalker — Chandra,Mark Winters
+Chandra- Heart of Fire,5,2020,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/a/4/a4c3ca8c-c77c-43b8-84ad-796313ecc813.jpg?1783930694,Legendary Planeswalker — Chandra,Josu Hernaiz
+Chandra- Hope's Beacon,6,2023,2.7,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a146ea07-ec1c-448d-b67a-dd9f9e27c2e0.jpg?1783916996,Legendary Planeswalker — Chandra,Kieran Yanner
+Chandra- Legacy of Fire,5,2023,2.56,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6b764e0d-ded0-4036-83b1-de49c6ee8f7e.jpg?1783915480,Legendary Planeswalker — Chandra,Chris Rahn
+Chandra- Pyromaster,4,2017,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7ab164f6-bfea-4519-bb44-80a716630f4f.jpg?1783936152,Legendary Planeswalker — Chandra,Chris Rahn
+Chandra's Firemaw,5,2020,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/7/6/76cf0b50-155f-4e65-9e48-88b378ad93a1.jpg?1783930618,Creature — Hellion,Bryan Sola
+Chandra's Flame Wave,5,2019,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5f13b6a7-fa62-4d94-a56c-f2e64c8c1666.jpg?1783932918,Sorcery,Paul Scott Canavan
+Chandra's Ignition,5,2023,7.16,#ff1a1a,https://cards.scryfall.io/normal/front/9/6/960f45a3-f9cf-41e6-b813-f3dee620a944.jpg?1783913867,Sorcery,Eric Deschamps
+Chandra's Incinerator,6,2020,2.74,#ff1a1a,https://cards.scryfall.io/normal/front/e/d/ed875705-b7b6-4464-b16f-61629ffed04f.jpg?1783930694,Creature — Elemental,Craig J Spearing
+Chandra's Outburst,5,2018,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f1e849c3-f357-4e81-a580-be5056bed51b.jpg?1783934936,Sorcery,Yongjae Choi
+Chandra- Spark Hunter,4,2025,2.13,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg?1783907885,Legendary Planeswalker — Chandra,Devin Elle Kurtz
+Chandra's Phoenix,3,2017,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1a91cd9b-9a5d-4251-bd6c-41c3ebd6d991.jpg?1783936150,Creature — Phoenix,Aleksi Briclot
+Chandra's Regulator,2,2019,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/8/f/8f1b1d5c-f71e-4c68-8baf-c134e42ed6f2.jpg?1783932981,Legendary Artifact,Eric Deschamps
+Chandra- the Firebrand,4,2012,1.03,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/beb039db-7367-4af1-8d85-4951f58e2732.jpg?1783940488,Legendary Planeswalker — Chandra,D. Alexander Gregory
+Change of Fortune,4,2021,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/6/3/63ca5ce5-94e7-43a1-8f2b-f0a4532f617a.jpg?1783924841,Sorcery,Sam Guay
+Chaos Dragon,3,2022,5.15,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/08219fbc-c155-4d1d-a08c-d2546c44bccc.jpg?1783922430,Creature — Dragon,Grzegorz Rutkowski
+Chaos Harlequin,4,1996,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/e/c/ec7d7c80-4e3c-454e-b2ed-6f0436df19c9.jpg?1783947179,Creature — Human,Alan Rabinowitz
+Chaos Imps,6,2012,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/c/7/c70a702a-c9be-4bee-9087-22b5905f783a.jpg?1783940357,Creature — Imp,Tyler Jacobson
+Chaoslace,1,1995,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/476180df-8b88-4ead-b6c5-6ccb3e8a2cfd.jpg?1783947833,Instant,Dameon Willich
+Chaos Lord,7,1995,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee245922-b380-4b2e-a43f-ab1ba8078943.jpg?1783947491,Creature — Human,Brian Snõddy
+Chaos Maw,7,2017,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/8/0/8094908b-1d3a-42df-bc27-8456fbb98e65.jpg?1783936032,Creature — Hellion,Steve Argyle
+Chaos Moon,4,1995,0.98,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aae0543f-7f8b-4327-b735-ac21244e9936.jpg?1783947491,Enchantment,Drew Tucker
+Chaosphere,3,1996,8.79,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bd41cb92-578b-4fc8-b1e6-56604088fcd5.jpg?1783947082,World Enchantment,Steve Luke
+Chaos Warp,3,2026,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/5/7/57f61970-382e-415c-868b-6bbb6c78825d.jpg?1783903234,Instant,Filipe Pagliuso
+Chaotic Goo,4,1997,1.38,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0e9881a4-3078-4fe0-be09-54ddad1d18a0.jpg?1783946631,Creature — Ooze,Allen Williams
+Chaotic Transformation,6,2022,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bdfb44f1-e366-437a-bde3-59bfdb362864.jpg?1783921321,Sorcery,Joseph Meehan
+Char,3,2005,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/f/f/ff3a24af-e995-4d05-ac2c-e9676048675d.jpg?1783943658,Instant,Adam Rex
+Charging Cinderhorn,4,2016,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/f/c/fc0b61f2-4bb7-4dfa-907c-71787930d58f.jpg?1783937089,Creature — Elemental Ox,Lius Lasahido
+Charmbreaker Devils,6,2021,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4abf9b03-4157-42f0-ab3d-484bd9b64bb2.jpg?1783927547,Creature — Devil,Dan Murayama Scott
+Charming Scoundrel,2,2023,1.14,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1783915097,Creature — Human Rogue,Caroline Gariba
+Charred Foyer // Warped Space,10,2024,2.5,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1783909470,Enchantment — Room // Enchantment — Room,Andrew Mar
+Chef's Kiss,3,2021,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c936ebbd-512a-49a6-ab23-16ac34b4a3a9.jpg?1783926847,Instant,Iain McCaig
+Chiss-Goria- Forge Tyrant,9,2023,2.43,#ff1a1a,https://cards.scryfall.io/normal/front/9/2/923eb713-c955-4e12-8a8f-df3b4b361487.jpg?1783918155,Legendary Creature — Dragon,Svetlin Velinov
+Chong and Lily- Nomads,4,2025,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/6/c/6cf1c3d5-3fae-4a43-81c8-c823d2755b99.jpg?1783904822,Legendary Creature — Human Bard Ally,Phima
+Choreographed Sparks,2,2026,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0cda4235-4dce-48fe-a8a5-2a952dedbe25.jpg?1783903673,Instant,Paolo Parente
+City on Fire,8,2023,12.37,#ff1a1a,https://cards.scryfall.io/normal/front/6/f/6f455cc1-a822-44ef-ba7c-bfcff69bd45e.jpg?1783916996,Enchantment,Jake Murray
+Clash of Realities,4,2005,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/064dcfb2-6088-49c9-89b2-88d63c9add53.jpg?1783944191,Enchantment,Jim Nelson
+Clickslither,4,2014,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3ab74f04-8aaa-438e-97b4-bfa1db4c5442.jpg?1783938767,Creature — Insect,Kev Walker
+Clive- Ifrit's Dominant // Ifrit- Warden of Inferno,6,2025,3.39,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Noble Warrior // Legendary Enchantment Creature — Saga Demon,Nino Is
+Coercive Recruiter,5,2023,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/1/6/16a1d084-34f1-4278-ae54-d0dac288b1da.jpg?1783913865,Creature — Orc Pirate,Randy Vargas
+Collapsing Borders,4,2000,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/c/c/cc019633-788e-4095-9610-6c0a432f7656.jpg?1783945687,Enchantment,Glen Angus
+Collective Defiance,3,2025,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/1/7/17d512c0-fc02-419f-90f2-a6acc7815bd4.jpg?1783908123,Sorcery,Kieran Yanner
+Collective Inferno,5,2026,1.45,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1ec084cc-997d-4079-b445-8f701ec3c277.jpg?1783904449,Enchantment,Jason A. Engle
+Collision of Realms,7,2022,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/49618217-1bbb-498a-a6f0-f269ce7166a6.jpg?1783923992,Sorcery,Piotr Dura
+Combat Celebrant,3,2017,1.42,#ff1a1a,https://cards.scryfall.io/normal/front/2/8/28b63c3d-2e55-4343-b49a-11fa602ec473.jpg?1783936491,Creature — Human Warrior,Chris Rallis
+Combustible Gearhulk,6,2024,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c80e620e-bece-4c48-9dd6-7bcdacabf521.jpg?1783909612,Artifact Creature — Construct,Daarken
+Comet Storm,2,2020,3.48,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bb5f586d-6bf0-4590-ad73-2d46b2a45b1a.jpg?1783928714,Instant,Jung Park
+Commune with Lava,2,2021,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/862771b6-8e82-45b7-922f-4f40322a607e.jpg?1783926211,Instant,Ryan Barger
+Confusion in the Ranks,5,2003,18.57,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9d46aca2-4714-4d2c-9466-5f1c043b8726.jpg?1783944542,Enchantment,Ron Spencer
+Connecting the Dots,2,2024,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg?1783912884,Enchantment,Aaron J. Riley
+Conquering Manticore,6,2013,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/9/5/95f5bf3f-3fa7-47db-981b-933cdb505398.jpg?1783939841,Creature — Manticore,Chris Rahn
+Conspicuous Snoop,2,2020,3.46,#ff1a1a,https://cards.scryfall.io/normal/front/5/d/5d878dab-5ed2-4ef3-b2c7-472290892854.jpg?1783930693,Creature — Goblin Rogue,Zoltan Boros
+Conspiracy Theorist,2,2026,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/dd6797f7-ecc4-4c45-b1e4-26963a1614dc.jpg?1783903775,Creature — Human Shaman,Svetlin Velinov
+Cool but Rude,2,2026,7.32,#ff1a1a,https://cards.scryfall.io/normal/front/a/5/a566ab2d-6ec8-4833-8ad6-210378b1a20e.jpg?1783904098,Enchantment — Class,Lordigan
+Cori-Steel Cutter,2,2025,5.57,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/490eb213-9ae2-4b45-abec-6f1dfc83792a.jpg?1783907363,Artifact — Equipment,Xabi Gaztelua
+Cosmic Larva,3,2004,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/deaa0b9b-258e-4daf-8fec-ce64864d6bbf.jpg?1783944396,Creature — Beast,Jeff Easley
+Count on Luck,3,2025,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/8/f/8f31beae-9b8f-4c32-af84-9f3ee767ba1d.jpg?1783907886,Enchantment,Michal Ivan
+Countryside Crusher,3,2013,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/5/4/54582b89-a152-4686-8172-82db740dfea2.jpg?1783939984,Creature — Giant Warrior,Volkan Baǵa
+Court of Embereth,4,2023,6.44,#ff1a1a,https://cards.scryfall.io/normal/front/3/2/327cea0d-6328-4194-91de-8c6c937406ef.jpg?1783914984,Enchantment,Peter Polach
+Court of Ire,5,2020,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/7/3/73ca0dcc-7a87-49da-8011-8c11a8835df2.jpg?1783928819,Enchantment,Alexander Forssberg
+Covetous Dragon,5,1999,4.1,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c5f37e36-c004-4b89-a668-5cd984c59019.jpg?1783946068,Creature — Dragon,rk post
+Coward // Killer,6,2023,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9e389269-deef-4c48-b6d1-c505bf7cc6b3.jpg?1783914657,Sorcery // Sorcery,Bartek Fedyczak
+Crackle with Power,2,2021,7.29,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/de547f52-3798-4b3a-947d-24873251204b.jpg?1783927356,Sorcery,Micah Epstein
+Crackling Spellslinger,5,2024,1.32,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aa735e13-f784-4174-91fc-3751aaa559d1.jpg?1783911966,Creature — Human Wizard,Marta Nael
+Cragganwick Cremator,4,2020,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b13d612-f5d4-4423-99bc-359c47a8aa99.jpg?1783930168,Creature — Giant Shaman,Jeremy Enecio
+Crag Saurian,3,1999,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/1/f/1f0907a5-938e-4ef4-aa85-e7c1ae4317a6.jpg?1783945941,Creature — Lizard,Matthew D. Wilson
+Crash Through,1,2021,4.5,#ff1a1a,https://cards.scryfall.io/normal/front/1/3/13556e56-24bf-4149-a61f-80850cfc0523.jpg?1783926545,Sorcery,Tyler Walpole
+Craterclaw Colossus,7,2026,49.95,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/47793a51-08c6-4ad2-a7e5-a4484d83a5cd.jpg?1784324668,Artifact Creature — Beast Construct,Mark Zug
+Crater Elemental,3,2015,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/c/4/c4ee8d1f-00e8-44e3-b125-ef98e1461263.jpg?1783938591,Creature — Elemental,Svetlin Velinov
+Crater Hellion,6,2016,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/c/e/ce5c02ae-e390-4da6-9904-ec138abbe047.jpg?1783937583,Creature — Hellion Beast,Daren Bader
+Crater's Claws,1,2014,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/9/5/95dde66b-b4a1-4a1e-8c9e-0bec4790b1e5.jpg?1783939074,Sorcery,Noah Bradley
+Creative Technique,5,2026,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/c/0/c0b5ba5f-ac25-4134-91c1-9677ba86576c.jpg?1783903775,Sorcery,Gaboleps
+Creepy Puppeteer,4,2021,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0bd17b9f-fd93-47d4-9cc4-cd333d0004f5.jpg?1783924838,Creature — Human Rogue,Marie Magny
+Crimson Hellkite,9,2001,1.36,#ff1a1a,https://cards.scryfall.io/normal/front/5/4/5451e44f-8dd2-48c6-ba67-5c62a04819ef.jpg?1783945473,Creature — Dragon,Carl Critchlow
+Crimson Honor Guard,5,2021,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7ac7b366-a967-4efb-9254-a4ec423d63a7.jpg?1783924947,Creature — Vampire Knight,Kieran Yanner
+Crimson Manticore,4,1997,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4f6884be-9e7c-407b-9165-6a720a634bb5.jpg?1783946915,Creature — Manticore,Roger Raupp
+Crucible of Fire,4,2017,0.82,#ff1a1a,https://cards.scryfall.io/normal/front/d/7/d7a6f4dd-29c9-4084-a622-098b197a6eb7.jpg?1783935530,Enchantment,Dominick Domingo
+Cunning Giant,6,1998,2.1,#ff1a1a,https://cards.scryfall.io/normal/front/0/a/0aa284a7-3aac-4e88-becb-548a28c77401.jpg?1783946468,Creature — Giant,Jeffrey R. Busch
+Cursed Mirror,3,2026,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/077392b3-6b06-46c8-8737-51e85f690448.jpg?1783903775,Artifact,David Gaillet
+Cursed Recording,4,2024,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg?1783909470,Artifact,Kim Sokol
+Curse of Bloodletting,5,2012,1.55,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9dc4ac6f-0005-47f8-bee9-10429cc542e4.jpg?1783940820,Enchantment — Aura Curse,Michael C. Hayes
+Curse of Hospitality,3,2021,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/4/5/45bcb839-4cff-4349-9892-0c76ae81929c.jpg?1783924838,Enchantment — Aura Curse,Dominik Mayer
+Curse of Marit Lage,5,1995,2.08,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69b381c1-aa71-4d40-a320-70f58a440d51.jpg?1783947491,Enchantment,Amy Weber
+Curse of Obsession,5,2021,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69ba6262-a3b1-4009-b2ed-ae684dfae022.jpg?1783925370,Enchantment — Aura Curse,Irvin Rodriguez
+Curse of Shaken Faith,2,2021,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/3/7/371b7795-5cfc-4e2b-b26c-2def52c61dbf.jpg?1783925603,Enchantment — Aura Curse,Campbell White
+Curse of Stalked Prey,2,2011,0.77,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/11a18883-8990-40a0-bcb2-e01d0e82bfad.jpg?1783940941,Enchantment — Aura Curse,Christopher Moeller
+Curse of the Fire Penguin // Curse of the Fire Penguin Creature,6,2004,1.04,#ff1a1a,https://cards.scryfall.io/normal/front/c/0/c01e8089-c3a9-413b-ae2d-39ede87516d3.jpg?1783944247,Enchantment — Aura // Creature — Penguin,Matt Thompson
+Cyclops Gladiator,4,2010,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b6f2eddc-b296-40d0-bf59-44899f1570e8.jpg?1783941808,Creature — Cyclops Warrior,Kev Walker
+Dance with Calamity,8,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69f34a40-30f8-4fdd-bb21-79171ba2f00d.jpg?1783903775,Sorcery,Fajareka Setiawan
+Dan Lewis,2,2023,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/24b5c60e-f2f5-40d7-8713-edc3ecedb5e0.jpg?1783914656,Legendary Creature — Human,Randy Gallegos
+Daredevil- Fearless Fighter,3,2026,3.49,#ff1a1a,https://cards.scryfall.io/normal/front/a/5/a5cf63bd-66db-48b4-87b9-0d0e923e1e42.jpg?1783903051,Legendary Creature — Human Hero,David Seeley
+Daretti- Rocketeer Engineer,5,2025,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg?1783907885,Legendary Creature — Goblin Artificer,Borja Pindado
+Daretti- Scrap Savant,4,2023,0.98,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7cb9d4a0-66bd-454d-b676-80192a96c723.jpg?1783915656,Legendary Planeswalker — Daretti,Dan Murayama Scott
+Dark Apostle,4,2022,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6e346481-c01c-4a93-876e-1130c5edd970.jpg?1783920891,Creature — Astartes Warlock,Games Workshop
+Dark-Dweller Oracle,2,2021,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/4055e8a0-eb0d-4754-b07a-399cb914917c.jpg?1783926208,Creature — Goblin Shaman,Deruchenko Alexander
+Day of the Moon,3,2023,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/a/d/adc53534-f362-4871-a594-9855a4923cd0.jpg?1783914658,Enchantment — Saga,Skinnyelbows
+Deadapult,3,2001,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bdc93b3d-bde4-422f-9edc-e337719be7b4.jpg?1783945617,Enchantment,Mark Brill
+Dead Before Sunrise,4,2024,0.53,#ff1a1a,https://cards.scryfall.io/normal/front/f/2/f2206ff3-f02b-4598-b14b-9db0428f5aeb.jpg?1783911966,Instant,Alix Branwyn
+Deadshot,4,1997,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/5/5/55d212c5-1642-456f-829f-57f68a2116b6.jpg?1783946632,Sorcery,Heather Hudson
+Deathbellow War Cry,8,2020,0.99,#ff1a1a,https://cards.scryfall.io/normal/front/c/f/cf0f58ac-88ef-445c-a12b-0bb1cf482298.jpg?1783931490,Sorcery,Josh Hass
+Death-Greeter's Champion,3,2023,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7cb2b582-1c45-4bb2-8aef-59a71a5a9e94.jpg?1783917284,Creature — Human Warrior,Jason Rainville
+Death Kiss,6,2022,4.25,#ff1a1a,https://cards.scryfall.io/normal/front/5/3/537b9888-70c5-4bee-8f26-d1457fdf1167.jpg?1783922503,Creature — Beholder,Daren Bader
+Decadent Dragon // Expensive Taste,4,2023,1.55,#d78f42,https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1783915066,Creature — Dragon // Instant — Adventure,Wylie Beckert
+Decree of Annihilation,10,2003,2.24,#ff1a1a,https://cards.scryfall.io/normal/front/7/3/73744717-518c-478e-9da9-201c49124f37.jpg?1783944875,Sorcery,John Avon
+Deep-Slumber Titan,4,2008,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg?1783942749,Creature — Giant Warrior,Steve Prescott
+Defiler of Instinct,4,2022,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0e76e0cc-caff-4b15-b550-39e2324c8c95.jpg?1783921320,Creature — Phyrexian Kavu,Steven Belledin
+Deflecting Swat,3,2023,66.66,#ff1a1a,https://cards.scryfall.io/normal/front/b/4/b4b36435-55b3-4615-8812-af41d4fc64d9.jpg?1783915656,Instant,Izzy
+Delayed Blast Fireball,3,2022,15.32,#ff1a1a,https://cards.scryfall.io/normal/front/e/5/e59903e3-a344-4218-9d41-8b19a9bc8311.jpg?1783922501,Instant,Andreas Zafiratos
+Delete,2,2023,1.47,#ff1a1a,https://cards.scryfall.io/normal/front/8/7/875c7337-78af-4e13-89e5-3255ba2d4053.jpg?1783914653,Sorcery,Steve Argyle
+Delina- Wild Mage,4,2021,6.5,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e87459aa-af8f-4bd2-a310-151353083a2e.jpg?1783926480,Legendary Creature — Elf Shaman,Wisnu Tan
+Demanding Dragon,5,2021,0.58,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4d8a5bab-813a-488a-ab65-3286582ef595.jpg?1783926210,Creature — Dragon,Chris Rahn
+Demonfire,1,2014,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4de10b65-2079-46a4-9966-fdb30359810a.jpg?1783938735,Sorcery,Greg Staples
+Depthshaker Titan,7,2025,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/972f3582-ad7c-4fe9-af29-90fa695a623f.jpg?1783906065,Artifact Creature — Robot,PINDURSKI
+Descendants' Fury,4,2026,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/5/5/55af97c0-3377-4a77-8a8a-5bc894d7d678.jpg?1783904551,Enchantment,Aldo Domínguez
+Descent into Avernus,3,2022,12.99,#ff1a1a,https://cards.scryfall.io/normal/front/f/a/faadf72f-b2d5-4271-8d5c-a586acf63453.jpg?1783922742,Enchantment,Bruce Brenneise
+Descent of the Dragons,6,2015,3.44,#ff1a1a,https://cards.scryfall.io/normal/front/5/a/5ab919f3-5797-406b-ae1f-7a7c27739b2d.jpg?1783938591,Sorcery,Steve Prescott
+Desolation Giant,4,2018,0.22,#d78f42,https://cards.scryfall.io/normal/front/b/7/b74a47b5-100d-424f-8432-7668c50458f8.jpg?1783934746,Creature — Giant,Alan Pollack
+Desolation of Smaug,4,2026,24.95,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/2462358b-52c8-49b2-8d97-d65a9188f8f7.jpg?1784376974,Sorcery,Irvin Rodriguez
+Desperate Ritual,2,2025,20.66,#ff1a1a,https://cards.scryfall.io/normal/front/e/7/e7a32387-5faf-4f93-8cb2-d54bd7f1001b.jpg?1783906666,Instant — Arcane,Frank Frazetta
+Destructive Force,7,2010,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1abde258-08e0-4762-8142-38e08a960f9d.jpg?1783941809,Sorcery,Jung Park
+Detective's Phoenix,3,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e2a01edd-dbc0-4ed4-b827-9b608290e9a1.jpg?1783911273,Enchantment Creature — Phoenix,Deruchenko Alexander
+Determined Iteration,2,2026,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d95490fe-44f2-4f83-b587-b0df402d38ed.jpg?1783903820,Enchantment,Chris Rallis
+Detritivore,4,2007,2.69,#ff1a1a,https://cards.scryfall.io/normal/front/2/e/2ec01f4b-b3df-4e2b-ae93-2f2d0cc279bd.jpg?1783943150,Creature — Lhurgoyf,Paolo Parente
+Devastating Dreams,2,2002,3.29,#ff1a1a,https://cards.scryfall.io/normal/front/9/f/9fffeed0-a5ea-47ac-a7a4-0cc3bb1d408a.jpg?1783945149,Sorcery,Tony Szczudlo
+Devastating Onslaught,1,2025,1.8,#ff1a1a,https://cards.scryfall.io/normal/front/f/c/fc779971-24e2-46a8-86be-16f0b244a3d2.jpg?1783905955,Sorcery,Chris Seaman
+Devastating Summons,1,2010,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/1/5/15b09784-8e89-4013-975d-57e4d26cc926.jpg?1783941977,Sorcery,Jung Park
+Devilish Valet,3,2022,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/4/5/45d3fc69-6c5e-4ede-9f8d-c1cee096a78a.jpg?1783923120,Creature — Devil Warrior,Bud Cook
+Devil K. Nevil,3,2022,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/89e71131-9591-4773-9c6a-1dc381d0e1ab.jpg?1783920570,Legendary Creature — Devil Performer,Paolo Parente
+Devil's Play,1,2019,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/d/4/d46473a7-69f5-492b-845d-c8862a1fec85.jpg?1783932758,Sorcery,Austin Hsu
+Devils' Playground,6,2016,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/1/2/1207e6eb-15a7-4ec4-91b3-880375704bb6.jpg?1783937756,Sorcery,Wayne England
+Diaochan- Artful Beauty,4,1999,166.9,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/6180c476-dadf-4c03-ab1e-639386bd4319.jpg?1783946108,Legendary Creature — Human Advisor,Miao Aili
+Dictate of the Twin Gods,5,2014,2.18,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69cc93f2-8198-45b1-9193-7cfd1cf7ced4.jpg?1783939427,Enchantment,Jaime Jones
+Dire Flail // Dire Blunderbuss,1,2023,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact — Equipment // Artifact — Equipment,Anthony Devine
+Dire Fleet Daredevil,2,2024,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9de2ad47-c6d5-4cd8-ae32-66ae167e25a0.jpg?1783911921,Creature — Human Pirate,Zoltan Boros
+Disaster Radius,7,2018,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/ba63c385-7eb8-4ddb-ae27-2b5921cd0525.jpg?1783934748,Sorcery,James Paick
+Disharmony,3,1994,50.86,#ff1a1a,https://cards.scryfall.io/normal/front/e/0/e09a6b9b-eb0e-475d-8558-08e347412790.jpg?1783948057,Instant,Bryon Wackwitz
+Dismissive Pyromancer,2,2018,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg?1783934555,Creature — Human Wizard,Bram Sels
+Display of Power,3,2023,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/2/9/295b8595-5b4e-4fc8-8249-486d36e15f67.jpg?1783916288,Instant,Shahab Alizadeh
+Disrupt Decorum,4,2024,4.29,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c5323fe7-d9df-4287-ae13-d9db35f7973b.jpg?1783912998,Sorcery,Sidharth Chaturvedi
+Divergent Transformations,7,2023,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a1cd7456-71dd-463f-98a2-2d6a9cfb7395.jpg?1783915655,Instant,Kev Walker
+Dockside Extortionist,2,2022,10.96,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9e2e3efb-75cb-430f-b9f4-cb58f3aeb91b.jpg?1783921889,Creature — Goblin Pirate,Lie Setiawan
+Dominating Vampire,3,2021,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b11d234-c6e4-45b2-a3c2-dcacc77cc084.jpg?1783924838,Creature — Vampire,PINDURSKI
+Donna Noble,4,2023,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b6ffec6a-fbba-46cc-becb-4ee5ef8c4971.jpg?1783914654,Legendary Creature — Human,Andrey Kuzinskiy
+Don't Try This at Home,2,2022,0.11,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/ab5c5c1e-1d48-481d-b3b3-97e9cc8416f3.jpg?1783920569,Enchantment,Tyler Walpole
+Double Trouble,5,2025,2.08,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f9a73605-3a17-4887-8395-5bb8d10714bd.jpg?1783905371,Instant,Nathaniel Himawan
+Double Vision,5,2022,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b597992-8e11-41a0-ac87-33fffd82b993.jpg?1783923260,Enchantment,Heonhwa
+Dracogenesis,8,2025,12.38,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0d5674f9-22b2-45f9-902d-4fd245485c60.jpg?1783907362,Enchantment,Kai Carpenter
+Draconautics Engineer,2,2025,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/c/4/c44440be-e611-4e70-9919-b08e2354b7ad.jpg?1783907884,Creature — Goblin Artificer,Artur Nakhodkin
+Draconic Destiny,3,2022,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/f/7/f71240ad-1daf-419a-aaeb-5f9d5079c3dd.jpg?1783920074,Enchantment — Aura,Justin Hernandez & Alexis Hernandez
+Draconic Intervention,4,2021,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/6/5/657de246-b9fc-47b1-b932-091e9500bb82.jpg?1783927356,Sorcery,Johan Grenier
+Dragonhawk- Fate's Tempest,5,2024,4.44,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/8659789c-6a2c-439f-a348-b9b1b06c55b8.jpg?1783910824,Legendary Creature — Bird Dragon,Victor Adame Minguez
+Dragonkin Berserker,2,2021,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/e/7/e7f22fe4-2390-4c3d-8b5e-0cf398d97f6a.jpg?1783928231,Creature — Human Berserker,Lie Setiawan
+Dragon Mage,7,2016,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/416cfb3f-237b-4516-824e-230e0db64a5d.jpg?1783937065,Creature — Dragon Wizard,Matthew D. Wilson
+Dragonmaster Outcast,1,2025,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/a/4/a485edea-07cd-48dd-97e7-daeba85553d6.jpg?1783907071,Creature — Human Shaman,Raymond Swanland
+Dragon Roost,6,2007,0.83,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1da84a3e-a8b2-4cb4-b9c9-1b5c2dca8c67.jpg?1783943022,Enchantment,Jim Pavelec
+Dragonspeaker Shaman,3,2025,1.68,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/be918553-aed5-455d-8b36-23a73dc3f907.jpg?1783906779,Creature — Human Barbarian Shaman,Yigit Koroglu
+Dragon's Rage Channeler,1,2025,39.25,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/2429510d-ce59-472d-b0df-5e6b7cdf63af.jpg?1783906751,Creature — Human Shaman,Molly Mendoza
+Dragonstorm,9,2013,3.82,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/230cd568-f7ed-4571-a609-36522add91d0.jpg?1783939984,Sorcery,Kev Walker
+Dragon-Style Twins,5,2014,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/646edf58-4bc5-4d87-af68-b8b006ccb806.jpg?1783939073,Creature — Human Monk,Wesley Burt
+Dragon Tempest,2,2017,3.23,#ff1a1a,https://cards.scryfall.io/normal/front/a/c/ac9a03b8-7ba2-476b-864f-c248df900379.jpg?1783935898,Enchantment,Willian Murai
+Dragon Tyrant,10,2003,1.44,#ff1a1a,https://cards.scryfall.io/normal/front/0/4/04d1a29b-af80-4f9a-881b-ef7374ecbce1.jpg?1783944875,Creature — Dragon,Kev Walker
+Dragon Whisperer,2,2015,0.85,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5c75b106-349f-44e1-a737-079955cc91b2.jpg?1783938590,Creature — Human Shaman,Chris Rallis
+Dragonwing Glider,5,2023,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/5/4/5456b036-231e-4a64-b060-0709f5254664.jpg?1783918031,Artifact — Equipment,Andreas Zafiratos
+Drakuseth- Maw of Flames,7,2026,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9e9b40f5-3dd0-4607-a78d-b004d57fa4ea.jpg?1783903947,Legendary Creature — Dragon,Grzegorz Rutkowski
+Dreadhorde Arcanist,2,2019,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fd97b3cf-924e-4f77-bb82-0bf19592389f.jpg?1783933429,Creature — Zombie Wizard,G-host Lee
+Dream Pillager,7,2022,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/68c8d00f-23f3-429a-a99a-a6f3ec21c137.jpg?1783922426,Creature — Dragon,Min Yum
+Dropkick Bomber,3,2024,1.95,#ff1a1a,https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg?1783908953,Creature — Goblin Warrior,Quintin Gleim
+Dualcaster Mage,3,2021,4.17,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/defcc4a3-40e0-4f5d-b23c-6cd6a614abc1.jpg?1783927545,Creature — Human Wizard,Matt Stewart
+Dual Casting,2,2012,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7aa45bfd-7075-470d-8aaa-16e34109eb5a.jpg?1783940686,Enchantment — Aura,Johannes Voss
+Duchess- Wayward Tavernkeep,4,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/3/8/38c0a17f-787b-41ac-8375-d9532dce1f4f.jpg?1783912405,Legendary Creature — Human Citizen,Kieran Yanner
+Duelist's Flame,2,2025,5.23,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/230e997e-3736-4afd-8571-1cc1b1d6ed96.jpg?1783904653,Instant,Lius Lasahido
+Dwarven Armorer,1,1994,3.94,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1d50bf06-97ab-4874-a484-9289f41dc98e.jpg?1783947896,Creature — Dwarf,Bryon Wackwitz
+Dwarven Armory,4,1995,0.54,#ff1a1a,https://cards.scryfall.io/normal/front/7/d/7d14a430-6e08-40cf-970a-cae84bba6ef7.jpg?1783947490,Enchantment,Richard Thomas
+Dwarven Bloodboiler,3,2002,5.99,#ff1a1a,https://cards.scryfall.io/normal/front/9/a/9ac576b2-cda4-4aea-aa5c-933ec0457dda.jpg?1783945118,Creature — Dwarf,Arnie Swekel
+Dwarven Pony,1,1995,1.49,#ff1a1a,https://cards.scryfall.io/normal/front/5/3/53a3019f-0b27-4ba3-be4c-73ed50eb9514.jpg?1783947285,Creature — Horse,Margaret Organ-Kean
+Dwarven Sea Clan,3,1995,0.67,#ff1a1a,https://cards.scryfall.io/normal/front/4/c/4cb722d9-1998-4912-a6f2-4ffa8d21311a.jpg?1783947284,Creature — Dwarf,Amy Weber
+Dwarven Shrine,3,2001,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85197997-5e1a-46ce-8f0d-6da5ce297baf.jpg?1783945232,Enchantment,Matt Cavotta
+Dwarven Thaumaturgist,3,1997,1.04,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e68aa29-9f38-48a2-b00a-39aef9d91f6d.jpg?1783946727,Creature — Dwarf Shaman,Kipling West
+Earthquake,1,2018,0.6,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7cf2f3c7-66b2-48f6-97ef-09150903df7e.jpg?1783934745,Sorcery,Adrian Smith
+Earthshaker Khenra,2,2017,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0d60eabe-b281-4eba-9c26-287364ed2067.jpg?1783936030,Creature — Jackal Warrior,Jason A. Engle
+Echoing Assault,5,2024,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/3/2/3213bfee-c0a0-49a2-9080-cdaa09b414c5.jpg?1783910732,Enchantment,Bram Sels
+Ecstatic Beauty,3,2023,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/86ae18ff-e9df-4712-a0d0-a02621740b5a.jpg?1783914651,Sorcery,Alice Xia Zhang
+Efreet Flamepainter,4,2021,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d9f0731c-2a3d-4613-bffa-8b967e4f142e.jpg?1783927358,Creature — Efreet Shaman,Marta Nael
+Eidolon of the Great Revel,2,2018,2.39,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/183ef738-0559-49ca-85b4-e6836521f203.jpg?1783935151,Enchantment Creature — Spirit,Cyril Van Der Haegen
+Electric Seaweed,4,2026,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1ead9586-2b40-498e-90d3-c8a3aa81ef92.jpg?1783904167,Creature — Plant Wall,Randy Gallegos
+Electro- Assaulting Battery,3,2025,6.08,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d672cfad-e656-47f8-bf93-64f262aff33e.jpg?1783905338,Legendary Creature — Human Villain,Piotr Dura
+Electrodominance,2,2025,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85e29bdc-938e-4132-813e-70c5e922efaf.jpg?1783907070,Instant,Dmitry Burmak
+Electroduplicate,3,2024,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg?1783909104,Sorcery,Warren Mahy
+Electropotence,3,2009,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/9/8/9830b9e9-950c-4763-9396-8194d08bf8df.jpg?1783942145,Enchantment,Christopher Moeller
+Electryte,5,1998,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85c3d04f-4010-4db3-9e4e-afa8116b263d.jpg?1783946331,Creature — Trilobite Beast,Thomas M. Baxa
+Elemental Appeal,4,2009,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3a583f30-a3e0-4c4f-81b3-01452edaf22c.jpg?1783942145,Sorcery,Anthony Francisco
+Elemental Eruption,6,2024,3.49,#ff1a1a,https://cards.scryfall.io/normal/front/3/2/32126592-a988-4171-b52e-cca80b881aff.jpg?1783911964,Sorcery,Andrea Piparo
+Elemental Mastery,4,2022,0.54,#ff1a1a,https://cards.scryfall.io/normal/front/7/7/77dd1c84-0c67-41a2-aa19-ca448520ac54.jpg?1783923957,Enchantment — Aura,Cyril Van Der Haegen
+Elkin Lair,4,1997,1.28,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bcb625ba-3718-4988-962c-bf2e11eb4c16.jpg?1783946989,World Enchantment,Jerry Tiritilli
+Ellie- Brick Master,2,2025,7.19,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e973462f-589d-4c53-81d7-075ec1d5a9b4.jpg?1783905138,Legendary Creature — Human Survivor,Irvin Rodriguez
+Elturel Survivors,4,2022,0.76,#ff1a1a,https://cards.scryfall.io/normal/front/e/3/e376b59a-5702-4706-b713-01cab4e253cc.jpg?1783922740,Creature — Tiefling Peasant,Zoltan Boros
+Embercleave,6,2019,9.5,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aaae15dd-11b6-4421-99e9-365c7fe4a5d6.jpg?1783932625,Legendary Artifact — Equipment,Joe Slucher
+Embereth Skyblazer,4,2019,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/1/6/166ee7fc-a0f7-49af-85bf-d5b36bb2bff4.jpg?1783932551,Creature — Human Knight,Daarken
+Emberheart Challenger,2,2024,0.9,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/0035082e-bb86-4f95-be48-ffc87fe5286d.jpg?1783910821,Creature — Mouse Warrior,Chris Rahn
+Embermaw Hellion,5,2015,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/6/6/664f60a8-e80a-4fe0-b76c-2d76c728329e.jpg?1783938332,Creature — Hellion,James Paick
+Ember Swallower,4,2013,0.11,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e2715851-9def-42a0-bed4-0923e599e19a.jpg?1783939763,Creature — Elemental,Slawomir Maniak
+Emberwilde Captain,4,2020,1.57,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/362850cd-d33c-4f61-9b3a-5de748adee7c.jpg?1783928816,Creature — Djinn Pirate,Tyler Walpole
+Emberwilde Djinn,4,1996,0.7,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c9e8c9f5-61dd-4dcc-bd40-8f366374ea18.jpg?1783947081,Creature — Djinn,Mike Dringenberg
+Embrace the Unknown,3,2024,1.84,#ff1a1a,https://cards.scryfall.io/normal/front/5/a/5aea4066-4f67-4a3d-b65d-04f74e1aaa76.jpg?1783911965,Sorcery,Quintin Gleim
+Emeritus of Conflict // Lightning Bolt,2,2026,1.25,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f58dba4f-1abb-47a3-a684-29c32bab95c0.jpg?1783903670,Creature — Human Wizard // Instant,Alix Branwyn
+Emissary of Grudges,6,2018,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/b/8/b8d3d78d-a18b-4ed2-a076-9893fbba94bc.jpg?1783934337,Creature — Efreet,Stanton Feng
+Enchanter's Bane,2,2024,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/3/f/3f053af0-9a08-44e5-be57-6d0fabfde31a.jpg?1783909612,Enchantment,Steve Prescott
+End-Blaze Epiphany,1,2026,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/0/f/0f0a90ae-b3b3-4f52-8997-eac514b29e57.jpg?1783904455,Instant,Tyler Walpole
+End the Festivities,1,2026,2.07,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7b82c1d9-9677-4940-9282-8ee345d37a4e.jpg?1783904242,Sorcery,Cabrol
+Enduring Courage,4,2024,2.85,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f46ac55f-d68e-4d5d-af0a-3879f97f705e.jpg?1783909470,Enchantment Creature — Dog Glimmer,Yigit Koroglu
+Ensnared by the Mara,4,2023,7.26,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/11454c82-3f1d-4456-8857-0dcb01d34298.jpg?1783914651,Sorcery,Andrey Kuzinskiy
+Éomer- Marshal of Rohan,4,2023,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0bd31ce9-9551-4efe-8bd2-b97d8efbf75e.jpg?1783916292,Legendary Creature — Human Knight,Jesper Ejsing
+Epicenter,5,2001,4.75,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1a9232ae-9f32-4bbc-a020-554b3f9cbbd3.jpg?1783945230,Sorcery,Anthony S. Waters
+Erratic Cyclops,4,2021,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/4/8/48dae537-ff11-438f-8367-46121a88f60f.jpg?1783927546,Creature — Cyclops Shaman,Milivoj Ćeran
+Etali- Primal Conqueror // Etali- Primal Sickness,7,2023,33.59,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elder Dinosaur // Legendary Creature — Phyrexian Elder Dinosaur,Ryan Pancoast
+Etali- Primal Storm,6,2024,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b6af9894-95b5-4c8e-902f-a9ba70f02e4a.jpg?1783909067,Legendary Creature — Elder Dinosaur,Raymond Swanland
+Eternal Flame,4,1994,5.58,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d646feea-3c20-4737-8d20-ffad42258ced.jpg?1783947935,Sorcery,Mark Poole
+Evendo Brushrazer,3,2025,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8b9001a4-953c-4a32-b51a-c6bec7e74f9e.jpg?1783906065,Creature — Insect Warrior,Igor Grechanyi
+Everquill Phoenix,4,2023,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/3/3/333db3bc-98e9-4635-b1b0-a7e57ee59165.jpg?1783917149,Creature — Phoenix,Lie Setiawan
+Excruciator,8,2005,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a3c98460-e8b8-45d6-9bf0-7600b234964b.jpg?1783943655,Creature — Avatar,Paolo Parente
+Exocrine,3,2022,1.97,#ff1a1a,https://cards.scryfall.io/normal/front/5/b/5b8c1303-6829-4c82-96de-a67bc0d72e42.jpg?1783920890,Creature — Tyranid,Cory Trego-Erdner
+Expedited Inheritance,2,2024,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b65209da-cf48-4d37-b045-7d181070fd05.jpg?1783912881,Enchantment,Micah Epstein
+Experimental Frenzy,4,2018,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b8f32e2-5dc8-4f1b-8a69-d3ae06378ed8.jpg?1783934164,Enchantment,Simon Dominic
+Explosive Singularity,10,2022,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e6cdd822-44a1-4d58-9de4-69fc56eae255.jpg?1783923869,Sorcery,Liiga Smilshkalne
+Exquisite Firecraft,3,2015,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/42eca98e-a164-4f70-a0b0-7a604863f30b.jpg?1783938330,Sorcery,Chase Stone
+Fable of the Mirror-Breaker // Reflection of Kiki-Jiki,3,2022,6.31,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Goblin Shaman,Joseph Meehan
+Faithless Looting,1,2024,8.32,#ff1a1a,https://cards.scryfall.io/normal/front/b/0/b069ede2-dec3-43b3-85ce-b9d60a1e96a7.jpg?1783909715,Sorcery,Dave Trampier
+Falkenrath Gorger,1,2025,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/1/6/16c376f5-f69b-49d4-95f4-92bdd68c564c.jpg?1783908121,Creature — Vampire Berserker,Anna Steinbauer
+Falkenrath Marauders,5,2011,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/b/9/b9c09887-6d2b-48b4-a483-16b8a45babd0.jpg?1783940937,Creature — Vampire Warrior,James Ryman
+Falkenrath Pit Fighter,1,2021,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/a/7/a743a3b6-3278-4644-a2d5-acf495c273ed.jpg?1783925603,Creature — Vampire Warrior,Anna Fehr
+Falling Star,3,1994,145.19,#ff1a1a,https://cards.scryfall.io/normal/front/f/2/f2b9983e-20d4-4d12-9e2c-ec6d9a345787.jpg?1783948056,Sorcery,Douglas Shuler
+Fall of Cair Andros,3,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/354b4623-50a0-41f1-ad1e-7dd6ac3852df.jpg?1783916289,Enchantment,Shahab Alizadeh
+Fall of the Titans,1,2016,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/8/c/8c21da73-0dad-4b2b-8cc6-61861bed9410.jpg?1783937906,Instant,Chris Rallis
+Fang- Roku's Companion,5,2025,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/1/2/1280d51a-f4a9-4021-b229-8d9af701318c.jpg?1783904821,Legendary Creature — Dragon,Douzen
+Farid- Enterprising Salvager,3,2022,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/003367c7-6cb8-4451-8349-76ce5d21e367.jpg?1783919718,Legendary Creature — Human Soldier,Bruno Biazotto
+Fast Forward,5,2026,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/f/e/fe07512e-46c1-4f45-a06f-5875acaf8928.jpg?1783904167,Sorcery,Narendra Bintara Adi
+Fatal Frenzy,3,2007,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/4/e/4e2fe87d-e886-4e30-8ff2-3886199f0461.jpg?1783943148,Instant,Steve Ellis
+Fated Conflagration,4,2014,0.12,#ff1a1a,https://cards.scryfall.io/normal/front/6/6/66ea1aeb-bd42-4960-b40f-e7c2fd1efb5c.jpg?1783939545,Instant,Adam Paquette
+Fated Firepower,3,2025,3.92,#ff1a1a,https://cards.scryfall.io/normal/front/5/1/51352127-1f86-42e9-b4ca-2fd58b14e86b.jpg?1783904959,Enchantment,Takayama Toshiaki
+Fateful Showdown,4,2016,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a19d5bdd-7f45-4ff1-bd1a-ac4e87572bcb.jpg?1783937194,Instant,Chris Rallis
+Fateful Tempest,3,2026,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/9/6/96ab4d23-14d7-429f-b62e-868c13997fb8.jpg?1783903858,Sorcery,Jabari Weathers
+Fault Line,2,1998,3.42,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/cab4fd0e-9f84-4628-92a7-858ad8064531.jpg?1783946331,Instant,Ron Spencer
+Fear of Missing Out,2,2024,2.07,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg?1783909470,Enchantment Creature — Nightmare,John Stanko
+Feldon of the Third Path,3,2023,1.73,#ff1a1a,https://cards.scryfall.io/normal/front/0/3/0360f1ff-15c9-48e3-89eb-fbc4bf140c55.jpg?1783917150,Legendary Creature — Human Artificer,Chase Stone
+Feldon- Ronom Excavator,2,2022,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5ca4cb0e-63ad-4275-a27f-da476260b467.jpg?1783920069,Legendary Creature — Human Artificer,Howard Lyon
+Felhide Spiritbinder,4,2014,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bbbbe4ce-d6a6-428d-aeee-1c316f358777.jpg?1783939545,Creature — Minotaur Shaman,Mathias Kollros
+Fervent Champion,1,2019,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c52d66db-5570-48a1-99cf-e0417517747b.jpg?1783932624,Creature — Human Knight,Steve Argyle
+Fervent Mastery,5,2021,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/1/f/1f824caf-b32c-442a-8631-887831a57360.jpg?1783927355,Sorcery,Sean Sevestre
+Fervor,3,2012,6.78,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a88515c2-4b4f-4d16-9f50-149ef012e961.jpg?1783940484,Enchantment,Wayne England
+Festival of Embers,5,2024,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/4433ee12-2013-4fdc-979f-ae065f63a527.jpg?1783910820,Enchantment,Greg Staples
+Fickle Efreet,4,2000,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca6d047a-f3dc-4c34-9679-fb76037e4044.jpg?1783945778,Creature — Efreet,Dave Dorman
+Fiendish Duo,6,2024,2.87,#ff1a1a,https://cards.scryfall.io/normal/front/e/b/ebb44595-56f6-4be5-80bb-618ddd320f4a.jpg?1783912997,Creature — Devil,Lucas Graciano
+Fiendlash,2,2021,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9cbc0e7e-b478-431e-abaf-ce7113057730.jpg?1783926246,Artifact — Equipment,Antonio José Manzanedo
+Fiery Bombardment,2,2008,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/c/3/c348d137-4774-41d7-8b4d-d383c816ae2a.jpg?1783942683,Enchantment,Nils Hamm
+Fiery Confluence,4,2025,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85d431c2-e4fa-426d-83cb-ecb782e7e87d.jpg?1783904804,Sorcery,Salvatorre Zee Yazzie
+Fiery Emancipation,6,2020,14.56,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0b12e4b7-2c45-4795-94d3-901f89b8f290.jpg?1783930692,Enchantment,Alexander Forssberg
+Fiery Encore,5,2021,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/ae544d03-2d12-4994-b573-424c41ecc91d.jpg?1783927594,Sorcery,Justyna Dura
+Fiery Gambit,3,2003,3.03,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a91376ed-5868-4887-8389-5ef5b9471786.jpg?1783944541,Sorcery,Scott M. Fischer
+Fighting Chance,1,1998,2.43,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca75f6e9-5eee-4904-88c0-71ec730a0f23.jpg?1783946512,Instant,Mike Raabe
+Filigree Racer,4,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/a/0/a00c289a-646c-4b4c-b028-fa7783adc8f3.jpg?1783911422,Artifact — Vehicle,Gaboleps
+Finale of Promise,2,2024,1.34,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0dbbb636-96c2-472c-a51d-d527e8e97798.jpg?1783911921,Sorcery,Jaime Jones
+Final Fortune,2,2001,17.8,#ff1a1a,https://cards.scryfall.io/normal/front/f/b/fb80afc3-4887-42a0-afb2-7fa997981fb2.jpg?1783945470,Instant,Greg Hildebrandt & Tim Hildebrandt
+Fin Fang Foom,4,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/7/7/7777fac1-7bf5-4454-960d-26ec3183e392.jpg?1783902932,Legendary Creature — Alien Dragon Villain,Filipe Pagliuso
+Firbolg Flutist,6,2022,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/7/3/73255900-11ac-4a82-bd30-2dc24addd8e6.jpg?1783922740,Creature — Giant Bard,Joseph Weston
+Fireball,1,2005,8.04,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7c11fcd9-abad-47c8-ae47-55750bc1c9de.jpg?1783944220,Sorcery,Mark Tedin
+Firebender Ascension,2,2025,0.72,#ff1a1a,https://cards.scryfall.io/normal/front/2/9/2929b702-03c6-4cf0-a3f7-61b27f4803be.jpg?1783904958,Enchantment,Tetsuko
+Firebending Student,2,2025,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/3/b/3b366f59-16fe-43cb-888d-1f93ef8fd332.jpg?1783904958,Creature — Human Monk,Kozato
+Firebird- Blazing Ranger,3,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/11dc3b30-b130-4558-ab37-9c32792641ea.jpg?1783903285,Legendary Creature — Human Ranger Hero,Alessandra Pisano
+Firedrinker Satyr,1,2013,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/683eaf5a-2f43-477f-b212-70ca5fe04f13.jpg?1783939763,Creature — Satyr Shaman,Anthony Palumbo
+Fireflux Squad,4,2020,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4bcff20b-06f7-4228-a99c-6ff46e73e353.jpg?1783931214,Creature — Human Soldier,Kieran Yanner
+Fire Nation Archers,4,2025,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e83ee667-7726-42e9-9483-6cfc6f9ce638.jpg?1783904779,Creature — Human Archer,Shiyu
+Fire Nation Turret,3,2025,7.72,#ff1a1a,https://cards.scryfall.io/normal/front/f/2/f25cc190-05e2-4aba-b214-46f687c07a10.jpg?1783904840,Artifact,Fahmi Fauzi
+Fires of Invention,4,2019,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a12b16b0-f75f-42d8-9b24-947c1908e0f7.jpg?1783932623,Enchantment,Stanton Feng
+Fires of Mount Doom,3,2023,1.96,#ff1a1a,https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg?1783916217,Legendary Enchantment,Shahab Alizadeh
+Firestorm,1,1997,53.58,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e674aa8a-668a-4345-95ee-73a0b87bbcb1.jpg?1783946726,Instant,Jeff Miracola
+Firewing Phoenix,4,2012,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/b/8/b8824674-ced2-448e-9bf0-03c1c43a5315.jpg?1783940484,Creature — Phoenix,James Paick
+Firion- Wild Rose Warrior,3,2025,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/9/8/98366937-d15b-4a66-b9f6-878d50b63871.jpg?1783906604,Legendary Creature — Human Rebel Warrior,Elizabeth Peiró
+Five-Alarm Fire,3,2013,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/f/b/fb550d0c-2261-4f41-a2b1-d185f0bce86a.jpg?1783940125,Enchantment,Karl Kopinski
+Flailing Manticore,4,1999,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6eee8c2e-bda7-4bf9-80fe-87d96024ca8b.jpg?1783945939,Creature — Manticore,Roger Raupp
+Flameblade Angel,6,2016,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/1/0/1031ec22-c99f-4843-a7cf-c8332234eca8.jpg?1783937753,Creature — Angel,Cynthia Sheppard
+Flameblast Dragon,6,2018,0.56,#ff1a1a,https://cards.scryfall.io/normal/front/c/6/c66293df-a50e-4c64-9482-a2af68288d76.jpg?1783934297,Creature — Dragon,Jaime Jones
+Flamebreak,3,2004,1.15,#ff1a1a,https://cards.scryfall.io/normal/front/8/7/87e1f06f-7c87-4da8-b339-e571e391cab1.jpg?1783944439,Sorcery,Trevor Hairsine
+Flame Fusillade,4,2005,3.26,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7fcad5f0-53c4-4b72-ac05-ef9ca5b55611.jpg?1783943654,Sorcery,Dany Orizio
+Flame Javelin,6,2009,0.72,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/407858c8-316d-47a7-8234-c490a0bc87a6.jpg?1783942499,Instant,Zoltan Boros & Gabor Szikszai
+Flamekin Harbinger,1,2023,18.11,#ff1a1a,https://cards.scryfall.io/normal/front/0/4/0420119f-a25b-44c7-b82f-51d05dfd94c5.jpg?1783915186,Creature — Elemental Shaman,Yu Maeda
+Flamekin Herald,3,2020,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/2/d2616030-01f2-43b1-98ba-f7e5a5a75379.jpg?1783928814,Creature — Elemental Wizard,Johan Grenier
+Flame On!,5,2026,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/7030f86d-d7e7-444d-9ed0-1758260926ed.jpg?1783903284,Sorcery,Rafater
+Flamerush Rider,5,2023,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0de4181f-652e-4eab-8de0-57a346c51994.jpg?1783917148,Creature — Human Warrior,Min Yum
+Flamescroll Celebrant // Revel in Silence,2,2021,0.21,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Shaman // Instant,Uriah Voth
+Flameshadow Conjuring,4,2023,3.62,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/ae113258-288f-47d5-8f79-e2e51b6326de.jpg?1783917147,Enchantment,Seb McKinnon
+Flameskull,3,2021,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/3/2/32d3f766-4098-4023-9a23-e9ff6722b66d.jpg?1783926479,Creature — Skeleton,Xavier Ribeiro
+Flame Slash,1,2022,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bcfe4a26-3ea8-404e-92bd-b453eee6c862.jpg?1783921650,Sorcery,Antonio José Manzanedo
+Flamewake Phoenix,3,2024,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a94f008e-48a0-406b-83fa-99cd396831f8.jpg?1783909067,Creature — Phoenix,Min Yum
+Flame-Wreathed Phoenix,4,2014,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a36bca58-e92f-4496-92d6-5ecba7a0424d.jpg?1783939545,Creature — Phoenix,James Ryman
+Flaming Tyrannosaurus,7,2023,8.7,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0bc8ecfd-7388-4725-8c58-bed2cc61400f.jpg?1783914651,Creature — Dinosaur,Axel Sauerwald
+Flare of Duplication,3,2024,1.63,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/497a10c6-131b-464e-95e4-e47708a24d48.jpg?1783911272,Instant,Olivier Bernard
+Flashback,1,2026,3.53,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b832fda-d7c4-4566-884c-2a8b6da15488.jpg?1783903669,Instant,Flavio Greco Paglia
+Flayer of the Hatebound,6,2019,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/6/2/620e8ec3-aeea-498b-a54a-acd922c4bb60.jpg?1783932755,Creature — Devil,Jana Schirmer & Johannes Voss
+Fledgling Dragon,4,2002,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/3/1/315e5b4e-ae58-412a-be27-c4ef4899fbbd.jpg?1783945118,Creature — Dragon,Greg Staples
+Fling,2,2024,2.09,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/6873b4a8-90cb-4096-922a-4fa23cdec3c8.jpg?1783909707,Instant,Jon Vermilyea
+Flowstone Mauler,6,1998,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a3165251-6ac6-4294-8bca-595c362f4ceb.jpg?1783946556,Creature — Beast,Paolo Parente
+Flowstone Overseer,5,2000,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/3/e/3e644ab8-3cc3-413d-a918-44fc636087ae.jpg?1783945821,Creature — Beast,Andrew Goldhawk
+Flowstone Slide,4,2007,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/074121e8-aecc-469f-b181-8e6a9e918826.jpg?1783943020,Sorcery,Chippy
+Flowstone Wyvern,5,1997,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee7949c7-ab80-46a1-9cf7-d8e8c004df6e.jpg?1783946630,Creature — Drake,Stephen Daniele
+Food Fight,2,2023,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg?1783915094,Enchantment,Filipe Pagliuso
+Force of Rage,3,2019,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/0/a/0aaa2d10-3725-4b3a-94fe-3c6648db9a2a.jpg?1783933113,Instant,Clint Cearley
+Forgestoker Dragon,6,2014,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fd44170-ded7-4895-8950-bfa9d19e471d.jpg?1783939545,Creature — Dragon,Todd Lockwood
+Forked Lightning,4,1997,1.44,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85883197-fd55-4e82-862f-87be4f789493.jpg?1783946817,Sorcery,Ted Naifeh
+Form of the Dinosaur,6,2018,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/41e4fe86-281d-4174-bb72-ac5bb9560b7e.jpg?1783935299,Enchantment,Daarken
+Form of the Dragon,7,2005,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1cfc77f1-290a-4394-bc16-76f3659810f0.jpg?1783943969,Enchantment,Carl Critchlow
+Fortune Thief,5,2018,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/b/9/b9700b3c-c309-4305-8761-3cf3ec902639.jpg?1783935149,Creature — Human Rogue,Christopher Moeller
+Freejam Regent,6,2017,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d6b5147f-b422-47d3-98a0-dcc2d6f4e17a.jpg?1783936754,Creature — Cat Dragon,Volkan Baǵa
+From the Ashes,4,2013,3.47,#ff1a1a,https://cards.scryfall.io/normal/front/4/5/4529a3d2-e4e6-4cca-bcea-16b51f69bbec.jpg?1783939669,Sorcery,Karl Kopinski
+Frontier Warmonger,4,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/824aa845-0523-4434-8992-bce42f5b2bcb.jpg?1783912998,Creature — Human Warrior,Livia Prima
+Frontline Heroism,3,2026,0.96,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7fb34149-5e09-47cb-bd1f-f2f9ee14dce3.jpg?1783903443,Enchantment,Fajareka Setiawan
+Fugitive Codebreaker,2,2024,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg?1783912881,Creature — Goblin Rogue,Joseph Weston
+Full Throttle,6,2025,6.68,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg?1783907882,Sorcery,Benjamin Ee
+Fumiko the Lowblood,4,2020,0.6,#ff1a1a,https://cards.scryfall.io/normal/front/d/3/d3ee3011-3d17-435d-a483-79b0419b589b.jpg?1783931174,Legendary Creature — Human Samurai,Michael Sutfin
+Furnace Dragon,9,2004,0.56,#ff1a1a,https://cards.scryfall.io/normal/front/6/2/62f5c675-b629-45ec-907c-36594f5fe54a.jpg?1783944438,Creature — Dragon,Matthew D. Wilson
+Furnace of Rath,4,2009,6.81,#ff1a1a,https://cards.scryfall.io/normal/front/d/7/d7f0e720-3c32-4040-b663-7f99ad5bc810.jpg?1783942323,Enchantment,John Matson
+Fury,5,2026,0.64,#ff1a1a,https://cards.scryfall.io/normal/front/9/3/932d0fb9-382d-464a-9427-b91fa2398cdb.jpg?1783911524,Creature — Elemental Incarnation,Victor Adame Minguez
+Furyborn Hellkite,7,2011,0.94,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5b735e5-da9d-4740-acff-aac9dd24334c.jpg?1783941071,Creature — Dragon,Brad Rigney
+Furygale Flocking,10,2026,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a967af7a-03ed-4858-9c26-66f2cb706b02.jpg?1783903857,Sorcery,Loïc Canavaggia
+Fury of the Horde,7,2014,6.23,#ff1a1a,https://cards.scryfall.io/normal/front/5/2/52dd1712-6937-4630-b44c-952699307da4.jpg?1783939119,Sorcery,Stephen Tappin
+Furystoke Giant,5,2008,5.54,#ff1a1a,https://cards.scryfall.io/normal/front/5/b/5b102dc6-d7ef-48dd-8b77-2ce43955f7fa.jpg?1783942748,Creature — Giant Warrior,Ralph Horsley
+Fury Storm,4,2018,4.46,#ff1a1a,https://cards.scryfall.io/normal/front/1/0/10dad353-7200-46de-96ad-4c457b94c62b.jpg?1783934336,Instant,Mark Poole
+Gadrak- the Crown-Scourge,3,2025,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/249bf4b2-9239-4303-9c5d-81d06f6b7fb1.jpg?1783907069,Legendary Creature — Dragon,Daarken
+Galvanic Blast,1,2025,5.28,#ff1a1a,https://cards.scryfall.io/normal/front/e/b/eb93617a-539f-4448-bb4a-ea281a3fc340.jpg?1783907686,Instant,Laura Plansker
+Galvanoth,5,2012,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/23f2e251-1a90-433e-b63a-1a361f5dc6b3.jpg?1783940419,Creature — Beast,Kev Walker
+Gamble,1,2023,17.4,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e37fae5-ddd0-4e16-8581-71579f89d9c5.jpg?1783918462,Sorcery,Andrew Goldhawk
+Game of Chaos,3,1997,14.0,#ff1a1a,https://cards.scryfall.io/normal/front/9/5/95b44933-6b0b-426a-97d4-7a7cf6ad1d65.jpg?1783946912,Sorcery,Thomas Gianni
+Gastal Thrillroller,3,2025,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg?1783907881,Artifact — Vehicle,Caio Monteiro
+Gau- Feral Youth,2,2025,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/89175ce1-0746-4ba1-970e-617d134b0527.jpg?1783906357,Legendary Creature — Human Berserker,Eglė Mosakaitė
+Geier Reach Bandit // Vildin-Pack Alpha,3,2016,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Rogue Werewolf // Creature — Werewolf,Slawomir Maniak
+Geistflame Reservoir,3,2021,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b247ce7-9c58-404f-bed1-84abb37575ab.jpg?1783925600,Artifact,Anna Christenson
+Gemcutter Buccaneer,4,2023,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/c/e/ce8f708a-2b7b-48b9-88ae-70dd60007b3d.jpg?1783913908,Creature — Orc Pirate Artificer,Helge C. Balzer
+Generous Plunderer,2,2024,11.78,#ff1a1a,https://cards.scryfall.io/normal/front/4/c/4c6cf93a-d073-48ac-88db-c46bf3e10beb.jpg?1783912000,Creature — Human Rogue,Alexander Mokhov
+Geode Rager,6,2022,1.62,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1c5974dd-78fc-4bfb-8678-72041c797584.jpg?1783922423,Creature — Elemental,Caio Monteiro
+Ghired's Belligerence,2,2019,2.15,#ff1a1a,https://cards.scryfall.io/normal/front/b/8/b8348ef6-f2ae-4277-ae04-7849c508f0e4.jpg?1783932805,Sorcery,Izzy
+Ghitu Fire,1,2000,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/78827acd-a526-411b-bd22-ab9b538c75dd.jpg?1783945685,Sorcery,Glen Angus
+Ghost-Spider- Gwen Stacy,5,2025,11.16,#ff1a1a,https://cards.scryfall.io/normal/front/f/a/fa0ccd32-63c8-47a2-8de1-5845dad8e682.jpg?1783905370,Legendary Creature — Spider Human Hero,Xabi Gaztelua
+Gilgamesh- Master-at-Arms,6,2025,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1eb81329-fb7a-4347-b96c-9960a5c48e87.jpg?1783906605,Legendary Creature — Human Samurai,Lorenzo Mastroianni
+Gimli of the Glittering Caves,3,2023,2.3,#ff1a1a,https://cards.scryfall.io/normal/front/5/a/5afc0319-9e17-4e81-a0b6-e76645bacb04.jpg?1783916028,Legendary Creature — Dwarf Warrior,Sidharth Chaturvedi
+Gimli's Reckless Might,4,2023,4.77,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/36f85c90-08e9-42cd-9d5d-55f77d5544aa.jpg?1783914203,Enchantment,Jason Rainville
+Gleeful Arsonist,3,2024,5.85,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bbb2956c-ef76-4e80-81d4-7f1ce6841d37.jpg?1783909657,Creature — Human Wizard,Nereida
+Gleeful Demolition,1,2025,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/9/f/9f30a6a5-e8b3-403a-bfe1-1f78d45e392e.jpg?1783907439,Sorcery,Vincent Proce
+Glimpse of Tomorrow,0,2021,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/7/e/7ee1fcbc-3573-42c5-b3e3-1f44a6400cd0.jpg?1783926844,Sorcery,Jokubas Uogintas
+Glint-Horn Buccaneer,3,2019,8.22,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df2df9cb-14f5-470f-b438-20f4ae8d0d59.jpg?1783932979,Creature — Minotaur Pirate,Zack Stella
+Glóin- Dwarf Emissary,3,2023,1.07,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/868a2aa7-bcaf-409b-8802-d00ee1f2ae77.jpg?1783916283,Legendary Creature — Dwarf Advisor,Tomas Duchek
+Glorious End,3,2017,1.28,#ff1a1a,https://cards.scryfall.io/normal/front/2/9/2922b976-7beb-4c68-b39e-1b66d5c6f65e.jpg?1783936489,Instant,Raymond Swanland
+Glorybringer,5,2025,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/06f90d62-6d21-47b1-a427-eb25a42f4dcb.jpg?1783907070,Creature — Dragon,Sam Burley
+Goblin Assault,3,2008,0.9,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d039402e-2c74-4bea-b360-b93979b52698.jpg?1783942561,Enchantment,Jaime Jones
+Goblin Bomb,2,1997,15.83,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/97e8a436-9fd0-409f-a020-0f9f41602d50.jpg?1783946726,Enchantment,Ron Spencer
+Goblin Bombardment,2,2021,2.34,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e262f55e-9239-4a97-a19e-9b08fb34502e.jpg?1783926784,Enchantment,Dave Kendall
+Goblin Bushwhacker,1,2024,3.84,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/052df800-9f13-4469-9e8c-16d327025aa0.jpg?1783908596,Creature — Goblin Warrior,Dominik Mayer
+Goblin Chainwhirler,3,2018,0.76,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8bdb2883-3cfd-4fb0-9f99-6a57277f7fe4.jpg?1783934992,Creature — Goblin Warrior,Svetlin Velinov
+Goblin Chieftain,3,2020,6.83,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/89fcc35b-76fa-4408-8620-a1e11b2caf1f.jpg?1783930390,Creature — Goblin,Sam Wood
+Goblin Cruciverbalist,3,2022,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/b/9/b90bd23d-0f0f-41d7-ba12-776f012714f7.jpg?1783920565,Creature — Goblin Wizard Guest,Mike Burns
+Goblin Dark-Dwellers,5,2020,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/3/b/3bb7be0d-1937-4b30-909c-df2b31a921e3.jpg?1783931172,Creature — Goblin,Steven Belledin
+Goblin Diplomats,2,2017,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4ad346cb-c3e5-4aea-8de6-bb62827e25a9.jpg?1783935602,Creature — Goblin,Izzy
+Goblin Engineer,2,2019,9.97,#ff1a1a,https://cards.scryfall.io/normal/front/a/5/a55c4d47-5252-40af-961d-c08bc688028a.jpg?1783933112,Creature — Goblin Artificer,Jehan Choo
+Goblin Festival,2,1999,0.9,#ff1a1a,https://cards.scryfall.io/normal/front/a/c/ac067eb8-427f-4bfa-b392-0bb41ac8370e.jpg?1783946069,Enchantment,Jeff Laubenstein
+Goblin Flotilla,3,1994,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/8/7/87024efe-4a74-49fe-a43a-480bed0a650a.jpg?1783947895,Creature — Goblin,Tom Wänerstrand
+Goblin Game,7,2001,1.73,#ff1a1a,https://cards.scryfall.io/normal/front/c/b/cbe6e7e5-ffea-4c6c-8a42-28e695029f24.jpg?1783945618,Sorcery,DiTerlizzi
+Goblin General,3,1998,7.44,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7fdce2e5-60dd-4993-b74c-f49f013b28f0.jpg?1783946466,Creature — Goblin Warrior,Keith Parkinson
+Goblin Goliath,6,2018,2.03,#ff1a1a,https://cards.scryfall.io/normal/front/5/9/5973744a-72c3-48e6-b99a-8f6d634c06bb.jpg?1783933994,Creature — Goblin Mutant,Slawomir Maniak
+Goblin Goon,4,2020,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/5/b/5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7.jpg?1783930389,Creature — Goblin Mutant,Steve Prescott
+Goblin Guide,1,2020,1.26,#ff1a1a,https://cards.scryfall.io/normal/front/3/c/3c0f5411-1940-410f-96ce-6f92513f753a.jpg?1783930165,Creature — Goblin Scout,Filip Burburan
+Goblin Kaboomist,2,2014,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/8/0/80e1d85a-18e5-4c6a-85fd-a009bd8fda38.jpg?1783939173,Creature — Goblin Warrior,Kev Walker
+Goblin King,3,2007,13.61,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b266935-25ea-49c5-a1da-57c22a4362fd.jpg?1783943019,Creature — Goblin,Ron Spears
+Goblin Marshal,6,1999,0.67,#ff1a1a,https://cards.scryfall.io/normal/front/6/a/6a85b2f9-c12c-46dd-ae04-470ebf5ec6d9.jpg?1783946067,Creature — Goblin Warrior,DiTerlizzi
+Goblin Matron,3,2023,41.06,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a8f56067-4b86-4788-8fd7-648c9041dbd4.jpg?1783915190,Creature — Goblin,Wizard of Barge
+Goblin Piledriver,2,2015,3.17,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b332e3d-dcf4-4f62-8130-124ec5d23b90.jpg?1783938329,Creature — Goblin Warrior,Matt Cavotta
+Goblin Pyromancer,4,2002,0.8,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bb4815b7-fc20-44a4-ad1c-66d92993557f.jpg?1783945055,Creature — Goblin Wizard,Edward P. Beard, Jr.
+Goblin Rabblemaster,3,2017,0.68,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bce84a87-093a-42de-9696-8c3250e0f33b.jpg?1783935602,Creature — Goblin Warrior,Svetlin Velinov
+Goblin Razerunners,4,2022,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5c06fb09-1e64-49c7-9938-541c0433bf5a.jpg?1783923958,Creature — Goblin Warrior,Raymond Swanland
+Goblin Recruiter,2,2023,89.3,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6efb3b4c-ac12-406c-8517-9fccefdd1544.jpg?1783915191,Creature — Goblin,Wizard of Barge
+Goblin Ringleader,4,2024,4.06,#ff1a1a,https://cards.scryfall.io/normal/front/f/b/fba83c0d-f72b-442c-ae30-6cf557bd157d.jpg?1783911486,Creature — Goblin,Svetlin Velinov & Scott Okumura
+Goblin Settler,4,2022,2.88,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c8d75604-4941-4faf-8f1a-7fc529e64962.jpg?1783923539,Creature — Goblin,Roman Klonek
+Goblin Sharpshooter,3,2013,27.75,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4f72e9e2-ed47-40ff-bc2e-8446ef545022.jpg?1783939668,Creature — Goblin,Wayne Reynolds
+Goblin Spymaster,3,2022,2.39,#ff1a1a,https://cards.scryfall.io/normal/front/1/6/1687ea64-fcc0-4bd8-aa7e-3c893d4ef2a8.jpg?1783922424,Creature — Goblin Rogue,Wayne Reynolds
+Goblin Trashmaster,4,2018,6.74,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg?1783934551,Creature — Goblin Warrior,Jakub Kasper
+Goblin Warrens,3,1999,1.07,#ff1a1a,https://cards.scryfall.io/normal/front/1/2/1255654b-f983-4862-9112-9e378ea5d9fe.jpg?1783946172,Enchantment,Dan Frazier
+Goblin Welder,1,2018,22.35,#ff1a1a,https://cards.scryfall.io/normal/front/1/7/17cd920a-de09-454a-a9da-c84512e3aff1.jpg?1783934742,Creature — Goblin Artificer,Scott M. Fischer
+Goddric- Cloaked Reveler,3,2023,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg?1783915094,Legendary Creature — Human Noble,Jason A. Engle
+Godo- Bandit Warlord,6,2023,1.07,#ff1a1a,https://cards.scryfall.io/normal/front/0/1/01d566cf-cb32-461d-8afe-b0f3f4c24160.jpg?1783915653,Legendary Creature — Human Barbarian,Paolo Parente
+Gogo- Mysterious Mime,4,2025,1.67,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0db05dc8-03f8-4ab4-9ca3-2aaaa0099eb4.jpg?1783906356,Legendary Creature — Wizard,Lee Woo-chul
+Goldlust Triad,5,2025,5.72,#ff1a1a,https://cards.scryfall.io/normal/front/2/8/2876d57a-a17e-4892-9992-321a32562e13.jpg?1783907174,Creature — Dragon,Arif Wijaya
+Goldnight Castigator,4,2016,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca3d3c9a-d41b-4743-87a6-68d116460fe2.jpg?1783937751,Creature — Angel,Zack Stella
+Goldspan Dragon,5,2026,5.82,#ff1a1a,https://cards.scryfall.io/normal/front/8/4/848c1951-90fa-4f01-9aed-76f1afcd9995.jpg?1783903774,Creature — Dragon,Andrew Mar
+Goldwardens' Gambit,8,2023,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0cb7f413-f9b9-4b1c-898a-c49c571613f0.jpg?1783918159,Sorcery,Manuel Castañón
+Goliath Daydreamer,4,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/88e8cd13-2a29-4df6-937c-1bed68fbeafa.jpg?1783904444,Creature — Giant Wizard,Omar Rayyan
+Gornog- the Red Reaper,3,2024,3.57,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c80a88ae-f2f2-426a-88f3-76b5d598c25f.jpg?1783908855,Legendary Creature — Minotaur Warrior,Ishikawa Kenta
+Goro-Goro- Disciple of Ryusei,2,2022,1.17,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1ca736c7-35a9-48c7-b5a9-69b2a6e33ad0.jpg?1783923865,Legendary Creature — Goblin Samurai,Mike Jordana
+Grand Melee,4,2002,1.4,#ff1a1a,https://cards.scryfall.io/normal/front/9/a/9a0d3142-4224-4b51-885d-33c8938418c1.jpg?1783945053,Enchantment,Trevor Hairsine
+Granulate,4,2004,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/e/1/e13798b8-689e-4f19-af10-b72d3fe19f3c.jpg?1783944395,Sorcery,Brian Snõddy
+Gravity Sphere,3,1994,51.18,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a2749332-e99a-4a0c-b3a3-5578b552fa11.jpg?1783948056,World Enchantment,Brian Snõddy
+Greater Gargadon,10,2022,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/7/6/76bf6bf0-4821-41eb-bacc-32e9a2d47845.jpg?1783921887,Creature — Beast,Rob Alexander
+Great Train Heist,1,2024,4.91,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/357dd9b2-5d2d-49f6-86f0-f5c4d63474dd.jpg?1783911821,Instant,Campbell White
+Grenzo- Havoc Raiser,2,2025,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/aba981f9-ebc6-48ac-b768-557f632b82df.jpg?1783907070,Legendary Creature — Goblin Rogue,Svetlin Velinov
+Grenzo's Rebuttal,6,2014,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b798ace-18e4-45fb-98ae-69528f7b5a2f.jpg?1783939375,Sorcery,Dave Kendall
+Grim Lavamancer,1,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1ab6ffe8-e1ad-4db9-98f7-d6038f271866.jpg?1783918459,Creature — Human Wizard,Michael Sutfin
+Grim Reaper's Sprint,5,2024,1.64,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/18e76286-9e06-42de-b322-eb8aa2cdca3a.jpg?1783912404,Enchantment — Aura,Anton Solovianchyk
+Grip of Chaos,6,2003,4.57,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/defbbd3a-0e7d-4af2-b25f-9003ddad0bf5.jpg?1783944873,Enchantment,Mark Tedin
+Grub- Storied Matriarch // Grub- Notorious Auntie,3,2026,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Goblin Warlock // Legendary Creature — Goblin Warrior,Jesper Ejsing
+Guff Rewrites History,3,2023,3.49,#ff1a1a,https://cards.scryfall.io/normal/front/e/1/e16c6ab7-cab9-4ee3-9f17-d6817f61efcc.jpg?1783915480,Instant,Matt Stewart
+Guild Feud,6,2012,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e622878-0aea-4401-873e-d34bf05ee98d.jpg?1783940355,Enchantment,Karl Kopinski
+Guttersnipe,3,2026,4.73,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f6d2ed27-2d70-4851-80cb-8480ac938516.jpg?1783904219,Creature — Goblin Shaman,Kevin Eastman
+Gwen Stacy // Ghost-Spider,2,2025,2.42,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Performer Hero // Legendary Creature — Spider Human Hero,Victor Adame Minguez
+Hamletback Goliath,7,2020,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/368ee4e3-c9eb-4898-99cd-bbe148936f99.jpg?1783930390,Creature — Giant Warrior,Paolo Parente & Brian Snõddy
+Hammerfist Giant,6,2018,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fc5a36a-b572-4689-84b9-c5fb87d954c2.jpg?1783934742,Creature — Giant Warrior,Carl Critchlow
+Hammer of Bogardan,3,2003,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/abf6e6c0-ddea-4d15-ab1a-5c7d9fa69d51.jpg?1783944721,Sorcery,Ron Spencer
+Hammer of Purphoros,3,2025,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/9/0/900de725-741b-4b25-8e40-78ed7575a83f.jpg?1783906038,Legendary Enchantment Artifact,Yeong-Hao Han
+Hand to Hand,3,1997,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/af4cb86a-db01-4d9a-99e9-bb50ce23507f.jpg?1783946629,Enchantment,Carl Frank
+Hanweir Garrison,3,2025,1.62,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/1811b4fa-fed6-46ea-a6de-bb7624a5b1de.jpg?1783908121,Creature — Human Soldier,Vincent Proce
+Haphazard Bombardment,6,2018,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/e/5/e558a5bd-e8f9-477f-a514-1bf0708f4e9e.jpg?1783934993,Enchantment,Jesper Ejsing
+Harmless Offering,3,2024,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg?1783908922,Sorcery,Howard Lyon
+Harmonic Prodigy,2,2026,3.23,#ff1a1a,https://cards.scryfall.io/normal/front/6/3/63a565e3-d7a8-469d-898f-49fef634c107.jpg?1783903818,Creature — Human Wizard,Nathaniel Himawan
+Harness by Force,3,2014,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9bde89c1-aafa-43d9-adbf-671fa2b52d4f.jpg?1783939426,Sorcery,Yefim Kligerman
+Harness the Storm,3,2016,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/5/2/5294d359-c599-40ed-9e06-2a3cc8624d6a.jpg?1783937750,Enchantment,Raymond Swanland
+Harsh Mentor,2,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/3/d/3d440fb1-3e19-4615-a988-558b9d3db179.jpg?1783909612,Creature — Human Cleric,Shreya Shetty
+Hateflayer,7,2008,2.66,#ff1a1a,https://cards.scryfall.io/normal/front/3/8/38c26ba3-e325-433b-b653-4e80e737b54d.jpg?1783942683,Creature — Elemental,Thomas M. Baxa
+Havoc Eater,7,2024,0.82,#ff1a1a,https://cards.scryfall.io/normal/front/1/7/17054e75-d801-4962-83c1-0b52e7b65f66.jpg?1783913044,Creature — Elemental,David Szabo
+Hawkeye- Master Marksman,2,2026,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/9/9/9991b684-0ae0-4aa4-8f22-a9c473f5d69c.jpg?1783902931,Legendary Creature — Human Archer Hero,Bachzim
+Hawkeye- Trick Shot,4,2026,4.9,#ff1a1a,https://cards.scryfall.io/normal/front/0/f/0f05832a-395e-44ba-8e1b-1488c3960343.jpg?1783903109,Legendary Creature — Human Archer Hero,Thanh Tuấn
+Hazoret- Godseeker,2,2025,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg?1783907881,Legendary Creature — God,Chris Rallis
+Hazoret's Favor,3,2017,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8b467412-c06b-4cd9-a877-7722051fb758.jpg?1783936488,Enchantment,Raymond Swanland
+Hazoret's Undying Fury,6,2017,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7f578576-19ca-4e67-94da-2c0767d9a2bb.jpg?1783936027,Sorcery,Victor Adame Minguez
+Hazoret the Fervent,4,2017,0.87,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/36ed9f9d-99a7-49f4-b0ad-d71355809d32.jpg?1783936487,Legendary Creature — God,Chase Stone
+Headliner Scarlett,4,2024,5.47,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/be77b98a-dd79-477c-8ab2-7ebf5637a89e.jpg?1783912584,Legendary Creature — Human Warlock,Heonhwa
+Hearthborn Battler,3,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/bef1cf5c-9738-4062-8cb1-87a372d36687.jpg?1783910820,Creature — Lizard Warlock,Zoltan Boros
+Heartless Hidetsugu,5,2023,2.63,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7b3ff07c-9653-4197-ad3d-638e712e8465.jpg?1783915651,Legendary Creature — Ogre Shaman,Carl Critchlow
+Heart of Bogardan,4,1997,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/4/e/4e30d025-1df9-4a08-b686-037e9cbf23a6.jpg?1783946726,Enchantment,Terese Nielsen
+Heart-Piercer Manticore,4,2019,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/6/c/6cd213a1-92f6-49dd-9ea9-41a00879faaa.jpg?1783932755,Creature — Manticore,Scott Murphy
+Heart Wolf,4,1995,0.61,#ff1a1a,https://cards.scryfall.io/normal/front/e/0/e0427dcd-26da-462b-b936-a382d3d8afce.jpg?1783947283,Creature — Wolf,Margaret Organ-Kean
+Heat Shimmer,3,2020,7.27,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/86956f26-3761-4841-a9b5-f8205bf01f19.jpg?1783930163,Sorcery,Franz Vohwinkel
+Heat Stroke,3,1997,4.46,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1baf2a6c-57ec-4b38-8b08-4b3f800dbe99.jpg?1783946725,Enchantment,Andrew Robinson
+Hedron Detonator,3,2023,6.62,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7f1ccee1-20d1-48f2-ae90-a7a78172e05d.jpg?1783917283,Creature — Goblin Artificer,Caroline Gariba
+Hell-Bent Raider,3,2002,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7f41ac1c-2603-4234-8963-cd47bb894024.jpg?1783945149,Creature — Human Barbarian,Mike Ploog
+Hellion Eruption,6,2016,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e1649a2-adc4-4703-a453-df3cfdb423a2.jpg?1783936834,Sorcery,Anthony Francisco
+Hellkite Charger,6,2023,4.06,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/6836c646-83ff-4bf8-96dd-4cbdd6c7e861.jpg?1783915650,Creature — Dragon,Jaime Jones
+Hellkite Courser,6,2025,2.77,#ff1a1a,https://cards.scryfall.io/normal/front/d/3/d33eca2e-fef0-42fd-9970-46d5bdb4bd4b.jpg?1783907069,Creature — Dragon,Caio Monteiro
+Hellkite Igniter,7,2023,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/c/dc03ad3e-8113-432c-bff6-3ced73af8728.jpg?1783917146,Creature — Dragon,Jason Chan
+Hellkite Tyrant,6,2024,4.33,#ff1a1a,https://cards.scryfall.io/normal/front/a/7/a7cb4100-1696-4393-8f1f-634018e0b78f.jpg?1783908487,Creature — Dragon,Aleksi Briclot
+Hellrider,4,2020,2.98,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7bbfd905-8c71-4389-9174-6e84bcbcf05c.jpg?1783930388,Creature — Devil,Svetlin Velinov
+Hellspur Posse Boss,4,2024,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5f348c7e-7d72-40f1-a65f-ee7ff4b09412.jpg?1783911819,Creature — Lizard Rogue,Artur Nakhodkin
+Hell's Thunder,3,2014,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/c/3/c3661c2d-f211-4e32-8edb-bb73617537e2.jpg?1783939125,Creature — Elemental,Karl Kopinski
+Hell to Pay,1,2024,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/8/4/84ad8ed7-1429-432e-8217-a4db3b97675c.jpg?1783911820,Sorcery,Liiga Smilshkalne
+Heretic's Punishment,5,2011,0.12,#ff1a1a,https://cards.scryfall.io/normal/front/d/2/d2c9e963-bb0c-4490-8238-9476b924abf7.jpg?1783940935,Enchantment,Vincent Proce
+Hero of Oxid Ridge,4,2011,0.57,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1a516bce-3d2d-4e0f-afc7-27be3d88848c.jpg?1783941379,Creature — Human Knight,Eric Deschamps
+Hew the Entwood,5,2023,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/8/1/81940498-a5bf-4bcd-b06d-8816887b2a2b.jpg?1783916285,Sorcery,Manuel Castañón
+Hexing Squelcher,2,2026,21.33,#ff1a1a,https://cards.scryfall.io/normal/front/6/7/674960ce-ff33-4d5e-a24a-a4582b2e9809.jpg?1783904442,Creature — Goblin Sorcerer,Matt Stewart
+Hexplate Wallbreaker,5,2023,7.74,#ff1a1a,https://cards.scryfall.io/normal/front/f/7/f75e6145-79a4-4400-8e0a-c334e4a780fb.jpg?1783918159,Artifact — Equipment,Aaron Miller
+Hidetsugu's Second Rite,4,2005,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg?1783944146,Instant,Jeff Miracola
+Hired Claw,1,2024,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1ae41080-0d67-4719-adb2-49bf2a268b6c.jpg?1783910820,Creature — Lizard Mercenary,Quintin Gleim
+Hit the Mother Lode,7,2023,1.1,#ff1a1a,https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg?1783913759,Sorcery,Diego Gisbert
+Hivis of the Scale,5,1996,1.66,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee84e61e-d99a-489b-a3b1-cb45fc81bce6.jpg?1783947076,Legendary Creature — Lizard Shaman,Andrew Robinson
+Hoard Hauler,4,2022,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/1/9/19f190e9-52f3-4e34-8fb6-88174c189ee7.jpg?1783923119,Artifact — Vehicle,Jake Murray
+Hoarding Dragon,5,2014,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7c4c4a0f-0ee4-422d-b807-f64b77dd6831.jpg?1783939172,Creature — Dragon,Matt Cavotta
+Hoard-Smelter Dragon,6,2021,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/2/f/2f4c5867-73c4-4e10-bbf5-6a69df879547.jpg?1783926205,Creature — Dragon,Eric Deschamps
+Hobgoblin Bandit Lord,3,2021,4.96,#ff1a1a,https://cards.scryfall.io/normal/front/0/9/09e9dc36-f2d8-4384-98cb-e44c00b02433.jpg?1783926478,Creature — Goblin Rogue,Mark Zug
+Homura- Human Ascendant // Homura's Essence,6,2005,3.88,#ff1a1a,https://cards.scryfall.io/normal/front/8/4/84920a21-ee2a-41ac-a369-347633d10371.jpg?1783944146,Legendary Creature — Human Monk // Legendary Enchantment,Kev Walker
+Hostility,6,2018,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9b54945a-d355-40fd-b1fd-9ecb2d696de5.jpg?1783934741,Creature — Elemental Incarnation,Omar Rayyan
+Hot Pursuit,2,2024,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bbba7b9f-d944-4987-b60d-34733382ec53.jpg?1783913044,Enchantment,Michele Giorgi
+Hound of Griselbrand,4,2012,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/0/f/0fe68bce-6207-4fd1-9e82-a18fd2d6ddca.jpg?1783940682,Creature — Elemental Dog,Svetlin Velinov
+Hour of Devastation,5,2017,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/d/4/d420cc12-cfd7-4007-a0c2-b16c8f63a754.jpg?1783936028,Sorcery,Simon Dominic
+Howl of the Horde,3,2014,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/5/d/5db4baf3-f0dc-4b27-8323-a76764332590.jpg?1783939072,Sorcery,Slawomir Maniak
+Howlsquad Heavy,3,2025,3.49,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg?1783907881,Creature — Goblin Mercenary,Leonardo Santanna
+Hulk- Always Angry,7,2026,2.14,#ff1a1a,https://cards.scryfall.io/normal/front/e/a/eab5ca32-fe4c-41d2-9b80-9992ee482c01.jpg?1783903112,Legendary Creature — Gamma Berserker Hero,Thanh Tuấn
+Hulkling- Young Avenger,4,2026,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/6/3/6358d9ec-7542-4364-8bba-ca29fe470338.jpg?1783903050,Legendary Creature — Kree Skrull Hero,Stephanie Hans
+Human Torch,4,2026,0.94,#d78f42,https://cards.scryfall.io/normal/front/b/f/bf7b63ef-c7b4-4001-b64a-c7443f5268ba.jpg?1783903303,Legendary Creature — Human Hero,Vilhelmas Banys
+Humble Defector,2,2025,0.64,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e2ea145d-3be2-4660-8cf2-0157c76ec9c1.jpg?1783904852,Creature — Human Rogue,Viacom
+Hunted Dragon,5,2018,0.65,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/351cea54-905e-401b-8627-7c3fd192b772.jpg?1783934741,Creature — Dragon,Mark Zug
+Hunting Velociraptor,3,2023,75.19,#ff1a1a,https://cards.scryfall.io/normal/front/e/2/e2c5c161-49c5-404d-bd8e-86e634222232.jpg?1783913639,Creature — Dinosaur,Caio Monteiro
+Hurr Jackal,1,1995,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/c/1/c1c0ab2b-04bf-4cba-8efa-3d1d0ab4f50d.jpg?1783947828,Creature — Jackal,Drew Tucker
+Ib Halfheart- Goblin Tactician,4,2014,1.31,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e950415c-2abe-4afe-9ef4-6d63eba2c833.jpg?1783938766,Legendary Creature — Goblin Advisor,Wayne Reynolds
+Ignacio of Myra's Marvels,4,2022,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8bb6342b-0b9e-4379-b433-70bbaeb04c19.jpg?1783920566,Legendary Creature — Lizard Performer,Gaboleps
+Ignite the Future,4,2022,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/5/8/58e82d3c-a7ec-4e0d-a17e-51ebd2f3f331.jpg?1783922422,Sorcery,Alex Konstad
+Ignition Team,7,2014,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9dc89eb3-4497-4f05-8fed-d378b6e425ca.jpg?1783939373,Creature — Goblin Warrior,Karl Kopinski
+Iizuka the Ruthless,5,2005,1.3,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9ce461f7-385d-4379-83de-49571247c30d.jpg?1783944146,Legendary Creature — Human Samurai,Darrell Riche
+Ilharg- the Raze-Boar,5,2024,11.84,#ff1a1a,https://cards.scryfall.io/normal/front/3/d/3d397fc3-fd4e-45ad-ad40-0f8a585c15fd.jpg?1783913313,Legendary Creature — Boar God,Filip Burburan
+Illicit Auction,5,1999,4.87,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/97d68c39-cfdd-4883-9058-d648d073ae36.jpg?1783946170,Sorcery,Scott Kirschner
+Ill-Tempered Loner // Howlpack Avenger,4,2021,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Grzegorz Rutkowski
+Illuminate History,4,2021,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/9/8/98739789-80b5-4224-a2e4-09e00654aa9d.jpg?1783927352,Sorcery — Lesson,Jokubas Uogintas
+Imminent Doom,3,2017,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/a/5/a51f8207-485e-4a4e-aa62-8e0e69645a0e.jpg?1783936027,Enchantment,Daniel Ljunggren
+Immolating Gyre,6,2020,4.97,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bd0b8aee-fbfb-470f-9ac2-64fce0b4b2fb.jpg?1783930503,Sorcery,Campbell White
+Immolation Shaman,2,2019,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/4/5/45e668e5-ef50-43eb-852e-b111370459c8.jpg?1783933678,Creature — Lizard Shaman,Svetlin Velinov
+Immortal Phoenix,6,2019,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/afcb9f15-be65-494c-9672-162d38c6f0a5.jpg?1783932901,Creature — Phoenix,Daarken
+Imodane- the Pyrohammer,4,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/14b44833-0482-4b47-a594-4050bb87f1a5.jpg?1783915094,Legendary Creature — Human Knight,Chris Rahn
+Impact Resonance,2,2018,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/c/d/cd1742a6-adbd-4fbe-82c7-fe3589623d14.jpg?1783934741,Instant,Jesper Ejsing
+Impact Tremors,2,2025,5.94,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4a78413f-8b7a-460f-ad9c-1074deaf2e70.jpg?1783905569,Enchantment,Zoltan Boros & Scott Okumura
+Impatience,3,2001,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/11443908-358f-4886-a2da-9b98002a3a3a.jpg?1783945460,Enchantment,Kunio Hagio
+Impending Disaster,2,1999,1.22,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/44497303-9686-4810-bf0f-876dd9696cab.jpg?1783946235,Enchantment,Pete Venters
+Impending Flux,3,2023,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/9/8/98cc159d-74f7-41fe-a866-c18d96219794.jpg?1783914651,Sorcery,Ben Wootten
+Imperial Hellkite,7,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/c/f/cffb1feb-9368-4d91-bd4b-36a24fe849e6.jpg?1783912997,Creature — Dragon,Matt Cavotta
+Imperial Recruiter,3,2021,13.87,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/05bd329b-5707-42fc-af1c-084cc604e805.jpg?1783926783,Creature — Human Advisor,Zack Stella
+Impetuous Devils,4,2016,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1ba7acc0-6ef0-4c34-be23-118e1872271f.jpg?1783937460,Creature — Devil,Filip Burburan
+Imposing Grandeur,5,2021,1.46,#ff1a1a,https://cards.scryfall.io/normal/front/8/d/8d236055-d524-4312-9c6f-eddb34703e3e.jpg?1783925000,Sorcery,Mila Pesic
+Improvisation Capstone,7,2026,10.46,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d01fe6e9-49ee-4708-833e-75cd5a9f167c.jpg?1783903667,Sorcery — Lesson,Marta Nael
+Improvised Arsenal,2,2026,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/003265d9-b2fc-4916-afc8-53ed2d6aa053.jpg?1783904096,Artifact — Equipment,Leanna Crossan
+Impulsive Maneuvers,4,2001,3.91,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d9b404c0-9ce1-4491-82fd-6dba7e6895cd.jpg?1783945228,Enchantment,Dave Dorman
+Impulsivity,7,2026,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/c/1/c1c9ff71-b818-4d8b-8e0a-432becb7bf09.jpg?1783904604,Creature — Elemental Incarnation,Alex Konstad
+Incandescent Soulstoke,3,2007,0.8,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c8829b3c-5267-44c6-b709-c2dfc683b0a8.jpg?1783942873,Creature — Elemental Shaman,Todd Lockwood
+Incendiary Command,5,2013,1.85,#ff1a1a,https://cards.scryfall.io/normal/front/9/2/925d6ae9-deb8-41a4-99de-fd6fc6924d3b.jpg?1783939667,Sorcery,Wayne England
+Incinerate,2,2008,5.34,#ff1a1a,https://cards.scryfall.io/normal/front/f/0/f09dd696-8dff-41dd-b510-b2ad4c5d6c36.jpg?1783942814,Instant,Zoltan Boros & Gabor Szikszai
+Incinerator of the Guilty,6,2024,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0c6aca64-a554-45c1-9f23-4f7878abeda5.jpg?1783912888,Creature — Dragon,Lucas Graciano
+Incite Rebellion,6,2018,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/3633c759-f86a-436d-b54d-0d6c9ef14b63.jpg?1783934740,Sorcery,Alex Horley-Orlandelli
+Increasing Vengeance,2,2019,1.39,#ff1a1a,https://cards.scryfall.io/normal/front/2/a/2a362d78-76a1-4dbc-80cc-0360e98ba280.jpg?1783932753,Instant,Anthony Francisco
+Indomitable Creativity,3,2017,0.86,#ff1a1a,https://cards.scryfall.io/normal/front/e/d/edd00e45-2ae1-4cd0-92a1-155c95f8dc72.jpg?1783936753,Sorcery,Deruchenko Alexander
+Indulge // Excess,5,2022,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d653b755-1e09-45c4-8d44-8a950151ca51.jpg?1783923360,Sorcery // Sorcery,Gaboleps
+Industrial Advancement,4,2022,5.41,#ff1a1a,https://cards.scryfall.io/normal/front/8/1/81f1416c-48bd-4168-aacd-a9b0a3afb8bc.jpg?1783923360,Enchantment,Svetlin Velinov
+Infantry Shield,3,2025,0.65,#ff1a1a,https://cards.scryfall.io/normal/front/3/7/37332798-462e-49d3-b197-72411ccf67e5.jpg?1783907173,Artifact — Equipment,Xabi Gaztelua
+Inferno,7,2003,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/b/f/bf6895de-9c74-49a0-a71c-1e55a6897dfa.jpg?1783944719,Instant,Don Hazeltine
+Inferno of the Star Mounts,6,2021,2.7,#ff1a1a,https://cards.scryfall.io/normal/front/c/7/c788c6a6-20d9-4a93-a898-330b085226c4.jpg?1783926476,Legendary Creature — Dragon,Jesper Ejsing
+Inferno Project,7,2021,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca760378-fa30-47ac-b3e0-7dc2e72b3422.jpg?1783927593,Creature — Elemental,Olivier Bernard
+Inferno Titan,6,2023,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9ee80c14-5857-4752-b958-a51cf6706c96.jpg?1783915649,Creature — Giant,Kev Walker
+Infinity Elemental,7,2020,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f9330f67-0f79-4374-804c-5ca30841b8bb.jpg?1783931331,Creature — Elemental,Seb McKinnon
+Instigator Gang // Wildblood Pack,4,2011,0.86,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Greg Staples
+Insult // Injury,6,2017,0.73,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/eeac671f-2606-43ed-ad60-a69df5c150f6.jpg?1783936458,Sorcery // Sorcery,Lucas Graciano
+Insurrection,8,2023,14.24,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df8a0a8c-1953-46e6-9da5-b4c20909ce1c.jpg?1783915648,Sorcery,Mark Zug
+In the Web of War,5,2005,0.82,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f12b7124-d9d0-480c-b622-777a74d4f679.jpg?1783944189,Enchantment,Ron Spencer
+Inti- Seneschal of the Sun,2,2023,2.34,#ff1a1a,https://cards.scryfall.io/normal/front/f/a/fa7a55aa-ae61-4933-b7a4-dcc55dac6fcd.jpg?1783913759,Legendary Creature — Human Knight,Victor Adame Minguez
+Into the Fire,3,2023,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/8/0/80f649bb-b163-44ae-801f-8884143c407f.jpg?1783916990,Sorcery,Grzegorz Rutkowski
+Invader Parasite,5,2011,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/89a8c53f-2cb0-41ea-8391-c32667f17c30.jpg?1783941308,Creature — Phyrexian Insect,Volkan Baǵa
+Invasion of Kaldheim // Pyre of the World Tree,4,2023,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Enchantment,Bryan Sola
+Invasion of Karsus // Refraction Elemental,4,2023,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Creature — Elemental,Zoltan Boros
+Invasion of Tarkir // Defiant Thundermaw,2,2023,1.91,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Creature — Dragon,Darren Tan
+Invasion Plans,3,1998,1.44,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f52c2f83-9535-4ee5-9964-5cc01e617981.jpg?1783946555,Enchantment,Pete Venters
+Invoke Calamity,5,2022,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/f/e/fe666c86-6734-4c47-9244-bcd26b54068d.jpg?1783923866,Instant,Svetlin Velinov
+Ion Storm,3,2023,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/3/8/3871356b-a44c-4393-a69b-e5101508c5a8.jpg?1783917145,Enchantment,Michael Sutfin
+Irencrag Feat,4,2019,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5bcf822-e129-45f6-9403-310ce9410f3b.jpg?1783932622,Sorcery,Yongjae Choi
+Irencrag Pyromancer,3,2019,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/9/a/9a7b0ead-5629-429d-bede-8154f3fae96d.jpg?1783932622,Creature — Human Wizard,Jason Rainville
+Ire Shaman,2,2015,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/18f8ac7a-a68a-4adf-995f-1cd96ee3d295.jpg?1783938589,Creature — Orc Shaman,Jack Wang
+Iroh- Dragon of the West,4,2025,2.64,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aa261709-8966-4dee-b16b-f9e2a32ad84b.jpg?1783904821,Legendary Creature — Human Noble Ally,Hokyoung Kim
+Ironclaw Curse,1,1997,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6ed35d03-80fd-421d-a8be-6708a5570a85.jpg?1783946910,Enchantment — Aura,Dennis Detwiller
+Iron Fist- Hero for Hire,2,2026,0.68,#ff1a1a,https://cards.scryfall.io/normal/front/9/f/9f1cdf84-c034-4435-8ce7-50f6b777fb57.jpg?1783903049,Legendary Creature — Human Mercenary Hero,Mateus Manhanini
+Iron Man- Tony Stark,5,2026,6.4,#ff1a1a,https://cards.scryfall.io/normal/front/e/c/ec18d8cd-67ed-4338-8ae7-69628469cd43.jpg?1783902992,Legendary Artifact Creature — Human Hero,David Szabo
+Isengard Unleashed,5,2023,2.84,#ff1a1a,https://cards.scryfall.io/normal/front/5/5/55b5cfd6-1e20-4950-815f-f6666d6aef24.jpg?1783914201,Sorcery,Jason Rainville
+Ishi-Ishi- Akki Crackshot,2,2005,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8e94fec2-dc56-4961-ba80-b9c904a345ab.jpg?1783944188,Legendary Creature — Goblin Warrior,Christopher Rush
+Izzet Chemister,3,2022,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/2/9/2970c679-562b-48ee-b631-2e3016f4f37c.jpg?1783922425,Creature — Goblin Wizard,Svetlin Velinov
+Jack of Hearts- Volatile Hero,3,2026,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/7882b42b-d88f-48fe-9b30-cfb338accadb.jpg?1783903047,Legendary Creature — Alien Human Hero,Gaboleps
+Jalum Grifter,5,1998,0.99,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9b5d0ead-7798-49a2-8106-418db1d4fd69.jpg?1783946426,Legendary Creature — Devil,Claymore J. Flapdoodle
+Jaws- Relentless Predator,5,2025,171.11,#ff1a1a,https://cards.scryfall.io/normal/front/c/6/c6d16a9e-98c0-46e0-987c-f0de0915a204.jpg?1783905167,Legendary Creature — Shark,Stephen Andrade
+Jaxis- the Troublemaker,4,2022,1.81,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/78127c0c-672f-4e4b-9c23-6a5f237228fd.jpg?1783923117,Legendary Creature — Human Warrior,Zoltan Boros
+Jaya Ballard,5,2021,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85169934-1033-49d7-8d42-45e982077a23.jpg?1783927541,Legendary Planeswalker — Jaya,Magali Villeneuve
+Jaya Ballard- Task Mage,3,2021,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/2/8/2890840e-da0b-40ba-b3c2-7e4af39922b3.jpg?1783927795,Legendary Creature — Human Spellshaper,Matt Cavotta
+Jaya- Fiery Negotiator,4,2022,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/3/b/3b9f54f0-4368-4d28-aa21-3f1e7be1b23a.jpg?1783921315,Legendary Planeswalker — Jaya,Marta Nael
+Jaya's Immolating Inferno,2,2020,2.4,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/365336b4-92ee-429d-8f18-4624cba5469d.jpg?1783928712,Legendary Sorcery,Noah Bradley
+Jaya's Phoenix,5,2023,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/a/c/aca45c6b-8cce-44db-9f5b-fa66075db6f6.jpg?1783915480,Creature — Phoenix,Justyna Dura
+Jeering Instigator,2,2014,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/7/2/72777ccf-1cd8-45e8-8dfb-0a42550b5607.jpg?1783939073,Creature — Goblin Rogue,Willian Murai
+Jeska's Will,3,2024,41.78,#ff1a1a,https://cards.scryfall.io/normal/front/9/9/99e0c371-1024-4432-9fd9-3bc29c8d38e4.jpg?1783912996,Sorcery,Izzy
+Jeska- Thrice Reborn,3,2020,6.35,#ff1a1a,https://cards.scryfall.io/normal/front/4/8/48caf4c4-745c-4072-bf3d-1a3fa7c3bc9c.jpg?1783928812,Legendary Planeswalker — Jeska,Yongjae Choi
+Jeska- Warrior Adept,4,2002,2.55,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1cf96a59-8b7d-4a5b-adfd-17eeedd95db5.jpg?1783945117,Legendary Creature — Human Barbarian Warrior,rk post
+Jiwari- the Earth Aflame,5,2005,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6b46105b-32c2-48fc-b71d-c3e8fcb8a8ea.jpg?1783944146,Legendary Creature — Spirit,Adam Rex
+J. Jonah Jameson,3,2025,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9ee905d6-b647-4eb1-a8d9-89add9bafc31.jpg?1783905336,Legendary Creature — Human Citizen,Paolo Rivera
+Judgment Bolt,4,2025,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/05b04b06-9271-4a28-a60e-287df0d1a4d1.jpg?1783906432,Instant,Billy Christian
+Junk Jet,2,2024,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/2397c9b8-3974-48b8-94bd-f05f2e20750c.jpg?1783912403,Artifact — Equipment,Billy Christian
+Jurin- Leading the Charge,6,2025,2.06,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/867b4e3d-e175-4d6b-868a-87b3d6f61b07.jpg?1783906767,Legendary Creature — Human Barbarian,Craig J Spearing
+Kaboom!,5,2002,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1e81e5fc-0e18-4dd8-a505-aa7dba8521a8.jpg?1783945054,Sorcery,Glen Angus
+Kamahl- Pit Fighter,6,2017,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7a65dd4d-f838-4964-bd5a-a517960cc644.jpg?1783936566,Legendary Creature — Human Barbarian,Kev Walker
+Kami of Celebration,5,2022,1.04,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bda67054-bbd8-4979-801a-a5e9ca335f49.jpg?1783923992,Creature — Spirit,Milivoj Ćeran
+Kargan Dragonlord,2,2010,0.94,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b669d2d9-649b-4941-9a76-9833bdf77ca4.jpg?1783941974,Creature — Human Warrior,Jason Chan
+Kargan Intimidator,2,2020,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/0885acdc-9b4c-4e28-8785-9e721a27e81e.jpg?1783929359,Creature — Human Warrior,Kieran Yanner
+Kari Zev's Expertise,3,2017,1.2,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/ab5c7400-6307-4c51-88b8-9c0232110714.jpg?1783936752,Sorcery,Jason Rainville
+Kari Zev- Skyship Raider,2,2023,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/4/8/48765efe-bcb5-4a15-acd0-607ead64ae6d.jpg?1783913863,Legendary Creature — Human Pirate,Brad Rigney
+Karlach- Fury of Avernus,5,2022,25.09,#ff1a1a,https://cards.scryfall.io/normal/front/7/7/775480ed-f574-40cb-bd9b-21102eaaff63.jpg?1783922734,Legendary Creature — Tiefling Barbarian,Billy Christian
+Karplusan Minotaur,4,2006,5.3,#ff1a1a,https://cards.scryfall.io/normal/front/9/6/963f45d7-ce84-47af-ae1c-727172a31f0f.jpg?1783943339,Creature — Minotaur Warrior,Wayne England
+Karplusan Yeti,5,2005,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/6/a/6ad95118-104c-41d4-a393-941e7b97fd8e.jpg?1783943961,Creature — Yeti,Wayne England
+Kavu Monarch,4,2000,0.54,#ff1a1a,https://cards.scryfall.io/normal/front/e/a/ea63dfd5-d8d7-45b8-8219-1cc2b3de5666.jpg?1783945684,Creature — Kavu,Terese Nielsen
+Kazuul- Tyrant of the Cliffs,5,2024,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/7/2/721df547-d777-4247-b130-a4e247445b04.jpg?1783912996,Legendary Creature — Ogre Warrior,Paul Bonner
+Kazuul Warlord,5,2009,1.05,#ff1a1a,https://cards.scryfall.io/normal/front/d/a/da42df13-eded-48e2-ad1a-ff74d718ce3c.jpg?1783942144,Creature — Minotaur Warrior Ally,Kev Walker
+Kediss- Emberclaw Familiar,2,2026,9.43,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aa1c4ada-a218-4701-a293-ae6cbbe5c4d8.jpg?1783904219,Legendary Creature — Elemental Lizard,Ken Mitchroney
+Keeper of Secrets,6,2022,11.1,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fe408aa-14d9-4afd-abfe-b5156c5341b7.jpg?1783920889,Creature — Demon,Miguel Sacristan
+Keldon Firebombers,5,2000,1.98,#ff1a1a,https://cards.scryfall.io/normal/front/d/3/d3fc78b5-c259-4c67-810c-99655e72c2da.jpg?1783945777,Creature — Human Soldier,Randy Gallegos
+Keldon Flamesage,3,2022,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/7/1/710d2a3c-63a7-4e33-9ae3-21fb6b3d8326.jpg?1783921315,Creature — Human Shaman,Jason A. Engle
+Kellan- Planar Trailblazer,1,2024,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg?1783909101,Legendary Creature — Human Faerie Scout,Zoltan Boros
+Kellan- the Fae-Blooded // Birthright Boon,3,2023,7.16,#d78f42,https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1783915063,Legendary Creature — Human Faerie // Sorcery — Adventure,Anna Steinbauer
+Kessig Wolfrider,1,2021,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg?1783924835,Creature — Human Knight,Bram Sels
+Khârn the Betrayer,4,2022,6.9,#ff1a1a,https://cards.scryfall.io/normal/front/c/2/c29e6c69-7830-4898-9d1e-97dfc2e868d9.jpg?1783920889,Legendary Creature — Astartes Berserker,Kekai Kotaki
+Khorvath Brightflame,6,2018,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5fa0404b-757a-4aee-bcd8-6150938d0fba.jpg?1783934877,Legendary Creature — Dragon,Carmen Sinek
+Khorvath's Fury,5,2018,2.35,#ff1a1a,https://cards.scryfall.io/normal/front/3/9/39107560-58d5-4a7d-84a0-df26f89856b4.jpg?1783934859,Sorcery,Mark Behm
+Kiki-Jiki- Mirror Breaker,5,2017,16.3,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a2ff0ee3-9600-4c7d-acec-6ec90595384e.jpg?1783935527,Legendary Creature — Goblin Shaman,Steven Belledin
+Killmonger- Ruthless Usurper,3,2026,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0ec1ec8b-24d7-40e4-9e9d-4d9ec4f0a4f8.jpg?1783903282,Legendary Creature — Human Villain,L.A. Draws
+Kilnmouth Dragon,7,2011,0.83,#ff1a1a,https://cards.scryfall.io/normal/front/6/7/67bbc1c3-8806-49d4-9111-a2334c66e5ec.jpg?1783941337,Creature — Dragon,Carl Critchlow
+Kindred Charge,6,2017,9.39,#ff1a1a,https://cards.scryfall.io/normal/front/3/e/3e7dc7f0-ba05-4a13-b8e0-7f536fbf0f34.jpg?1783935941,Sorcery,Dan Murayama Scott
+Knight Rampager,5,2022,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/6105271d-76ae-4df0-bc95-fcccc229fc21.jpg?1783920887,Artifact Creature — Knight,Games Workshop
+Knollspine Dragon,7,2008,1.1,#ff1a1a,https://cards.scryfall.io/normal/front/b/f/bfcfec58-bfe4-4b04-80e3-ee11c44e91a7.jpg?1783942747,Creature — Dragon,Steve Prescott
+Knollspine Invocation,3,2008,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/8/1/8157aade-9dfc-402d-8e1f-468bf2bccb9c.jpg?1783942747,Enchantment,Dave Dorman
+Knuckles the Echidna,4,2025,16.97,#ff1a1a,https://cards.scryfall.io/normal/front/5/4/54b65cca-7844-4d3e-9d7f-ed1f49f94425.jpg?1783906092,Legendary Creature — Echidna Warrior,Tyler Walpole
+Kobold Overlord,2,1994,62.3,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/490eeedb-9c03-4dc7-81fd-ae54a7932e4d.jpg?1783948054,Creature — Kobold,Julie Baroh
+Komainu Battle Armor,3,2022,4.4,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d6ecab4b-fcff-4cf9-8e26-f3c609179050.jpg?1783923991,Artifact Creature — Equipment Dog,Néstor Ossandón Leal
+Kookus,5,1997,0.65,#ff1a1a,https://cards.scryfall.io/normal/front/8/f/8fb90922-99d2-4b36-9039-bb806fd01756.jpg?1783946987,Creature — Djinn,Scott Hampton
+Koth- Fire of Resistance,4,2023,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/6/5/6528e012-4091-4722-b706-c51772676167.jpg?1783918027,Legendary Planeswalker — Koth,Eric Wilkerson
+Krark- the Thumbless,2,2020,1.63,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/06a981cd-1951-438e-95c9-68294795638e.jpg?1783928810,Legendary Creature — Goblin Wizard,Mathias Kollros
+Kratos- God of War,3,2025,53.22,#ff1a1a,https://cards.scryfall.io/normal/front/f/b/fb97e2a1-0e86-4c12-8d31-6ff7b825ca10.jpg?1783905133,Legendary Creature — God Warrior,Magali Villeneuve
+Krenko- Baron of Tin Street,3,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/5/5/5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg?1783912878,Legendary Creature — Goblin,Brian Valeza
+Krenko- Mob Boss,4,2024,1.84,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/824b2d73-2151-4e5e-9f05-8f63e2bdcaa9.jpg?1783909065,Legendary Creature — Goblin Warrior,Lie Setiawan
+Krenko's Buzzcrusher,4,2024,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg?1783912878,Artifact Creature — Insect Thopter,Joshua Raphael
+Krenko- Tin Street Kingpin,3,2023,3.19,#ff1a1a,https://cards.scryfall.io/normal/front/2/f/2f5689e2-d8a2-442b-8027-f89686adcb67.jpg?1783917146,Legendary Creature — Goblin,Viko Menezes
+Kruin Outlaw // Terror of Kruin Pass,3,2025,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Rogue Werewolf // Creature — Werewolf,David Rapoza
+Kuldotha Phoenix,5,2010,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6bb79b56-81f1-417f-b5ad-030ad29f904b.jpg?1783941723,Creature — Phoenix,Mike Bierek
+Kumano- Master Yamabushi,5,2004,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f93870f9-343f-43e7-8ae8-e7aaa56aacca.jpg?1783944299,Legendary Creature — Human Shaman,Adam Rex
+Kurkesh- Onakke Ancient,4,2014,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/2/e/2e2a0e9e-0e45-4af1-9f03-6fd3652933f9.jpg?1783939173,Legendary Creature — Ogre Spirit,Slawomir Maniak
+Labyrinth Champion,4,2013,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/3/f/3f86d035-a86d-4c2a-a19d-3b90e0f9ff0f.jpg?1783939761,Creature — Human Warrior,Chase Stone
+Laccolith Titan,7,2000,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/e/3/e36bc466-0f74-46fd-add2-c1cf3b3fe46b.jpg?1783945819,Creature — Beast,Tony Szczudlo
+Lady Loki- Agent of Chaos,6,2026,0.79,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/44ac85d4-0429-4813-b7fe-eed1f6575b7d.jpg?1783903283,Legendary Creature — God Sorcerer Villain,Marta Nael
+Laelia- the Blade Reforged,3,2026,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/2/c/2cb16354-1211-4230-90e2-4858ba68f348.jpg?1783903774,Legendary Creature — Spirit Warrior,Wisnu Tan
+Lamplight Phoenix,3,2024,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg?1783912876,Creature — Phoenix,Ryan Pancoast
+Landfill,5,1998,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/3/e/3ef5452d-b5cb-4772-a5ac-1b4c976e03a5.jpg?1783946425,Sorcery,Daren Bader
+Land's Edge,3,1995,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/41798dd9-8ce8-4642-89c2-7356ea129d4e.jpg?1783947364,World Enchantment,Brian Snõddy
+Last Chance,2,2023,5.2,#ff1a1a,https://cards.scryfall.io/normal/front/c/0/c0efb595-d407-4389-a99d-d97c4d6bdcd0.jpg?1783918459,Sorcery,Joshua Raphael
+Lathliss- Dragon Queen,6,2025,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0cb48015-627b-49cd-8dc3-d446e82b8172.jpg?1783907068,Legendary Creature — Dragon,Alex Konstad
+Lathnu Hellion,3,2016,0.12,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/14050179-84af-46f6-89be-338f8e7131cc.jpg?1783937192,Creature — Hellion,Lars Grant-West
+Latulla- Keldon Overseer,5,2000,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fd3c7b0c-98bd-4c63-bbb0-80484a5ab26f.jpg?1783945777,Legendary Creature — Human Spellshaper,Brom
+Laurine- the Diversion,3,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca2b008e-e144-45b1-9bc7-eb49e03a8a8f.jpg?1783911917,Legendary Creature — Human Rogue,Andrey Kuzinskiy
+Lavaball Trap,8,2009,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/c/0/c0d411e1-5488-4818-95a4-9f637efb9be6.jpg?1783942143,Instant — Trap,Zoltan Boros & Gabor Szikszai
+Lavaborn Muse,4,2013,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f9ac12fe-f895-4450-8516-1feb6a48f1bc.jpg?1783940069,Creature — Spirit,Brian Snõddy
+Lavabrink Floodgates,4,2020,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/2/d2f9a9bf-edd2-4448-bace-8bfba3ba529a.jpg?1783931213,Artifact,Anastasia Ovchinnikova
+Lava Dart,1,2025,12.54,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/8933ec5c-dd73-4c10-aafe-ad14520cda10.jpg?1783906755,Instant,Toru Terada
+Lava Hounds,4,2003,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/c/f/cf83d5c7-a17c-4350-9432-92a01421b39a.jpg?1783944717,Creature — Dog,Steve White
+Lavaleaper,4,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/82902488-d178-4752-bcfb-dd3050654d23.jpg?1783904441,Creature — Elemental,Ron Spears
+Lava Runner,3,1999,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/0/9/09d0fbe6-6ce1-4b95-afb7-a7386b5033cf.jpg?1783945936,Creature — Lizard,Donato Giancola
+Lava Spike,1,2025,2.36,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/aebf5362-f9b9-451e-a2eb-b0e0fae1f974.jpg?1783906750,Sorcery — Arcane,K Wroten
+Legion Extruder,2,2024,3.32,#ff1a1a,https://cards.scryfall.io/normal/front/5/a/5a077de0-1893-40d0-a499-ee2e6e2258f1.jpg?1783912001,Artifact,Anton Solovianchyk
+Legion Loyalist,1,2013,5.66,#ff1a1a,https://cards.scryfall.io/normal/front/b/4/b47f639e-4635-4c26-bb2a-4925f0582c21.jpg?1783940123,Creature — Goblin Soldier,Eric Deschamps
+Legion Warboss,3,2025,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/3/d/3d726dff-2904-4a82-adaa-29c57a5c2aed.jpg?1783907068,Creature — Goblin Soldier,Alex Konstad
+Let the Galaxy Burn,6,2022,0.58,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/1120636b-d28b-4226-a1ba-cb42654c5a90.jpg?1783920887,Sorcery,Evan Shipard
+Leyline of Combustion,4,2019,0.6,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3a93c8e2-fb27-43af-83a7-2bd4d40e0eff.jpg?1783932974,Enchantment,Noah Bradley
+Leyline of Lightning,4,2006,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/23d09839-b41e-4aab-8913-40d63052dbf3.jpg?1783943500,Enchantment,Paolo Parente
+Leyline of Punishment,4,2010,3.24,#ff1a1a,https://cards.scryfall.io/normal/front/5/1/51a2eec5-f892-4466-b6c6-960626ba5640.jpg?1783941804,Enchantment,Charles Urbach
+Leyline of Resonance,4,2024,0.93,#ff1a1a,https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg?1783909467,Enchantment,Sergey Glushakov
+Leyline Tyrant,4,2025,2.22,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/0542d0d7-5b0f-4093-b74d-6a60f174aeb5.jpg?1783907068,Creature — Dragon,Chase Stone
+Liberating Combustion,5,2016,0.1,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c9d2156e-2d54-440e-b0fd-7bef702afbfc.jpg?1783937138,Sorcery,Lius Lasahido
+Life of the Party,4,2022,11.41,#ff1a1a,https://cards.scryfall.io/normal/front/3/0/30cfd6c9-9eed-493b-bd1d-113cb7935f61.jpg?1783923360,Creature — Elemental,Brian Valeza
+Lightning Bolt,1,2026,2.33,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b6bc6ff3-f466-4cb0-8b4e-a20d8ed129c8.jpg?1783904637,Instant,Fahmi Fauzi
+Lightning Cloud,4,1997,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7fcfc2ad-a1a4-4f65-a239-f11383aaafe1.jpg?1783946988,Enchantment,John Matson
+Lightning Crafter,4,2008,3.3,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f68f5ac9-0345-4052-9f93-d9f7afc66932.jpg?1783942786,Creature — Goblin Shaman,Dan Murayama Scott
+Lightning Phoenix,3,2020,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b52a3f11-6d55-4492-9a2c-c128c09b3d77.jpg?1783930502,Creature — Phoenix,Lie Setiawan
+Lightning Runner,5,2017,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/e/5/e5d9c7eb-dca4-4471-a91f-a5aad3a69c2f.jpg?1783936753,Creature — Human Warrior,Raymond Swanland
+Lightning- Security Sergeant,3,2025,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4ad4dce3-6e43-4528-b570-85547d03164e.jpg?1783906431,Legendary Creature — Human Soldier,Ramza Psyru
+Lightning Serpent,1,2006,3.39,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f6b4f4b6-51cd-4ae0-9585-82ad964853ba.jpg?1783943339,Creature — Elemental Serpent,John Avon
+Lightning Surge,5,2002,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/0/4/0452d78d-eafc-4ccb-a478-d1f46bcefffe.jpg?1783945116,Sorcery,Ron Spears
+Light Up the Night,1,2021,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/7/d/7de68154-3b82-4a94-98a6-cfc49d359e4e.jpg?1783925598,Sorcery,Wei Wei
+Lithophage,5,2012,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/b/f/bff49651-3673-4670-9807-3ef3a42b8f8f.jpg?1783940764,Creature — Insect,Mike Ploog
+Living Inferno,8,2006,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1c4b8143-2742-4262-b18f-2825bf8cea6f.jpg?1783943499,Creature — Elemental,John Avon
+Lizard Blades,2,2022,2.29,#ff1a1a,https://cards.scryfall.io/normal/front/a/7/a747e6cf-c687-4c4f-8e07-d51165d6cb62.jpg?1783923864,Artifact Creature — Equipment Lizard,Jason Kang
+Loafing Giant,5,2000,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/f/a/fab5f738-04d0-44c9-88ec-28469b668040.jpg?1783945683,Creature — Giant,Greg Hildebrandt & Tim Hildebrandt
+Loki- God of Lies,3,2026,3.48,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b519a04b-64a6-456f-b02a-a54be50342be.jpg?1783903108,Legendary Creature — God Sorcerer Villain,Kieran Yanner
+Loki's Scepter,3,2026,5.9,#ff1a1a,https://cards.scryfall.io/normal/front/5/7/57e90938-9225-4c15-b4fb-aad2cced2e6a.jpg?1783903282,Legendary Artifact,L J Koh
+Long-Range Sensor,3,2025,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7bc56147-9920-401d-8e4e-93d497e8b67a.jpg?1783906066,Artifact,Artur Treffner
+Loot Dispute,4,2022,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/0669a2bb-11c7-45d8-9299-09246ff4e72c.jpg?1783922503,Enchantment,Francisco Miyara
+Lord of Shatterskull Pass,4,2010,0.64,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b2159a7d-e37a-4c43-a7b9-1e7179a7e43b.jpg?1783941973,Creature — Minotaur Shaman,Kekai Kotaki
+Lost in Memories,2,2025,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/00cc4de5-f9b2-4a46-a410-b39446a9eaee.jpg?1783904819,Enchantment — Aura,Tubaki Halsame
+Luke Cage- Hero for Hire,4,2026,1.15,#ff1a1a,https://cards.scryfall.io/normal/front/5/1/51cef04a-fa47-4f82-8772-76d4bc82bada.jpg?1783903048,Legendary Creature — Human Mercenary Hero,Mateus Manhanini
+Lukka- Coppercoat Outcast,5,2020,0.58,#ff1a1a,https://cards.scryfall.io/normal/front/5/7/5798fdf0-d178-43d9-b821-8f3f654654b4.jpg?1783931048,Legendary Planeswalker — Lukka,Chris Rallis
+Ma Chao- Western Warrior,5,1999,80.2,#ff1a1a,https://cards.scryfall.io/normal/front/3/9/39b8cf7f-8c40-40e9-8118-e8626c3c6433.jpg?1783946105,Legendary Creature — Human Soldier Warrior,Koji
+Madcap Experiment,4,2016,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/05768b87-d2df-42fc-bf63-e471d31b32e3.jpg?1783937192,Sorcery,Joseph Meehan
+Maddening Hex,3,2021,5.52,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c8dd3a8d-5434-4405-8d17-e419a20f074a.jpg?1783926247,Enchantment — Aura Curse,Bryan Sola
+Maelstrom Artisan // Rocket Volley,3,2026,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5c88391d-271f-4021-a5d9-158ebc1e6357.jpg?1783903667,Creature — Minotaur Sorcerer // Sorcery,Eelis Kyttanen
+Magda- Brazen Outlaw,2,2021,2.59,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/079e6263-e54c-4899-a336-5315909b9322.jpg?1783928229,Legendary Creature — Dwarf Berserker,Slawomir Maniak
+Magda- the Hoardmaster,2,2024,0.76,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/4443d112-209b-49ec-bc40-3a11dcdb092e.jpg?1783911819,Legendary Creature — Dwarf Berserker,Diego Gisbert
+Mages' Contest,3,2000,15.78,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c516861c-68d9-4d02-a343-689dba0526c6.jpg?1783945683,Instant,Bradley Williams
+Magmablood Archaic,6,2026,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4d611278-9948-4345-b4dd-aa6eaf21b233.jpg?1783903667,Creature — Avatar,Joshua Raphael
+Magma Giant,7,2018,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/5/5/55ebd81a-4711-459d-9d97-d9ea12892184.jpg?1783934739,Creature — Giant,Nottsuo
+Magma Phoenix,5,2010,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/b/3/b3857c9b-136d-4e6a-bd3b-92dab1b71947.jpg?1783941803,Creature — Phoenix,Raymond Swanland
+Magmaquake,2,2021,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/8/a/8a8945b4-d2e1-4779-9c33-a8b062637fa6.jpg?1783926204,Instant,Gabor Szikszai
+Magma Sliver,4,2003,7.79,#ff1a1a,https://cards.scryfall.io/normal/front/9/0/9091d908-456f-4127-857d-b22fdb4f2fd9.jpg?1783944905,Creature — Sliver,Wayne England
+Magmatic Channeler,2,2020,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/d/8/d8be6570-5b5f-4ffc-a5e5-67d7c41c8caa.jpg?1783929356,Creature — Human Wizard,Bryan Sola
+Magmatic Force,8,2018,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e98eb29b-af03-4a96-b84c-a0bd51f80f03.jpg?1783934810,Creature — Elemental,Jung Park
+Magmatic Galleon,5,2023,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/4471a833-11b9-4146-a9c0-84a6896c94d8.jpg?1783913758,Artifact — Vehicle,Cristi Balanescu
+Magmatic Hellkite,4,2025,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/b/3/b3b3aec8-d931-4c7f-86b5-1e7dfb717b59.jpg?1783907360,Creature — Dragon,Tyler Walpole
+Magmaw,5,2015,0.1,#ff1a1a,https://cards.scryfall.io/normal/front/3/f/3f170d96-5070-41ed-abf3-e3bddceb9d0e.jpg?1783938237,Creature — Elemental,Karl Kopinski
+Magnetic Mountain,3,1995,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/9/9/993a14d5-a33d-426e-ab49-c3226a6fcdca.jpg?1783947826,Enchantment,Susan Van Camp
+Magnivore,4,2005,0.87,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/ab077f67-09c3-43d0-ad27-d1e6255c4d55.jpg?1783943959,Creature — Lhurgoyf,Carl Critchlow
+Magus of the Arena,6,2013,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/9/1/91e1c919-58e8-4637-a030-99ae90165585.jpg?1783939668,Creature — Human Wizard,Thomas M. Baxa
+Magus of the Moon,3,2021,4.14,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7c9bd75c-9606-4607-bfa6-d6acdee12820.jpg?1783927794,Creature — Human Wizard,Milivoj Ćeran
+Magus of the Scroll,1,2006,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/6060cada-52bf-4ef2-8a26-8ba04dded458.jpg?1783943219,Creature — Human Wizard,Greg Staples
+Magus of the Wheel,3,2023,1.24,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0e952dd9-ef09-40f0-993f-eb3a1516616a.jpg?1783915649,Creature — Human Wizard,Carl Frank
+Malignus,5,2012,5.03,#ff1a1a,https://cards.scryfall.io/normal/front/8/a/8a6a7000-4a1d-4cd4-a85e-4b7b20d8e543.jpg?1783940680,Creature — Elemental Spirit,Jung Park
+Manabarbs,4,2011,4.78,#ff1a1a,https://cards.scryfall.io/normal/front/a/d/adf081d5-e644-4f46-8bc8-a754b089acb4.jpg?1783941067,Enchantment,Jeff Miracola
+Mana Cache,3,2000,0.77,#ff1a1a,https://cards.scryfall.io/normal/front/5/8/583a33b3-7833-48e5-88c3-849a5771ef6e.jpg?1783945818,Enchantment,rk post
+Mana Cannons,3,2022,0.61,#ff1a1a,https://cards.scryfall.io/normal/front/5/b/5ba12cfc-36d3-4f9c-950e-3ed8b8f105fd.jpg?1783921477,Enchantment,Sidharth Chaturvedi
+Mana-Charged Dragon,6,2017,1.33,#ff1a1a,https://cards.scryfall.io/normal/front/0/3/03245712-18b9-48d2-b95e-24a38367abb9.jpg?1783936275,Creature — Dragon,Mike Bierek
+Mana Clash,1,2005,1.33,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bd41352f-617f-40f6-b612-11022180c18b.jpg?1783943957,Sorcery,Ron Spencer
+Mana Echoes,4,2020,59.8,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bd079929-fa58-4484-91b7-31305b87ee43.jpg?1783930162,Enchantment,Christopher Moeller
+Manaform Hellkite,4,2026,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/0/a/0a559655-0967-41b9-8248-170f95c05f84.jpg?1783903773,Creature — Dragon,Andrew Mar
+Mana Geyser,5,2024,9.19,#ff1a1a,https://cards.scryfall.io/normal/front/8/3/83425cfa-c08e-4c38-aeeb-dc6f0693ff72.jpg?1783909202,Sorcery,Mike Burns
+Manifold Mouse,2,2024,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/b/db3832b5-e83f-4569-bd49-fb7b86fa2d47.jpg?1783910819,Creature — Mouse Soldier,Randy Vargas
+Mannichi- the Fevered Dream,3,2005,0.67,#ff1a1a,https://cards.scryfall.io/normal/front/b/4/b403bdbb-13ab-43dd-a994-d45b994f6e0e.jpg?1783944188,Legendary Creature — Spirit,Martina Pilcerova
+Marauding Raptor,2,2023,1.27,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0b5cf2aa-f6dd-47d2-a57f-0ae2308c0f9a.jpg?1783913864,Creature — Dinosaur,Bayard Wu
+Maraxus of Keld,6,1997,1.52,#ff1a1a,https://cards.scryfall.io/normal/front/5/9/59329155-a423-4e8d-a7d4-c99555ff5ed1.jpg?1783946725,Legendary Creature — Human Warrior,Adrian Smith
+March of Reckless Joy,1,2022,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/780e1bf1-e392-40f2-9e84-764dedc5fcd4.jpg?1783923863,Instant,Fiona Hsieh
+Markov Blademaster,3,2012,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/1/2/122163dd-e070-48af-8036-e9850541d138.jpg?1783940816,Creature — Vampire Warrior,Jana Schirmer & Johannes Voss
+Markov Enforcer,6,2021,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/5/9/597bc4ae-335d-4d1d-8a57-530291abc540.jpg?1783924998,Creature — Vampire Soldier,Wisnu Tan
+Mass Hysteria,1,2025,4.29,#ff1a1a,https://cards.scryfall.io/normal/front/3/c/3c1854c9-11df-406d-b751-302b6f3a08fd.jpg?1783908114,Enchantment,Justine Cruz
+Mass Mutiny,5,2024,0.7,#ff1a1a,https://cards.scryfall.io/normal/front/b/8/b817473f-599d-45bb-a3b0-a96986ec5102.jpg?1783911917,Sorcery,Carl Critchlow
+Maximum Carnage,5,2025,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/7/d/7d72d867-6ed2-4900-a8ae-9d86f581ce32.jpg?1783905335,Enchantment — Saga,Bill Sienkiewicz
+Maximus- Knight Apparent,4,2026,1.08,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b2caf8e8-f98f-484f-b233-54ccf71ff9b9.jpg?1783904271,Legendary Creature — Human Knight,Ryan Valle
+Mechanized Warfare,3,2022,0.56,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/ba2d026f-bdca-4376-9d70-c81c707598e8.jpg?1783920064,Enchantment,Robin Olausson
+Meek Attack,3,2026,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/2/1/21157461-5435-4879-80a9-100afc5bbf4c.jpg?1783904442,Enchantment,Karl Kopinski
+Mega Flare,3,2025,1.71,#ff1a1a,https://cards.scryfall.io/normal/front/d/a/daecaf9c-f327-435a-963b-a4631b6cca5c.jpg?1783904652,Sorcery,Erion Makuo
+Megatog,6,2003,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/2/e/2e9734b1-c5fb-4b2b-bada-c45c3a725e01.jpg?1783944540,Creature — Atog,Pete Venters
+Megaton's Fate,6,2024,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e8492127-888d-4da0-b49f-fba6a356b0a9.jpg?1783912403,Sorcery,Chris Cold
+Meltdown,1,2025,6.15,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d957d60a-6eec-49d2-950f-306c4a12f60b.jpg?1783905085,Sorcery,Airi Yoshihisa
+Memorial Vault,4,2025,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a14ecd13-325a-4555-b1dd-d0d0d0826031.jpg?1783905951,Artifact,Javier Charro
+Memory Vessel,5,2024,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/2/e/2e37a5cd-887d-4b41-97f7-ae0bba85436b.jpg?1783911999,Artifact,Diego Gisbert
+Menacing Ogre,5,2009,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/8/d/8de4b5cc-748c-45d1-852b-0f522b8838ba.jpg?1783942323,Creature — Ogre,Ron Spencer
+Meteor Swarm,3,2021,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/b/8/b8f5e669-4e69-4763-bbb9-e9685bde912c.jpg?1783926474,Sorcery,Olivier Bernard
+Mezzio Mugger,5,2022,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/7/6/768e84a3-41b9-4f54-ae29-e5c7ae109e9a.jpg?1783923359,Creature — Lizard Rogue,Filipe Pagliuso
+Midnight Arsonist,4,2021,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4d322638-9775-42f4-b75e-d2e1a08bd75d.jpg?1783924997,Creature — Vampire,Campbell White
+Mila- Crafty Companion // Lukka- Wayward Bonder,3,2021,2.15,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Fox // Legendary Planeswalker — Lukka,Kieran Yanner
+Mindblaze,6,2004,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/5/9/59418766-5567-4ec4-af1f-1cb2db2958d0.jpg?1783944297,Sorcery,John Avon
+Mindmoil,5,2005,0.84,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0ccc79f7-2f35-4daf-a0c2-775f5fa6c249.jpg?1783943649,Enchantment,Alex Horley-Orlandelli
+Mindsparker,3,2013,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg?1783939913,Creature — Elemental,Wayne Reynolds
+Mine Layer,4,2001,2.83,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/497efda1-5013-45d2-b717-b0296218c42b.jpg?1783945228,Creature — Dwarf,Mark Brill
+Minion of the Mighty,1,2021,1.36,#ff1a1a,https://cards.scryfall.io/normal/front/f/f/ffd0a827-778b-48c3-bb85-4b4acef351d6.jpg?1783926474,Creature — Kobold,Oriana Menendez
+Mirage Phalanx,6,2021,1.37,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e67c7b3b-38c0-43ec-9cee-5605fc402af6.jpg?1783924995,Creature — Human Soldier,Scott Murphy
+Mirror March,6,2019,1.79,#ff1a1a,https://cards.scryfall.io/normal/front/5/0/50a27943-f08c-4cbd-affb-8e59411b3d4f.jpg?1783933678,Enchantment,Johannes Voss
+Mirror-Style Master,6,2023,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/d/3/d3481424-444e-4f13-881e-339e9c353988.jpg?1783917282,Creature — Human Warrior,Chris Rallis
+Mirrorwing Dragon,5,2026,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6ba557ab-9d80-4d0a-bddb-ec230cc4437d.jpg?1783903772,Creature — Dragon,Min Yum
+Mishra's Command,1,2022,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f4d2e518-30c6-480c-aaf4-b7596c9479e4.jpg?1783920068,Sorcery,Dominik Mayer
+Mizzium Mortars,2,2022,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/5/4/544b2931-0af1-4743-b7c1-91e1dc9294d5.jpg?1783922418,Sorcery,Christina Davis
+Mizzium Tank,3,2019,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/5643253b-0996-45a8-9488-5bcc9192f867.jpg?1783933423,Artifact — Vehicle,Wayne Reynolds
+Mizzix- Replica Rider,5,2022,4.41,#d78f42,https://cards.scryfall.io/normal/front/8/f/8faf1d83-3b6b-4e07-a024-3dfd37c29814.jpg?1783919182,Legendary Creature — Goblin Wizard,Zoltan Boros
+Mizzix's Mastery,4,2024,9.11,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fa2d7f2-05b3-468f-9f2c-a61b46bad88e.jpg?1783911917,Sorcery,Dan Murayama Scott
+Mjölnir- Hammer of Thor,4,2026,29.21,#ff1a1a,https://cards.scryfall.io/normal/front/e/0/e0c7f566-5351-44e3-a346-b84b0eb10209.jpg?1783902926,Legendary Artifact — Equipment,Wayne Reynolds
+Mob Rule,6,2021,3.18,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8b04c928-9ee5-4e39-962e-4686e25b5c33.jpg?1783924947,Sorcery,Jakub Kasper
+Mob Verdict,4,2024,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e9bdc40b-ab7a-44a4-afb5-41b6fc2dffdc.jpg?1783913043,Sorcery,Domenico Cava
+Mogg Assassin,3,2026,2.63,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4f55fdb1-4c4e-4bc7-aa22-d00b43d5cfa5.jpg?1783904233,Creature — Goblin Assassin,Austin DuRivage
+Moggcatcher,4,2000,14.62,#ff1a1a,https://cards.scryfall.io/normal/front/9/b/9ba582d7-1dce-4664-8bd9-6b419596788c.jpg?1783945818,Creature — Human Mercenary,Pete Venters
+Mogg Sentry,1,2005,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/56100dd7-250d-4a3a-b719-b25fc73873dc.jpg?1783943957,Creature — Goblin Warrior,Greg Staples
+Mogg War Marshal,2,2024,4.3,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fd170aa1-18be-470e-aa36-bfb11e9f92c1.jpg?1783911487,Creature — Goblin Warrior,Caroline Gariba & Scott Okumura
+Molten-Core Maestro,2,2026,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/3/2/326dfe32-3674-4a11-acd8-5ba62371235a.jpg?1783903666,Creature — Goblin Bard,Aleksi Briclot
+Molten Disaster,2,2013,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/1/7/17ca6865-e894-4390-ba27-b7cc8b03a424.jpg?1783939667,Sorcery,Ittoku
+Molten Duplication,2,2024,13.85,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fdbe1ac1-461f-4746-a8d8-6c8dea2c97c6.jpg?1783912001,Sorcery,Justyna Dura
+Molten Echoes,4,2021,10.05,#ff1a1a,https://cards.scryfall.io/normal/front/4/6/461d9f1c-53a4-48a6-bafb-0e70099f276c.jpg?1783924947,Enchantment,Zoltan Boros
+Molten Firebird,5,2007,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/dddda66c-2df4-452e-8eca-7e100213fd98.jpg?1783943143,Creature — Phoenix,Christopher Moeller
+Molten Hydra,2,1999,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/9/5/95234b29-9ac8-4200-b42d-9653ba51b010.jpg?1783946234,Creature — Hydra,Greg Staples
+Molten Influence,2,2001,6.26,#ff1a1a,https://cards.scryfall.io/normal/front/4/c/4c2b326b-d177-4a03-a0a3-fe2c2d4af272.jpg?1783945227,Instant,Franz Vohwinkel
+Molten Primordial,7,2013,1.6,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a8f5c7e2-f4da-4cee-a7d0-80b29bb73acd.jpg?1783940123,Creature — Avatar,Stephan Martiniere
+Molten Psyche,3,2010,4.84,#ff1a1a,https://cards.scryfall.io/normal/front/5/7/57e2382d-1f27-40d1-b809-c188c19ebc72.jpg?1783941723,Sorcery,Ryan Yee
+Molten Sentry,4,2005,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a9eb6c92-b385-4ef4-83ac-65a1a23e3d22.jpg?1783943649,Creature — Elemental,Kev Walker
+Moltensteel Dragon,6,2011,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/1/3/13b78018-bfbe-43fa-809f-9b52a155e11c.jpg?1783941307,Artifact Creature — Phyrexian Dragon,James Ryman
+Molten Vortex,1,2015,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d99fd073-c249-4cd2-9d71-be417c88c493.jpg?1783938327,Enchantment,Philip Straub
+Momo's Heist,3,2025,1.59,#ff1a1a,https://cards.scryfall.io/normal/front/b/f/bfc80abe-c36e-4a96-82d5-4d4c1a793ae4.jpg?1783904837,Sorcery,Brian Yuen
+Monastery Swiftspear,1,2025,4.87,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee6cb6af-81c6-4121-9941-7e9c1e68686a.jpg?1783906755,Creature — Human Monk,Toru Terada
+Mondronen Shaman // Tovolar's Magehunter,4,2012,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Shaman Werewolf // Creature — Werewolf,Mike Sass
+Monstrous Hound,4,1998,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/d/5/d5066b1b-3910-4434-83d6-030851f20bcf.jpg?1783946510,Creature — Dog,Dermot Power
+Monstrous Rage,1,2026,1.07,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9ebf25f9-844c-40c6-b0f0-d5c82ee04656.jpg?1783903313,Instant,Ed McGuinness & Dexter Vines
+Moonveil Dragon,6,2012,1.26,#ff1a1a,https://cards.scryfall.io/normal/front/9/2/92503118-b37b-4c52-b40a-487f6ad695ef.jpg?1783940815,Creature — Dragon,Todd Lockwood
+Moonveil Regent,4,2021,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f9fc55fd-161a-4d77-82f0-27075210e7e7.jpg?1783925597,Creature — Dragon,Joshua Raphael
+Moraug- Fury of Akoum,6,2025,2.2,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/4481eab8-9e7d-4db8-b1f2-fdf5ee1919a2.jpg?1783906037,Legendary Creature — Minotaur Warrior,Rudy Siswanto
+Mordant Dragon,6,2011,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b278baec-573a-4864-9bc5-4941ceb5adb2.jpg?1783941337,Creature — Dragon,Scott Chou
+Moria Marauder,2,2023,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/f/3/f33d5394-2248-4654-bec5-33b144752586.jpg?1783916282,Creature — Goblin Warrior,Andrea Piparo
+Mountain Goat,1,2023,10.92,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9dd3c43f-c5ff-42ee-a220-82aa7aef88e7.jpg?1783915184,Creature — Goat,John Darnielle
+Mudhole,3,2001,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/9/9/993d31bc-7355-4dfc-ac4e-ababaa0dc529.jpg?1783945227,Instant,Gary Ruddell
+Muxus- Goblin Grandee,6,2020,13.27,#ff1a1a,https://cards.scryfall.io/normal/front/2/c/2c716d10-2130-43b7-a939-349d437e1091.jpg?1783930502,Legendary Creature — Goblin Noble,Dmitry Burmak
+Myojin of Infinite Rage,10,2004,2.24,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df630ae9-aa17-46e9-95e7-4980f4a76ade.jpg?1783944297,Legendary Creature — Spirit,Kev Walker
+Myojin of Roaring Blades,8,2022,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b948181-4688-455c-97ae-990d0ec50f1d.jpg?1783923985,Legendary Creature — Spirit,Jason A. Engle
+Mysterious Stranger,4,2024,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/063ca0fa-1947-48da-86f9-76dd00dfb550.jpg?1783912403,Creature — Human Rogue,Xavier Ribeiro
+Mythos of Vadrok,4,2020,0.23,#d78f42,https://cards.scryfall.io/normal/front/2/b/2bbe99a7-3b58-4f23-bf86-e1e35b0bec2e.jpg?1783931047,Sorcery,Seb McKinnon
+Nahiri's Lithoforming,2,2020,0.73,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/06bb4bc1-6ef9-4015-9f5f-36f51dbac87e.jpg?1783929355,Sorcery,Campbell White
+Nahiri's Warcrafting,3,2023,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/a/0/a0453fea-3c88-4eb1-818a-9efa01986852.jpg?1783916985,Sorcery,Zara Alfonso
+Nahiri's Wrath,3,2016,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1e6cb8b0-e3a5-4a94-845d-3b286aa392ac.jpg?1783937457,Sorcery,Chris Rahn
+Najeela- the Blade-Blossom,3,2018,6.67,#d78f42,https://cards.scryfall.io/normal/front/2/c/2cb1d1da-6077-46b5-8c63-39882b8016f2.jpg?1783934856,Legendary Creature — Human Warrior,Matt Stewart
+Naktamun Lorespinner // Wheel of Fortune,3,2026,1.62,#ff1a1a,https://cards.scryfall.io/normal/front/a/c/acca1fd4-6384-460e-905f-118f01aa76ed.jpg?1783903856,Creature — Jackal Wizard // Sorcery,Ekaterina Burmak
+Nalathni Dragon,4,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/68005c8d-f047-4ee3-99cc-e7cd46feef60.jpg?1783910560,Creature — Dragon,Filip Burburan
+Nalfeshnee,6,2022,9.86,#ff1a1a,https://cards.scryfall.io/normal/front/b/7/b7717617-706a-4338-a207-dd8c08feb1c3.jpg?1783922503,Creature — Beast Demon,Sam White
+Need for Speed,1,2001,9.03,#ff1a1a,https://cards.scryfall.io/normal/front/8/4/8407b02f-66b3-4cfa-a3c4-105f314fd037.jpg?1783945226,Enchantment,Christopher Moeller
+Neheb- Dreadhorde Champion,4,2022,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a8cbc3ba-f552-43fd-a59b-f3d8e3edd12f.jpg?1783921424,Legendary Creature — Zombie Minotaur Warrior,Igor Kieryluk
+Neheb- the Eternal,5,2024,7.63,#ff1a1a,https://cards.scryfall.io/normal/front/7/6/767c5831-2195-4efa-802d-2ea2e6dabb5b.jpg?1783912998,Legendary Creature — Zombie Minotaur Warrior,Chris Rahn
+Nesting Dragon,5,2025,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/6/2/626db678-2dec-4026-af5a-83e834692ba0.jpg?1783907063,Creature — Dragon,Jehan Choo
+Nibelheim Aflame,4,2025,4.9,#ff1a1a,https://cards.scryfall.io/normal/front/3/d/3d3e926a-74af-4996-849f-d31e0fdedeae.jpg?1783906601,Sorcery,Arou
+Nico Minoru- Runaway,4,2026,37.0,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/89c21b09-8869-4d94-bf29-29c8d1c69d4f.jpg?1783903048,Legendary Creature — Human Warlock Hero,Carissa Susilo
+Nogi- Draco-Zealot,3,2025,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/86e576f2-8f9f-4bbf-85c4-b99ecb665412.jpg?1783907063,Legendary Creature — Kobold Shaman,Dmitry Burmak
+No Quarter,4,1997,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7c317ee7-ed92-4e3e-92bb-502099caccf8.jpg?1783946626,Enchantment,Doug Chaffee
+Norin the Wary,1,2006,21.71,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f61ea59a-1db0-4e6b-bcde-19787c76a49b.jpg?1783943219,Legendary Creature — Human Warrior,Heather Hudson
+Nova Chaser,4,2007,2.6,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/07f97507-abbe-4c8b-9683-f044e38f8d4b.jpg?1783942870,Creature — Elemental Warrior,Dan Murayama Scott
+Nova Flame,4,2026,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b5f713f-6ad9-445e-ae4c-56250bb3aecb.jpg?1783903280,Sorcery,Erikas Perl
+Nova Hellkite,5,2025,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/424af0d0-398c-4d78-9ad5-2171bf1bcbd1.jpg?1783905950,Creature — Dragon,Raymond Swanland
+Oath of Chandra,2,2016,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f570b0cb-2f38-422d-89d6-22c85e085328.jpg?1783937906,Legendary Enchantment,Wesley Burt
+Oath of Mages,2,1998,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/e/d/ed8708d2-2c73-4da5-b6ff-41c083b59caa.jpg?1783946510,Enchantment,Keith Parkinson
+Obliterate,8,2003,3.54,#ff1a1a,https://cards.scryfall.io/normal/front/c/8/c85f9623-5900-473c-a3b1-f98473b9a545.jpg?1783944712,Sorcery,Kev Walker
+Obsidian Charmaw,5,2021,1.63,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee6d08be-a6fc-44a5-932d-b6a8705534c0.jpg?1783926840,Creature — Dragon,Lucas Graciano
+Obsidian Fireheart,4,2017,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/49ef5a91-d293-468a-8816-b16ca4ba79e0.jpg?1783936149,Creature — Elemental,Raymond Swanland
+Obstinate Familiar,1,2001,0.7,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/88468a76-1f64-4189-bbb8-7c333181d57c.jpg?1783945225,Creature — Lizard,Terese Nielsen
+Ogre Arsonist,5,2013,0.8,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/474f4537-905d-44f2-bc69-1e94c6727ad1.jpg?1783940088,Creature — Ogre,Chris Rahn
+Ogre Battlecaster,3,2022,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/2/9/298f1ab2-4c66-4d91-8f6a-1bad230632df.jpg?1783919183,Creature — Ogre Shaman,Javier Charro
+Ogre Battledriver,4,2025,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/49998b89-61ae-4b10-903b-9eb24ce50d4b.jpg?1783907062,Creature — Ogre Warrior,Greg Staples
+Ogre Chitterlord,6,2023,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg?1783915039,Creature — Ogre Warrior,Piotr Foksowicz
+Ogre Enforcer,5,1997,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/b/0/b0f072d6-7489-4eb0-8c53-1fa42ad806a4.jpg?1783946987,Creature — Ogre,Pete Venters
+Ogre-Head Helm,2,2022,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3a0d5f7d-4e8a-42ad-8875-610004bd9796.jpg?1783923863,Artifact Creature — Equipment Ogre,Viko Menezes
+Ojer Axonil- Deepest Might // Temple of Power,4,2023,22.97,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Land,Victor Adame Minguez
+Okaun- Eye of Chaos,5,2018,2.96,#ff1a1a,https://cards.scryfall.io/normal/front/d/5/d53ee8c0-b27c-4556-b610-ff64edb7a18f.jpg?1783934878,Legendary Creature — Cyclops Berserker,Yongjae Choi
+Okk,2,2003,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/42641800-e209-4326-ae28-77ec83ac4b75.jpg?1783944711,Creature — Goblin,Peter Bollinger
+Olivia's Attendants,6,2021,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d9702fa3-9323-4e2f-92c9-6c31df198af2.jpg?1783924826,Creature — Vampire,Dmitry Burmak
+Omen of Fire,5,1996,1.14,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9c724b46-6e17-4bee-9bc6-e9fc5a379dd7.jpg?1783947176,Instant,Pete Venters
+Omniclown Colossus // Pie-roclasm,10,2022,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/2/0/209db1d7-844a-4eee-bdf2-319741f4cefe.jpg?1783920564,Artifact Creature — Clown Robot // Sorcery — Adventure,Ralph Horsley
+Opening Ceremony,6,2022,0.33,#d78f42,https://cards.scryfall.io/normal/front/1/7/1725526f-9a18-4cbd-83cf-16334aa56e76.jpg?1783920563,Sorcery,Greg Bobrowski
+Opportunistic Dragon,4,2025,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/e/a/eac89f5e-6331-4f4a-b0b4-bc9c57f8b892.jpg?1783907061,Creature — Dragon,Chris Rahn
+Oracle of Bones,4,2014,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/ddb1931e-c282-47a7-9382-608de6ec8efa.jpg?1783939544,Creature — Minotaur Shaman,Greg Staples
+Orb of Dragonkind,2,2021,2.2,#ff1a1a,https://cards.scryfall.io/normal/front/9/a/9a1c2cdd-353c-4747-bf0e-b995dd37ffca.jpg?1783926473,Artifact,Brian Valeza
+Orcish Librarian,2,1995,0.86,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8ed908d6-6d06-4ccb-9577-37ef2d01c1a5.jpg?1783947484,Creature — Orc,Phil Foglio
+Orcish Lumberjack,1,2025,12.17,#d78f42,https://cards.scryfall.io/normal/front/1/a/1ab1820e-7567-4742-be8a-9961d80ae51f.jpg?1783906665,Creature — Orc,Phil Foglio
+Orcish Siegemaster,3,2023,0.69,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1e9f9869-0f43-4eac-892f-26cd8a614330.jpg?1783916028,Creature — Orc Soldier,Anton Solovianchyk
+Ore-Rich Stalactite // Cosmium Catalyst,2,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact // Artifact,Tomek Larek
+Orgg,5,1997,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/c/7/c7eef087-8500-4fca-a10a-ff65d348bcb1.jpg?1783946905,Creature — Orgg,Daniel Gelon
+Orthion- Hero of Lavabrink,4,2023,4.76,#ff1a1a,https://cards.scryfall.io/normal/front/7/1/71dadbb3-7b8a-4656-973f-65a3284afe07.jpg?1783916901,Legendary Creature — Human Soldier,Aaron Miller
+Outpost Siege,4,2022,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a9f75fce-f0a1-4dec-982d-a86925c6e9d4.jpg?1783922418,Enchantment,Daarken
+Overclocked Electromancer,3,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/2/6/2670583a-bbd9-4e99-86d9-97e06227dc2a.jpg?1783911421,Creature — Lizard Wizard,Brent Hollowell
+Overlord of the Boilerbilges,6,2024,1.35,#ff1a1a,https://cards.scryfall.io/normal/front/d/5/d58d3545-043a-457a-8324-facc3c2363ec.jpg?1783909466,Enchantment Creature — Avatar Horror,Helge C. Balzer
+Overmaster,1,2023,2.99,#ff1a1a,https://cards.scryfall.io/normal/front/2/8/28e812a8-66cf-4005-a647-780d49aa74a4.jpg?1783918457,Sorcery,Chris Seaman
+Over the Top,7,2022,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/0/1/01eb9702-55c5-41b2-8bef-63d33dafa599.jpg?1783920066,Sorcery,Cristi Balanescu
+Overwhelming Victory,5,2025,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/498b0bff-28f2-458f-844b-13814cfa8b14.jpg?1783904818,Instant — Lesson,Joshua Raphael
+Ox of Agonas,5,2022,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/00c46d18-064e-403a-bf39-ec655d78390a.jpg?1783923956,Creature — Ox,Lie Setiawan
+Pact of the Titan,0,2021,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/4/6/4612effe-8ca2-4c27-90d2-d9255acc80d9.jpg?1783927792,Instant,Raymond Swanland
+Pain Distributor,3,2023,4.81,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3a3a0170-444e-4147-96b6-b14bb5649108.jpg?1783917281,Creature — Devil Citizen,Olivier Bernard
+Pain for All,3,2025,0.67,#ff1a1a,https://cards.scryfall.io/normal/front/d/2/d2948913-817b-4715-92d5-ed3cde347be7.jpg?1783905949,Enchantment — Aura,Dmitry Burmak
+Pallimud,3,1997,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/61adc314-cfb2-4fdd-925c-cc1dc4692992.jpg?1783946626,Creature — Beast,Quinton Hoover
+Parallectric Feedback,4,2006,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/891f1d29-377a-4f71-917f-ff10e785caee.jpg?1783943499,Instant,Mitch Cotie
+Parapet Thrasher,4,2025,1.1,#ff1a1a,https://cards.scryfall.io/normal/front/6/d/6d3ba135-e8d6-443a-952b-5c93edb4523c.jpg?1783907173,Creature — Dragon,Cristi Balanescu
+Pardic Dragon,6,2006,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/a/d/ad47d954-dda8-412a-b69b-a213bbd2f309.jpg?1783943217,Creature — Dragon,Zoltan Boros & Gabor Szikszai
+Pardic Miner,2,2001,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4a734abe-7bfd-4153-be2d-1c289fb60996.jpg?1783945226,Creature — Dwarf,Tony Szczudlo
+Party Thrasher,2,2024,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/b/7/b7f8bb8d-c46a-4531-9525-6981a222b468.jpg?1783911269,Creature — Lizard Wizard,Leanna Crossan
+Pashalik Mons,3,2023,2.66,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca20a650-65b0-4714-b7ce-0481af3db377.jpg?1783918458,Legendary Creature — Goblin Warrior,Dave Kendall
+Past in Flames,4,2017,4.21,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b7472f4-37b0-439f-b4ac-80706d40d191.jpg?1783936642,Sorcery,Anna Steinbauer
+Path of the Pyromancer,5,2023,3.97,#ff1a1a,https://cards.scryfall.io/normal/front/4/e/4eeaf326-4521-4508-8032-627677a82dd4.jpg?1783917281,Sorcery,Dominik Mayer
+Patron of the Akki,6,2005,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/18325283-ace8-414b-bf48-2ed36b5a9c24.jpg?1783944187,Legendary Creature — Spirit,Jim Nelson
+Petradon,8,2002,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/7/5/75ac6311-8516-4db2-8c1f-626f0db0d36f.jpg?1783945146,Creature — Nightmare Beast,Jim Nelson
+Phoenix of Ash,3,2020,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/7010ce26-16de-44cb-ba7e-3d904175b429.jpg?1783931546,Creature — Phoenix,Svetlin Velinov
+Photon- Mighty Marvel,4,2026,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b164aca-2bda-49a6-81ce-16ef4721ec63.jpg?1783903281,Legendary Creature — Human Hero,Tran Nguyen
+Pia and Kiran Nalaar,4,2023,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/5/a/5aab5a55-0aee-4d8e-92b7-92b057a00509.jpg?1783917144,Legendary Creature — Human Artificer,Eric Deschamps
+Pia Nalaar,3,2021,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9d2502c8-bf80-404c-9a9a-b843d355fcaa.jpg?1783927540,Legendary Creature — Human Artificer,Tyler Jacobson
+Pia's Revolution,3,2017,0.46,#ff1a1a,https://cards.scryfall.io/normal/front/5/1/51da6ff6-4d81-488e-83ff-8758f6c7bb9f.jpg?1783936751,Enchantment,Clint Cearley
+Pick Up the Pace,2,2026,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/5/5/55332b21-32ab-43dd-8046-9568e2dba6ac.jpg?1783903046,Enchantment,Irvin Rodriguez
+Pillaging Horde,4,1997,0.57,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1daad744-e6b2-4bd8-83df-2e97e9e60d16.jpg?1783946813,Creature — Human Barbarian,Kev Walker
+Planebound Accomplice,3,2019,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85fb9418-a22b-4f92-b494-f68c29bcb92a.jpg?1783933107,Creature — Human Wizard,Paul Scott Canavan
+Planeswalker's Fury,3,2001,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/6/f/6fa09e3a-bc7e-4292-aa5d-ce97c1b1f79f.jpg?1783945615,Enchantment,Christopher Moeller
+Planetary Annihilation,5,2025,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/8/6/8695796f-b6ed-46db-b1b8-07ed0cc5a5e5.jpg?1783906064,Sorcery,Cristi Balanescu
+Plargg and Nassari,5,2026,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e66ee7c6-23bc-4fef-a566-35aee2064bd9.jpg?1783903772,Legendary Creature — Orc Efreet,Yigit Koroglu
+Plargg- Dean of Chaos // Augusta- Dean of Order,2,2021,0.35,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Orc Shaman // Legendary Creature — Human Cleric,Bryan Sola
+Plasma Caster,2,2024,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/c/1/c1654256-25ea-4467-812d-25f32fe65cdd.jpg?1783912403,Artifact — Equipment,Kekai Kotaki
+Poetic Ingenuity,3,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg?1783913756,Enchantment,Kieran Yanner
+Popular Entertainer,2,2022,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/9/1/91844266-8b2f-421f-a944-544c51734e64.jpg?1783922731,Legendary Enchantment — Background,Zoltan Boros
+Port Razer,5,2023,1.12,#ff1a1a,https://cards.scryfall.io/normal/front/e/b/eb32429a-7ef9-418f-baf8-fed9aa010c9e.jpg?1783913863,Creature — Orc Pirate,Craig J Spearing
+Possessed Barbarian,4,2002,0.35,#d78f42,https://cards.scryfall.io/normal/front/5/7/57e79610-8cfe-4711-bc71-8c25d68036da.jpg?1783945145,Creature — Human Barbarian Horror,Scott M. Fischer
+Possibility Storm,5,2013,2.58,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/858aa831-b491-4f1e-bb56-33eeca14771d.jpg?1783940037,Enchantment,Jason Felix
+Possibility Technician,3,2025,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b146c78-403f-48c8-941d-41114498bb89.jpg?1783905949,Creature — Kavu Artificer,Antonio José Manzanedo
+Powder Ganger,3,2024,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7bb57c73-a454-450d-9db9-67501bf4559d.jpg?1783912402,Creature — Human Rogue,Fesbra
+Powerbalance,2,2024,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/aff7c0bb-1210-4aeb-b5f8-1387eb633b0f.jpg?1783911268,Enchantment,Steve Ellis
+Power Surge,2,1995,1.06,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0b5717af-a1a3-45cb-8b05-7543eed5532a.jpg?1783947825,Enchantment,Douglas Shuler
+Predator Dragon,6,2008,0.58,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg?1783942559,Creature — Dragon,Raymond Swanland
+Preyseizer Dragon,6,2016,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/4/6/468534eb-b6fb-4141-9260-c0c7b43480b9.jpg?1783936832,Creature — Dragon,Daarken
+Price of Progress,2,2024,15.03,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c90e3fd0-c6a9-493c-83b2-9386245c4cbe.jpg?1783913085,Instant,Alexander Khabbazi
+Prismari Pianist,3,2026,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/7/e/7e3e5990-ad48-4be2-af8a-4ff77177758d.jpg?1783903854,Creature — Djinn Bard,Izzy
+Prisoner's Dilemma,5,2024,5.98,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d678e736-7c29-433a-9a2a-b78749252377.jpg?1783913044,Sorcery,Serena Malyon
+Professional Face-Breaker,3,2022,5.69,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/42acbf52-b137-44f0-a815-2817fe8d2da2.jpg?1783923119,Creature — Human Warrior,Dan Murayama Scott
+Prophetic Flamespeaker,3,2014,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/7/3/73326c79-f884-42d5-8546-3db46ce4fe52.jpg?1783939422,Creature — Human Shaman,Cynthia Sheppard
+Prosperous Bandit,3,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6b3a7194-25e8-4639-a490-96e9cfce0f84.jpg?1783910731,Creature — Raccoon Rogue,Yohann Schepacz
+Pulse of the Forge,3,2004,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/e/a/ea3ed9c8-b552-4a9a-b77a-8b148638b4f0.jpg?1783944438,Instant,Paolo Parente
+Pulverize,6,1999,1.12,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/afbbc44d-60fb-45fc-a588-14aab0340134.jpg?1783945934,Sorcery,Scott M. Fischer
+Pumpkin Bombs,2,2025,1.69,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6e9a83b6-2881-4ba3-96d4-0fd89110837d.jpg?1783905367,Artifact,Dan Dos Santos
+Puppet Master- String Puller,3,2026,0.91,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/ab888daa-1161-4917-bca0-efd5c430b2d9.jpg?1783903279,Legendary Creature — Human Artificer Villain,John Tyler Christopher
+Puppet's Verdict,3,1999,4.52,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/052b743a-456d-49c3-881e-4f30c7645fa5.jpg?1783945934,Instant,Edward P. Beard, Jr.
+Purphoros- Bronze-Blooded,5,2020,4.76,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/af3af5c4-0960-44a2-976e-abdf7803c436.jpg?1783931548,Legendary Enchantment Creature — God,Eric Deschamps
+Purphoros- God of the Forge,4,2023,31.65,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/4736a2c4-c89c-48db-a104-6303e7e2eee8.jpg?1783915646,Legendary Enchantment Creature — God,Eric Deschamps
+Purphoros's Intervention,1,2020,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/e/c/ecc911ee-0e12-4b10-add7-9a9d63c29443.jpg?1783931547,Sorcery,Aleksi Briclot
+Pyreswipe Hawk,5,2024,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0cf88f89-9490-4477-b632-85c513e8c749.jpg?1783910729,Creature — Elemental Bird,Jorge Jacinto
+Pyretic Charge,5,2024,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/d/c/dc7a4733-63d9-4b47-8a2e-85d30fe82569.jpg?1783911965,Sorcery,Slawomir Maniak
+Pyretic Ritual,2,2026,4.75,#ff1a1a,https://cards.scryfall.io/normal/front/e/4/e4507ef5-0d30-42ca-b305-f99c6e10432b.jpg?1783903920,Instant,Justin Hernandez & Alexis Hernandez
+Pyrewild Shaman,3,2013,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/8/c/8c6f6e45-f613-420d-83d2-d93c643265ee.jpg?1783940037,Creature — Goblin Shaman,Lucas Graciano
+Pyroblast,1,2023,16.43,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1ab85094-710e-4529-a69c-a678af5389a9.jpg?1783915138,Instant,Takuma Ebisu
+Pyroclasm,2,1997,9.48,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/de214247-e5e3-4d8f-935a-797218416be1.jpg?1783946813,Sorcery,John Matson
+Pyrohemia,4,2025,9.82,#ff1a1a,https://cards.scryfall.io/normal/front/7/5/75fb5cb6-e8ab-4fd5-a1f3-985de4fda226.jpg?1783905136,Enchantment,Chris Rallis
+Pyrokinesis,6,2016,4.19,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/25f98f02-9ada-4561-93fd-9cfcb0f48b5d.jpg?1783937575,Instant,Igor Kieryluk
+Pyromancer Ascension,2,2017,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/0/f/0f9cea68-4390-4d73-a374-d6299cbc9271.jpg?1783936641,Enchantment,Kev Walker
+Pyromancer's Swath,3,2013,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b2ee7137-dbc4-4fe5-802a-42dada4445db.jpg?1783939980,Enchantment,Hideaki Takamura
+Pyromancy,4,1999,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/35a91a58-cc8b-47a3-8c53-43c32753a00d.jpg?1783946233,Enchantment,Quinton Hoover
+Pyrotechnic Performer,2,2024,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/0/f/0fa5671b-2651-4944-a50a-c768ec70229e.jpg?1783912874,Creature — Lizard Assassin,Peter Polach
+Quakebringer,5,2021,1.66,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c5bbffb9-1f1c-40e5-97f4-29bf1fc68625.jpg?1783928225,Creature — Giant Berserker,Lucas Graciano
+Quarum Trench Gnomes,4,1994,13.07,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1c3b33bf-3074-406e-86f3-2a9843cf4862.jpg?1783948053,Creature — Gnome,Dan Frazier
+Quicksilver- Brash Blur,1,2026,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/2/d/2d5819ca-165d-4f4c-9500-3ac206994880.jpg?1783902925,Legendary Creature — Mutant Hero,Michael MacRae
+Quicksmith Rebel,4,2017,0.1,#ff1a1a,https://cards.scryfall.io/normal/front/2/d/2d5f9755-b137-439c-9b54-1ad71ec1f9ec.jpg?1783936750,Creature — Human Artificer,Kieran Yanner
+Radha's Firebrand,2,2022,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/ae8a90c4-4a79-49e7-9fab-076b35d28adb.jpg?1783921311,Creature — Human Warrior,Ângelo Bortolini
+Radiant Flames,3,2022,0.11,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e80455ca-f23c-44da-b191-c3b12a9c546f.jpg?1783921424,Sorcery,Slawomir Maniak
+Radiant Performer,5,2021,0.75,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e8faedf4-1178-4f5d-8f46-7277dfe1ae2c.jpg?1783927591,Creature — Human Wizard,Alessandra Pisano
+Radiate,5,2002,4.71,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/2562c25a-999e-4fb5-a595-f376c8abf1ff.jpg?1783945145,Instant,Carl Critchlow
+Ragavan- Nimble Pilferer,1,2021,43.47,#ff1a1a,https://cards.scryfall.io/normal/front/a/9/a9738cda-adb1-47fb-9f4c-ecd930228c4d.jpg?1783926839,Legendary Creature — Monkey Pirate,Simon Dominic
+Rageblood Shaman,3,2020,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/568a31c0-799b-48b6-a91c-95d176b22670.jpg?1783930379,Creature — Minotaur Shaman,Mike Bierek
+Ragefire Hellkite,6,2022,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/23ccd68d-0162-4a4c-892e-1726b8b28612.jpg?1783921243,Creature — Dragon,Xavier Ribeiro
+Rage Nimbus,3,2010,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7c213b45-d86b-4ced-9ab9-44cd84ad94a4.jpg?1783941971,Creature — Elemental,Vincent Proce
+Rage Reflection,6,2020,1.55,#ff1a1a,https://cards.scryfall.io/normal/front/b/7/b767e176-1df5-4adc-bf6b-418d71b4dbbe.jpg?1783930161,Enchantment,Chris Seaman
+Raging Battle Mouse,2,2023,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg?1783915090,Creature — Mouse,Rudy Siswanto
+Raging River,2,1993,159.01,#ff1a1a,https://cards.scryfall.io/normal/front/7/e/7ee63877-056e-413d-932a-a393a4183686.jpg?1783948554,Enchantment,Sandra Everingham
+Rain of Riches,5,2024,1.56,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d633a188-f533-4d28-b3f0-a19f4d78cc40.jpg?1783911917,Enchantment,Evyn Fong
+Rakavolver,3,2001,0.34,#d78f42,https://cards.scryfall.io/normal/front/4/3/43787e24-0b7d-4005-8db4-68544476bd34.jpg?1783945342,Creature — Volver,Scott M. Fischer
+Rakdos Pit Dragon,4,2014,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/b/f/bff6c92f-e7c5-43d2-999c-d48b1ad2492a.jpg?1783938738,Creature — Dragon,Kev Walker
+Rakka Mar,4,2009,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/5/d/5d569b01-af52-41a6-9ce4-02ed2e057038.jpg?1783942477,Legendary Creature — Human Shaman,Jason Chan
+Rally the Horde,6,2005,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b292a8d2-44b1-4c20-8035-0f5912cc09a4.jpg?1783944145,Sorcery,Paolo Parente
+Ral- Monsoon Mage // Ral- Leyline Prodigy,2,2024,6.56,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Wizard // Legendary Planeswalker — Ral,Dmitry Burmak
+Rampaging Ferocidon,3,2024,3.12,#ff1a1a,https://cards.scryfall.io/normal/front/5/3/53c38f4e-81ec-45b3-a6cf-06a65b674978.jpg?1783909611,Creature — Dinosaur,Jonathan Kuo
+Rampaging Raptor,4,2023,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/64b80ddb-ce55-4ebc-b587-77843abc8bad.jpg?1783916985,Creature — Dinosaur,Denys Tsiperko
+Rampaging War Mammoth,7,2023,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/d/c/dc13dbf0-c0ff-4c76-96c6-d3ee88ab2fce.jpg?1783916027,Creature — Elephant,Simon Dominic
+Ran and Shaw,5,2025,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/6436e2d0-989f-47e3-90bc-9cde82a2ddb4.jpg?1783904952,Legendary Creature — Dragon,Miho Midorikawa
+Raphael- Ninja Destroyer,4,2026,1.15,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/eeffadda-cb71-4434-89bf-36db1a36da0b.jpg?1783904092,Legendary Creature — Mutant Ninja Turtle,Fajareka Setiawan
+Raphael's Technique,6,2026,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7ce8b00f-5a4f-4206-8eb3-e79308e91f47.jpg?1783904092,Instant,Andreas Zafiratos
+Raphael- Tag Team Tough,6,2026,5.98,#ff1a1a,https://cards.scryfall.io/normal/front/b/3/b3bae5c7-2c4a-42a6-a108-3f23d70204b4.jpg?1783904135,Legendary Creature — Mutant Ninja Turtle,Randy Vargas
+Raphael- the Muscle,5,2026,1.71,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bccdd54c-e64b-44d2-87b3-e80029672529.jpg?1783904174,Legendary Creature — Mutant Ninja Turtle,Ryan Pancoast
+Raphael- the Nightwatcher,4,2026,1.02,#ff1a1a,https://cards.scryfall.io/normal/front/6/a/6af50b50-3776-4383-b493-7c5dd732c965.jpg?1783904093,Legendary Creature — Mutant Ninja Turtle,Greg Staples
+Raubahn- Bull of Ala Mhigo,2,2025,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/7035d11b-525f-4120-8dcb-610095196681.jpg?1783906599,Legendary Creature — Human Warrior,Julia Vasilyeva
+Ravenous Baboons,4,1998,2.56,#ff1a1a,https://cards.scryfall.io/normal/front/6/d/6d00b68b-8b6a-48c9-8911-2a3270897091.jpg?1783946509,Creature — Monkey,Daren Bader
+Ravenous Robots,2,2026,1.88,#ff1a1a,https://cards.scryfall.io/normal/front/3/b/3b303ea3-9f4d-4c28-9446-285a23f841a0.jpg?1783904091,Artifact Creature — Robot,Kevin Sidharta
+Razorkin Needlehead,2,2024,4.89,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bc73b963-23c0-46d2-853a-34a8b463994e.jpg?1783909463,Creature — Human Assassin,Riccardo Federici
+Reality Scramble,4,2018,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/3/4/34337c23-5dad-4ea3-84e9-aae7e34b2b17.jpg?1783934336,Sorcery,Simon Dominic
+Realm-Scorcher Hellkite,6,2023,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg?1783915090,Creature — Dragon,Billy Christian
+Reckless Blaze,5,2025,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/82c686f9-b403-4ab2-af5d-cf586e18ecf5.jpg?1783904817,Sorcery — Lesson,NIJIMAARC
+Reckless Crew,4,2021,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bdd68d9d-b0b9-4915-8a12-658eb0e3dd4a.jpg?1783928224,Sorcery,Izzy
+Reckless Embermage,4,2001,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/b/0/b0f75ed4-b96c-444b-ac91-8aaa02f32f2d.jpg?1783945450,Creature — Human Wizard,Bob Petillo
+Reckless Endeavor,7,2021,10.23,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/ba98a4bd-e217-4dba-aee9-315b4f843cdf.jpg?1783926245,Sorcery,Billy Christian
+Reckless Stormseeker // Storm-Charged Slasher,3,2021,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Manuel Castañón
+Redcap Gutter-Dweller,4,2024,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/c/6/c6c7f55a-bcc7-4ca3-853d-fc6e260d9429.jpg?1783908920,Creature — Goblin Warrior,Alexey Kruglov
+Redirect Lightning,1,2025,9.32,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b5b14a7-1fdd-4efc-b197-cadfa7f7c860.jpg?1783904953,Instant — Lesson,Toni Infante
+Redoubled Stormsinger,3,2026,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/f/c/fc5fcb5e-091e-4f47-9c74-9e187a9e0e5d.jpg?1783903772,Creature — Orc Wizard,Filipe Pagliuso
+Red Sun's Twilight,2,2023,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7cac1827-69af-469d-b88c-fb9f2f33866a.jpg?1783918024,Sorcery,Julian Kok Joon Wen
+Red Sun's Zenith,1,2011,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/3/7/373eb109-0e30-41c1-b2df-6bc78d968890.jpg?1783941377,Sorcery,Svetlin Velinov
+Reforge the Soul,5,2025,6.92,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1c3509c6-2ae7-45be-8ac9-4d14d69db32f.jpg?1783908117,Sorcery,Jaime Jones
+Reiterate,3,2021,19.29,#ff1a1a,https://cards.scryfall.io/normal/front/9/9/99302c41-434f-41ff-a61a-2c3681a0c135.jpg?1783927791,Instant,Dan Murayama Scott
+Rekindled Flame,4,2008,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/1/3/131c6377-4ed4-4a76-a9cb-be7ad17d76fd.jpg?1783942682,Sorcery,Zoltan Boros & Gabor Szikszai
+Rekindling Phoenix,4,2022,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/1/a/1a9945ec-0996-434e-b177-97203eabaf24.jpg?1783923258,Creature — Phoenix,Jason Rainville
+Release the Gremlins,1,2017,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/d/4/d4ba75be-2428-45aa-bf02-75c379a5dfa2.jpg?1783936750,Sorcery,Izzy
+Relentless Assault,4,2020,4.61,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/97622209-9357-4347-8961-f77f8d2389d8.jpg?1783928712,Sorcery,Christopher Moeller
+Relic Retriever,2,2026,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/a/0/a016463d-a0aa-44a5-97ca-17ff70c4eb95.jpg?1783903853,Creature — Spirit Monkey,Aldo Domínguez
+Relic Robber,3,2020,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/4/5/4540205c-eee8-4db3-8757-710de874b313.jpg?1783929355,Creature — Goblin Rogue,Slawomir Maniak
+Rending Volley,1,2025,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/2/6/26f073a7-e4a7-4b2a-a768-f649fe337f2d.jpg?1783904851,Instant,Viacom
+Renegade Bull,5,2026,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aa23e922-f44b-4af8-8ce0-bc1bc1e65bad.jpg?1783903855,Creature — Ox,Adrián Rodríguez Pérez
+Repeated Reverberation,4,2023,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/1/c/1cb03593-9369-4c26-bfcc-8819648dc018.jpg?1783915431,Instant,Izzy
+Repeating Barrage,3,2017,0.1,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/ba90a2d6-8292-4ff1-91d0-b30ae9775f12.jpg?1783935741,Sorcery,Dan Murayama Scott
+Repercussion,3,1999,10.68,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d0f3c78e-16c0-4fbc-8ef4-fbf610f9d464.jpg?1783946065,Enchantment,Michael Sutfin
+Retriever Phoenix,4,2021,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4dd6cb53-3c82-4ac3-be1e-311322729198.jpg?1783927349,Creature — Phoenix,Karl Kopinski
+Return the Favor,2,2026,11.0,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bb224f6f-1da9-4090-a609-a4cd50740348.jpg?1783903500,Instant,Karuta Shiki
+Return the Past,6,2023,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/7/4/74de4341-d10a-47c6-8a60-9dfa491f1d02.jpg?1783914649,Enchantment,Irina Nordsol
+Reverberate,2,2012,2.94,#ff1a1a,https://cards.scryfall.io/normal/front/5/9/5996feb4-02ac-45e8-a7f2-966cf74391dc.jpg?1783940482,Instant,jD
+Reversal of Fortune,6,2004,3.93,#ff1a1a,https://cards.scryfall.io/normal/front/1/9/19cf87c0-369e-4ec2-bb9f-e8e29d63d448.jpg?1783944392,Sorcery,Greg Hildebrandt
+Rhuk- Hexgold Nabber,3,2023,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/d/7/d7c25806-1da6-4789-a17e-d2440184ec40.jpg?1783917920,Legendary Creature — Goblin Rebel,Andrea De Dominicis
+Riders of the Mark,7,2023,8.51,#ff1a1a,https://cards.scryfall.io/normal/front/d/e/de77686e-c4c1-4d38-a05c-03eb7363fc0b.jpg?1783913966,Creature — Human Knight,Antonio José Manzanedo
+Rift Bolt,3,2025,2.27,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b07edb8-4ba9-44b4-a8c7-da0447e4d1b9.jpg?1783906751,Sorcery,Deb JJ Lee
+Rimescale Dragon,7,2006,3.13,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/113d0342-0ba2-46b0-bda5-6a9fe4dcad3e.jpg?1783943335,Snow Creature — Dragon,Jeff Easley
+Rionya- Fire Dancer,5,2026,0.57,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/086e68b5-0f89-46d0-9a04-7f8658a9ab53.jpg?1783903772,Legendary Creature — Human Wizard,Heonhwa
+Risk Factor,3,2018,0.55,#ff1a1a,https://cards.scryfall.io/normal/front/4/e/4eda89d9-9bd1-4a55-ac02-f9a0625d8e5b.jpg?1783934160,Instant,Chris Seaman
+Risky Move,6,2002,1.26,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0b09315c-d6ff-4fdb-8774-c6402b45e959.jpg?1783945050,Enchantment,Jerry Tiritilli
+Rite of Flame,1,2025,7.35,#ff1a1a,https://cards.scryfall.io/normal/front/6/7/67dd3d5d-b200-4228-b72b-285b74eda569.jpg?1783905137,Sorcery,Johan Grenier
+Rite of Ruin,7,2012,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/89e7fec3-94b5-411e-aeb0-44a64f517986.jpg?1783940677,Sorcery,Clint Cearley
+Rite of the Dragoncaller,6,2024,3.5,#ff1a1a,https://cards.scryfall.io/normal/front/6/7/673e4561-8dfd-46db-b492-878009666ac7.jpg?1783909102,Enchantment,PINDURSKI
+Rivalry,3,1999,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/3/b/3b79677b-d5b9-47c7-a5f5-45446d5cddff.jpg?1783946233,Enchantment,Brian Snõddy
+Rix Maadi Reveler,2,2019,0.24,#d78f42,https://cards.scryfall.io/normal/front/c/4/c40396da-18e2-42ca-a78c-4838a38f68b8.jpg?1783933679,Creature — Human Shaman,Sara Winters
+RMS Titanic,4,2023,5.69,#ff1a1a,https://cards.scryfall.io/normal/front/3/f/3f5bcf60-f956-4e0d-beb7-a7f5c1c83692.jpg?1783914649,Legendary Artifact — Vehicle,Henry Peters
+Roar of Resistance,2,2023,1.76,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f5eb9570-6203-4a03-9a3e-e5c679df5903.jpg?1783918159,Enchantment,Lie Setiawan
+Robber of the Rich,2,2019,1.44,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0ecbe097-ba51-42e5-957c-382eb66c08f0.jpg?1783932619,Creature — Human Archer Rogue,Paul Scott Canavan
+Rockshard Elemental,7,2003,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/2/d/2d6343c0-3fb5-4bac-bea7-cba36498cd69.jpg?1783944904,Creature — Elemental,Anthony S. Waters
+Rograkh- Son of Rohgahh,0,2025,222.67,#ff1a1a,https://cards.scryfall.io/normal/front/0/5/05e9d580-5da2-4559-b611-870726c53791.jpg?1783906658,Legendary Creature — Kobold Warrior,Square Enix
+Roiling Vortex,2,2020,1.58,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0b057eb7-8439-4d26-89df-c345ab2773e1.jpg?1783929353,Enchantment,Campbell White
+Rolling Earthquake,1,2020,2.89,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69ab37d4-6ba3-404a-8162-f207874738ea.jpg?1783930157,Sorcery,Yang Hong
+Rorix Bladewing,6,2016,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/8/f/8f2e7e50-e0b7-474b-a07d-35071011a70c.jpg?1783937575,Legendary Creature — Dragon,Clint Cearley
+Rose- Cutthroat Raider,4,2024,2.16,#ff1a1a,https://cards.scryfall.io/normal/front/f/8/f803a510-99fe-467a-be3b-9301497ec7ec.jpg?1783912401,Legendary Artifact Creature — Robot,Zezhou Chen
+Rose Room Treasurer,4,2022,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/2/1/2167439d-792d-471e-9137-ee46dbf7a82d.jpg?1783923359,Creature — Ogre Warrior,David Sladek
+Rosnakht- Heir of Rohgahh,1,2022,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/0/1/013e33d4-7d08-4773-a570-469ae3cf92f2.jpg?1783921468,Legendary Creature — Kobold Warrior,Chris Seaman
+Rotisserie Elemental,1,2023,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg?1783915089,Creature — Elemental,Leonardo Santanna
+Rousing Refrain,5,2026,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b3ec666-0e57-4c42-872c-51799e0b5c68.jpg?1783903772,Sorcery,Izzy
+Rowan- Fearless Sparkmage,5,2019,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/0/3/030f4058-54e5-4333-bd6c-2789c334bf12.jpg?1783932556,Legendary Planeswalker — Rowan,Zack Stella
+Rowan Kenrith,6,2022,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bcf0514e-63b3-4695-93ae-527524d48c25.jpg?1783922419,Legendary Planeswalker — Rowan,Anna Steinbauer
+Rowan- Scholar of Sparks // Will- Scholar of Frost,3,2021,1.97,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Planeswalker — Rowan // Legendary Planeswalker — Will,Magali Villeneuve
+Rowan's Stalwarts,5,2019,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b537c4e3-88d1-430d-b4c8-16e0716d1927.jpg?1783932555,Creature — Human Knight,Deruchenko Alexander
+Rowan's Talent,4,2023,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/4/3/43e4ca86-0ba5-457c-bd18-9c4cc63e47d3.jpg?1783917246,Enchantment — Aura,Pauline Voss
+Rowdy Crew,4,2017,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/b/d/bdb3821a-ecc8-478d-93de-57200476868c.jpg?1783935739,Creature — Human Pirate,Steve Prescott
+Ruby Leech,2,2000,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/be621b12-4f4e-43a6-b65e-da4223e742b5.jpg?1783945682,Creature — Leech,Jacques Bredy
+Ruination,4,2011,4.43,#ff1a1a,https://cards.scryfall.io/normal/front/6/3/6330d925-96a8-47e1-855d-035ddc2af709.jpg?1783941204,Sorcery,Dermot Power
+Ruin Grinder,6,2021,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/56dd8c18-052b-4684-8ffa-f7d49af25759.jpg?1783927591,Artifact Creature — Construct,Hector Ortiz
+Rukh Egg,4,2005,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/e/4/e4bfc662-edfb-43ff-8022-1db971b1de22.jpg?1783943951,Creature — Bird Egg,Mark Zug
+Rumbling Crescendo,5,1998,0.66,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/ddf267c2-c3d5-48ba-93af-dd0af133add3.jpg?1783946325,Enchantment,Lawrence Snelly
+Runaway Steam-Kin,2,2018,1.48,#ff1a1a,https://cards.scryfall.io/normal/front/d/8/d8c9c111-fbc7-44e1-94bd-1ca164370623.jpg?1783934158,Creature — Elemental,Jason Felix
+Rundvelt Hordemaster,2,2022,2.02,#ff1a1a,https://cards.scryfall.io/normal/front/f/f/ffee9dbe-af90-4e19-844d-4df1180f24c4.jpg?1783921311,Creature — Goblin Warrior,Bruno Biazotto
+Runehorn Hellkite,6,2016,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f5fd8668-900c-48d1-aac3-8355cfc0bb74.jpg?1783937087,Creature — Dragon,Karl Kopinski
+Rust Harvester,1,2025,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7ce58765-d2f4-4fbf-8635-580c9400ff2e.jpg?1783905947,Artifact Creature — Robot,Jake Murray
+Ryan Sinclair,3,2023,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/42684d97-fce6-4a96-9c64-20e2cb382dca.jpg?1783914647,Legendary Creature — Human,Kim Sokol
+Ryusei- the Falling Star,6,2022,1.54,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a.jpg?1783922416,Legendary Creature — Dragon Spirit,Grzegorz Rutkowski
+Sabin- Master Monk,5,2025,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/4/3/43bacd07-fdaf-4ce4-bf7a-dda55a99d460.jpg?1783906355,Legendary Creature — Human Noble Monk,Kevin Glint
+Saheeli's Directive,3,2018,1.05,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/494c32ef-6fce-4330-9e34-a68497ae865e.jpg?1783934337,Sorcery,Craig J Spearing
+Sandstorm Crasher,4,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2bcf1ed6-5e5b-4035-9d21-f84ac4fc4fbd.jpg?1783908865,Creature — Minotaur Berserker Wizard,Néstor Ossandón Leal
+Sardian Avenger,2,2022,1.67,#ff1a1a,https://cards.scryfall.io/normal/front/5/9/593b4a4f-5644-44be-9bfe-752732ffe59e.jpg?1783919715,Creature — Goblin Warrior,Joseph Weston
+Sarkhan- Dragon Ascendant,2,2025,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/c/2/c2200646-7b7c-489d-bbae-16b03e1d7fb2.jpg?1783907353,Legendary Creature — Human Druid,Billy Christian
+Sarkhan- Fireblood,3,2018,2.14,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/3553a70e-75de-4a8c-9b20-92cd4a317101.jpg?1783934548,Legendary Planeswalker — Sarkhan,Grzegorz Rutkowski
+Sarkhan's Dragonfire,5,2018,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/b/9/b96a7320-089a-4a7e-813f-49ca1620df76.jpg?1783934484,Sorcery,Daarken
+Sarkhan's Unsealing,4,2020,1.22,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bb9c6068-cfd8-4371-b549-e474d573e52e.jpg?1783930377,Enchantment,Daarken
+Sarkhan- the Dragonspeaker,5,2014,0.53,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c58064fd-4d8b-4f54-812f-0bb1d7e2ddc2.jpg?1783939070,Legendary Planeswalker — Sarkhan,Daarken
+Sarkhan the Masterless,5,2023,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/2/a/2aced16a-ebbd-47bb-a4c4-9454afa9971c.jpg?1783915431,Legendary Planeswalker — Sarkhan,Kieran Yanner
+Satyr Firedancer,2,2014,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7fc6a735-cbf5-4af2-b15c-7ced82f0d9da.jpg?1783939542,Enchantment Creature — Satyr,Chris Rahn
+Savage Beating,5,2023,9.74,#ff1a1a,https://cards.scryfall.io/normal/front/3/c/3c979cab-3ae6-43b1-b067-1e5abfc2e2ed.jpg?1783915643,Instant,Matt Thompson
+Savage Firecat,5,2001,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/5/2/52e14dbe-4d33-405c-ab84-2fc6b1e000b8.jpg?1783945224,Creature — Elemental Cat,Dave Dorman
+Sawhorn Nemesis,4,2024,2.22,#ff1a1a,https://cards.scryfall.io/normal/front/2/9/29b33e43-ffd5-4697-8261-9b4f5de36a19.jpg?1783911421,Creature — Dinosaur,Monztre
+Scab-Clan Berserker,3,2015,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/3/8/38d600b0-8649-424a-acad-879f3067b55e.jpg?1783938326,Creature — Human Berserker,Dave Kendall
+Scalding Viper // Steam Clean,2,2023,0.32,#d78f42,https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1783915062,Creature — Elemental Snake // Sorcery — Adventure,Andrew Mar
+Scion of Opulence,3,2021,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/d/c/dc0296ec-0401-49c6-82c3-9d7e8aa5ee25.jpg?1783924998,Creature — Vampire Noble,Chris Rallis
+Scorched Earth,1,1997,0.69,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e6a97817-d1fd-4ba4-9ced-c2702b081523.jpg?1783946624,Sorcery,Nicola Leonard
+Scoria Wurm,5,2007,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/406f7fef-00f0-4ca5-ada4-c4a760e68467.jpg?1783943013,Creature — Wurm,Steve Firchow
+Scourge of Kher Ridges,8,2007,1.7,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/bede410a-8b5c-48c0-8f5d-d8bd17e0b86b.jpg?1783943104,Creature — Dragon,Daren Bader
+Scourge of the Throne,6,2025,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/c/d/cd44f295-c4c8-4f47-9d51-d5ba578f7f8d.jpg?1783907061,Creature — Dragon,Michael Komarck
+Scourge of Valkas,5,2021,3.89,#ff1a1a,https://cards.scryfall.io/normal/front/e/6/e6bd7225-b39f-4b3b-8c36-dbc2c09f6e50.jpg?1783926202,Creature — Dragon,Lucas Graciano
+Scourge Wolf,2,2016,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/072f47ad-3055-4bd2-b7fd-cfbd22720d58.jpg?1783937743,Creature — Wolf Horror,Jama Jurabaev
+Scrambleverse,8,2011,1.69,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b61fa9d-3f69-4632-be0e-09924ca88501.jpg?1783941065,Sorcery,Dan Murayama Scott
+Scrap Mastery,5,2018,4.06,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bc6d966e-fa6b-4eb4-b854-7425f5553518.jpg?1783934737,Sorcery,Dan Murayama Scott
+Scrap Welder,3,2022,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/14057067-2325-4229-8580-d9a6397ae343.jpg?1783923860,Creature — Goblin Artificer,Simon Dominic
+Screamer-Killer,5,2022,0.53,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/078b560f-9b86-401a-afff-21ddb1ebed61.jpg?1783920883,Creature — Tyranid,David Auden Nash
+Screaming Nemesis,3,2024,7.1,#ff1a1a,https://cards.scryfall.io/normal/front/c/e/ce35e6fb-ff54-44c4-a216-7ddd37f46882.jpg?1783909465,Creature — Spirit,Liiga Smilshkalne
+Screeching Phoenix,6,2018,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/4/b/4b9477ba-e198-4085-8733-fd392a5648e7.jpg?1783934626,Creature — Phoenix,Tingting Yeh
+Scuzzback Scrounger,2,2026,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0ea4a895-19c0-47af-ad9c-5db88ea9ae05.jpg?1783904441,Creature — Goblin Warrior,Mark Zug
+Search for Survivors,3,2000,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/2/f/2f19a1b5-48ba-44a9-b91f-2f628b223ffb.jpg?1783945776,Sorcery,Mark Romanoski
+Searing Blaze,2,2011,5.49,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/974c599b-170e-4948-b741-47f61c769b6e.jpg?1783941554,Instant,Jaime Jones
+Searing Blood,2,2025,0.77,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/6466873b-c1a5-4614-9409-a448221e06f1.jpg?1783904852,Instant,Viacom
+Searing Wind,9,2003,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/61afd3c5-7103-4247-8bb9-747532ae4265.jpg?1783944703,Instant,John Matson
+Searslicer Goblin,2,2024,1.03,#ff1a1a,https://cards.scryfall.io/normal/front/9/4/94ad0b97-a318-4e76-ac79-b3e83417c333.jpg?1783909102,Creature — Goblin Warrior,Wayne Reynolds
+Seasoned Pyromancer,3,2022,8.3,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/1427f615-8430-426e-a669-f9fe12033ac4.jpg?1783921882,Creature — Human Shaman,Cynthia Sheppard
+Season of the Bold,5,2024,1.19,#ff1a1a,https://cards.scryfall.io/normal/front/8/4/84352565-558b-4f9b-a411-532147806a78.jpg?1783910816,Sorcery,Eli Minaya
+Sedge Sliver,3,2021,0.97,#d78f42,https://cards.scryfall.io/normal/front/0/a/0af3c6b1-9139-46a3-ad41-91aabbdda55f.jpg?1783927789,Creature — Sliver,Richard Kane Ferguson
+Seething Song,3,2025,19.8,#ff1a1a,https://cards.scryfall.io/normal/front/7/7/77413fe0-0c5c-402d-8809-f9d434193654.jpg?1783905121,Instant,Joshua Raphael
+Seifer Almasy,4,2025,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9c776984-99ea-4181-ac95-78c41ba9d54f.jpg?1783906597,Legendary Creature — Human Knight,Kotetsu Kinoshita
+Seismic Assault,3,2018,0.73,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6b2eb4e6-4ce1-4f72-9b3d-b6a44b22bd2e.jpg?1783933801,Enchantment,Adam Paquette
+Seismic Mage,4,1999,0.61,#ff1a1a,https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg?1783945934,Creature — Human Spellshaper,Pete Venters
+Seize the Day,4,2026,2.48,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9cb5d064-f474-4db9-b349-b9f71c587742.jpg?1783903232,Sorcery,Michael MacRae
+Seize the Spotlight,3,2024,14.59,#ff1a1a,https://cards.scryfall.io/normal/front/0/1/01fe0af9-55b4-4390-8de4-2cd58aa7efde.jpg?1783911916,Sorcery,Ernanda Souza
+Sensation Gorger,3,2008,3.79,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b2e5eb69-dcd9-4784-bf4c-20b674f4c035.jpg?1783942784,Creature — Goblin Shaman,Matt Cavotta
+Sethron- Hurloon General,5,2020,0.33,#d78f42,https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg?1783930501,Legendary Creature — Minotaur Warrior,Jason Rainville
+Shadow of the Goblin,2,2025,1.06,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/854b6898-c480-435b-8952-a077c7977cec.jpg?1783905334,Enchantment,Pavel Kolomeyets
+Shah of Naar Isle,4,2007,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/c/e/cee5e9e3-e3ae-4e1b-a8fb-48c523631105.jpg?1783943101,Creature — Efreet,Jon Foster
+Shaman of the Great Hunt,4,2015,1.0,#d78f42,https://cards.scryfall.io/normal/front/b/f/bfbd8cd1-465c-4501-94ba-5a3402f30ded.jpg?1783938685,Creature — Orc Shaman,Ryan Alexander Lee
+Shaman's Trance,3,2002,0.66,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/dfc33a4f-9ec2-4324-82a1-a4b9700572f2.jpg?1783945115,Instant,Greg Hildebrandt
+Shared Animosity,3,2023,3.3,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1bd77ae9-c5ba-44af-80e9-7c852722ef6c.jpg?1783913862,Enchantment,Chuck Lukacs
+Share the Spoils,2,2021,3.64,#ff1a1a,https://cards.scryfall.io/normal/front/5/e/5e35d719-8766-47dc-8c0d-8e2b37b907a8.jpg?1783926244,Enchantment,Sidharth Chaturvedi
+Shattering Spree,1,2025,1.01,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/dd5d1ae1-2168-429e-a205-787b722f2637.jpg?1783904850,Sorcery,Viacom
+Shatterskull Charger,3,2020,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/6/c/6c6d6bc3-2162-4c2b-a5de-25103e706e37.jpg?1783929353,Creature — Giant Warrior,Lius Lasahido
+Shatterskull Smashing // Shatterskull- the Hammer Pass,2,2020,9.64,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Land,Adam Paquette
+Shatterstorm,4,1999,0.82,#ff1a1a,https://cards.scryfall.io/normal/front/f/5/f5129c8a-735b-44f5-9233-24b905e3103a.jpg?1783946167,Sorcery,James Allen
+She-Hulk- Wallbreaker,6,2026,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/8/c/8c57fb16-f4a3-437c-be27-d1c00a2be01e.jpg?1783903280,Legendary Creature — Gamma Hero,Julia Vasilyeva
+Shellshock,1,2026,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/7/d/7d180bb8-6a33-4c55-b4c0-2abbf6595d7b.jpg?1783904166,Instant,Brandon L. Hunt
+Shifting Shadow,3,2022,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f4c34cbe-c41f-4fcb-b1b6-720b6b214fef.jpg?1783923956,Enchantment — Aura,Christopher Burdett
+Shimatsu the Bloodcloaked,4,2004,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/7/1/71de0e2c-61ca-496e-8990-ed0e6f6521a6.jpg?1783944296,Legendary Creature — Demon Spirit,Dave Allsop
+Shiny Impetus,3,2026,3.49,#ff1a1a,https://cards.scryfall.io/normal/front/7/1/71bcf8d7-cc70-4d52-9607-09ed7e08d61b.jpg?1783995450,Enchantment — Aura,Gregg Schigiel
+Shivan Devastator,1,2022,3.43,#ff1a1a,https://cards.scryfall.io/normal/front/1/f/1f5d274c-3a03-4f0d-97e8-7eef6508105d.jpg?1783921310,Creature — Dragon Hydra,Brent Hollowell
+Shivan Dragon,6,2023,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7b78eb49-bd68-47e6-90a3-83ec2eeb4312.jpg?1783918456,Creature — Dragon,Donato Giancola
+Shivan Hellkite,7,2021,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/d/3/d33cfe2d-150d-4ab7-990a-c8b0b6ff4d37.jpg?1783926201,Creature — Dragon,Kev Walker
+Shivan Phoenix,6,1999,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/112aa0e2-7e4a-4ae8-bedb-d84b4116df5e.jpg?1783946233,Creature — Phoenix,Daren Bader
+Shivan Wumpus,4,2007,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/7/9/7958a1e5-b671-4ecb-95de-240ffaf5021e.jpg?1783943143,Creature — Beast,Ron Spears
+Shock,1,2025,1.11,#ff1a1a,https://cards.scryfall.io/normal/front/8/0/8066310c-dcd6-465b-a0ae-44c8602367de.jpg?1783905384,Instant,John Romita Sr.
+Shocker,2,1997,1.06,#ff1a1a,https://cards.scryfall.io/normal/front/9/0/90954848-af7e-47b3-82e7-9fedde6ad606.jpg?1783946623,Creature — Insect,Thomas M. Baxa
+Showstopping Surprise,5,2024,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/1/f/1ffdad45-0111-4c6a-bfb0-25aeee7aea1d.jpg?1783913043,Instant,David Palumbo
+Shrieking Mogg,2,2000,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0ce46919-d312-490c-8942-39fbb2d375bf.jpg?1783945816,Creature — Goblin,Dan Frazier
+Shunt,3,2007,0.89,#ff1a1a,https://cards.scryfall.io/normal/front/5/e/5e54b10e-5307-4138-8f80-28406170f2c6.jpg?1783943011,Instant,Greg Hildebrandt
+Siege Dragon,7,2014,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/1/2/12dc18f7-f4d4-421e-869e-c2e7598a9c77.jpg?1783939169,Creature — Dragon,Karl Kopinski
+Siege-Gang Commander,5,2026,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/7/d/7d67e614-03d2-4034-b82f-25962fc378d4.jpg?1783903455,Creature — Goblin,Aaron Miller
+Siege-Gang Lieutenant,4,2026,1.68,#ff1a1a,https://cards.scryfall.io/normal/front/7/6/76049160-69f7-4114-81f3-dfab8242ac15.jpg?1783903441,Creature — Goblin,Warren Mahy
+Siege of Towers,2,2006,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/4/d/4db24da9-8901-4e2d-9565-39ce1b7639c9.jpg?1783943496,Sorcery,Anthony S. Waters
+Silverclad Ferocidons,7,2018,2.52,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5f0d0c8d-c057-4a44-bd1e-38e1dd175778.jpg?1783935293,Creature — Dinosaur,Simon Dominic
+Simian Spirit Guide,3,2024,39.25,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/234b53a3-cf34-46dd-a556-653e2348c5da.jpg?1783913075,Creature — Ape Spirit,Graham Yarrington
+Sin Prodder,3,2020,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/d/b/db89172e-0542-4858-9e65-38b1bac8cdeb.jpg?1783930377,Creature — Devil,Jack Wang
+Skarrgan Firebird,6,2013,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/4460973c-190e-4ab2-9be2-8c64e5380505.jpg?1783939840,Creature — Phoenix,Kev Walker
+Skarrgan Hellkite,5,2025,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a373c35e-a54a-4dae-a527-e94dfb10230a.jpg?1783907060,Creature — Dragon,Svetlin Velinov
+Skewer the Critics,3,2025,1.78,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/23051bcf-2326-4527-bdab-032915ff271a.jpg?1783906750,Sorcery,Yuko Shimizu
+Skirk Alarmist,2,2003,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fd1c1d41-8666-4c1d-9498-0e259472958d.jpg?1783944905,Creature — Human Wizard,Justin Sweet
+Skirk Fire Marshal,5,2014,2.8,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aac5a2ff-c9fc-4ae1-8207-69d7fe4fd11f.jpg?1783938764,Creature — Goblin,Greg Hildebrandt & Tim Hildebrandt
+Skizzik,4,2000,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/d/c/dc7732bc-e168-44d9-923a-db7e985bd6db.jpg?1783945679,Creature — Elemental,Ron Spencer
+Skullcrack,2,2024,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/1/7/170a06cd-501e-43c8-98e0-63ebd61cc0aa.jpg?1783911719,Instant,Mark A. Nelson
+Skullscorch,2,2002,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/88f1343c-77bf-4f44-8226-fdfb2c2c7015.jpg?1783945145,Sorcery,Bradley Williams
+Skyfire Kirin,4,2005,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/2/d/2d425562-3f0f-4aa3-a761-48ba445b8380.jpg?1783944143,Legendary Creature — Kirin Spirit,Tsutomu Kawade
+Skyfire Phoenix,4,2019,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/605b0d7d-4ece-4ad8-bf59-86ac121ccafe.jpg?1783932804,Creature — Phoenix,Greg Staples
+Skyline Despot,7,2021,0.54,#ff1a1a,https://cards.scryfall.io/normal/front/f/a/fabdbd03-6f1e-4ada-ad90-5c72d7e305b6.jpg?1783926200,Creature — Dragon,Lucas Graciano
+Skyship Stalker,4,2021,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6ea1dbf2-f3fb-40c4-86df-cd2511d27088.jpg?1783926203,Creature — Cat Dragon,Chris Rahn
+Slag Fiend,1,2011,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/c/0/c0d1ee33-e247-4ada-bb01-518611cd7d00.jpg?1783941305,Creature — Phyrexian Construct,Mike Bierek
+Slagstorm,3,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0.jpg?1783909063,Sorcery,Dan Murayama Scott
+Slash- Reptile Rampager,5,2026,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/0/2/025aafbc-5b24-4f5b-9b4a-81f6b9cb5ef3.jpg?1783904093,Legendary Creature — Mutant Berserker Turtle,Andrew Mar
+Slicer- Hired Muscle // Slicer- High-Speed Antagonist,5,2022,8.97,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact Creature — Robot // Legendary Artifact — Vehicle,Volta Creation
+Slickshot Show-Off,2,2024,6.06,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/7054012b-4f9d-44a0-aaf9-7fd3bddc7b2d.jpg?1783911814,Creature — Bird Wizard,Augusto Quirino
+Slobad- Goblin Tinkerer,2,2016,0.6,#ff1a1a,https://cards.scryfall.io/normal/front/4/2/4256dcc1-0eee-4385-9a5c-70abb212bf49.jpg?1783937064,Legendary Creature — Goblin Artificer,Kev Walker
+Slobad- Iron Goblin,3,2023,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b7dadf0-7323-403e-b353-33c121bdb0db.jpg?1783918024,Legendary Creature — Phyrexian Goblin Artificer,Chris Seaman
+Slumbering Dragon,1,2012,2.42,#ff1a1a,https://cards.scryfall.io/normal/front/2/7/277cbd0d-c8da-4a37-965c-6a60771df2f7.jpg?1783940479,Creature — Dragon,Chris Rahn
+Smaug the Magnificent,4,2026,73.46,#ff1a1a,https://cards.scryfall.io/normal/front/6/a/6a5d8fad-2ffd-4645-8c49-907999b6cecf.jpg?1783902784,Legendary Creature — Dragon,Francisco Miyara
+Smellerbee- Rebel Fighter,4,2025,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/5/a/5aef6ece-929b-4636-b32e-58f91741b869.jpg?1783904817,Legendary Creature — Human Rebel Ally,Enishi
+Smoke Spirits' Aid,1,2022,0.66,#ff1a1a,https://cards.scryfall.io/normal/front/e/4/e492a245-46ba-438e-8d81-4626faa49bff.jpg?1783923991,Sorcery,Uriah Voth
+Smoldering Egg // Ashmouth Dragon,2,2021,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Dragon Egg // Creature — Dragon,Simon Dominic
+Smoldering Stagecoach,4,2024,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/a/3/a39d6484-6530-4237-84b9-68ab8a056e7c.jpg?1783911964,Artifact — Vehicle,Billy Christian
+Sneak Attack,4,2023,11.23,#ff1a1a,https://cards.scryfall.io/normal/front/a/4/a45b4ca9-4355-4690-84c3-a7d44c367dbf.jpg?1783918452,Enchantment,Jerry Tiritilli
+Snort,4,2025,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/4/6/46f1179d-6e48-46ed-ab41-abddace7b5d4.jpg?1783906354,Sorcery,ikeda_cpt
+Solphim- Mayhem Dominus,4,2023,27.6,#ff1a1a,https://cards.scryfall.io/normal/front/c/3/c3a0c7f3-7fb9-43de-a9af-96532c31e5ed.jpg?1783918023,Legendary Creature — Phyrexian Horror,Chris Cold
+Song of Totentanz,1,2023,2.85,#ff1a1a,https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg?1783915088,Sorcery,Randy Gallegos
+Soulblast,6,2007,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/82e4e1b9-d93e-443e-91a4-69d4c9dac517.jpg?1783943011,Instant,Jim Nelson
+Soulfire Eruption,9,2020,1.87,#ff1a1a,https://cards.scryfall.io/normal/front/2/d/2def4384-7175-4a26-a5a0-8f2c5b5ad71c.jpg?1783928807,Sorcery,Andrey Kuzinskiy
+Soul Immolation,5,2026,2.55,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/234b70df-8c34-4da7-946e-b8b55a8df390.jpg?1783904438,Sorcery,Drew Tucker
+Soul of Shandalar,6,2014,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/0/3/03543d10-202b-4b07-a34b-64216a745d84.jpg?1783939169,Creature — Avatar,Raymond Swanland
+Soul-Scar Mage,1,2017,0.86,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg?1783936483,Creature — Human Wizard,Steve Argyle
+Sozin's Comet,5,2025,3.19,#ff1a1a,https://cards.scryfall.io/normal/front/6/4/649e50e5-299b-4191-87a8-36e9378795be.jpg?1783904953,Sorcery,Salvatorre Zee Yazzie
+Spark Fiend,5,1998,0.76,#ff1a1a,https://cards.scryfall.io/normal/front/e/a/ea73a7ef-e9da-4d5b-aa4d-a953cbacd6c2.jpg?1783946425,Creature — Beast,Pete Venters
+Spawn of Thraxes,7,2014,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/e/1/e13aa40e-c626-486d-8abc-10aa68542c5b.jpg?1783939418,Creature — Dragon,Svetlin Velinov
+Special Move,3,2026,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/600e2c3f-dfbd-4d5c-813a-47ae2d75ac12.jpg?1783904166,Instant,Victor Maury
+Spectacular Showdown,2,2024,2.25,#ff1a1a,https://cards.scryfall.io/normal/front/f/f/ffee18af-1160-46ad-9640-87eac49a5239.jpg?1783912995,Sorcery,Aniekan Udofia
+Spellbinding Soprano,2,2022,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/248d71f9-89ef-492e-a854-a890f7d91ef8.jpg?1783923359,Creature — Human Bard,Ernanda Souza
+Spellpyre Phoenix,5,2020,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f492c4f5-27b7-4f09-a3af-2fb1aeac50d5.jpg?1783931212,Creature — Phoenix,Svetlin Velinov
+Spicy Oatmeal Pizza,3,2026,0.47,#ff1a1a,https://cards.scryfall.io/normal/front/c/b/cbe07254-5a32-45d6-b0c0-d842640deb47.jpg?1783904636,Artifact — Food,Fajareka Setiawan
+Spider-Man- New Champion,3,2026,2.95,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bc90f14c-9289-4284-bc89-e0df8e03152b.jpg?1783903044,Legendary Creature — Spider Human Hero,Riccardo Federici
+Spider-Man- Web-Spinner,4,2026,22.59,#ff1a1a,https://cards.scryfall.io/normal/front/a/c/acf20da5-e460-4191-ad68-eae398bb7c5d.jpg?1783902999,Legendary Creature — Spider Human Hero,Junggeun Yoon
+Spider-Punk,2,2025,1.72,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0bd41879-fcd4-4211-9b98-47e7cdba5399.jpg?1783905333,Legendary Creature — Spider Human Hero,Forrest Imel
+Spider-Verse,5,2025,1.09,#ff1a1a,https://cards.scryfall.io/normal/front/f/8/f8779eb2-1210-430d-8d42-3077053441ee.jpg?1783905331,Enchantment,Alexander Gering
+Spiked Corridor // Torture Pit,8,2024,5.34,#ff1a1a,https://cards.scryfall.io/normal/front/b/9/b90164a1-8b0a-4445-a0ad-43e4c3324925.jpg?1783909656,Enchantment — Room // Enchantment — Room,Arthur Yuan
+Spikeshot Elder,1,2015,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/14c14e44-20ff-4128-b07d-4b751fc82d4e.jpg?1783938402,Creature — Goblin Shaman,Izzy
+Spinal Villain,3,1994,56.11,#ff1a1a,https://cards.scryfall.io/normal/front/d/6/d6d5e36f-0049-4be8-bf85-8dc0186339a4.jpg?1783948052,Creature — Beast,Anson Maddocks
+Spinerock Tyrant,5,2026,1.43,#ff1a1a,https://cards.scryfall.io/normal/front/4/7/478bbb7a-4b96-4e04-921e-bdf23185de25.jpg?1783904437,Creature — Dragon,Cory Godbey
+Spinneret and Spiderling,1,2025,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a27834b7-e763-48ac-845e-ed49f2fa6c6d.jpg?1783905332,Legendary Creature — Spider Human Hero,Le Vuong
+Spirit of Resilience,3,2026,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/60584e5b-4138-405b-bd02-612cf175184e.jpg?1783903856,Creature — Spirit Warrior,David Álvarez
+Spiteful Banditry,2,2023,5.72,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e85a82bc-49f3-4694-b688-808a541146db.jpg?1783916276,Enchantment,Manuel Castañón
+Spiteful Prankster,3,2024,1.3,#ff1a1a,https://cards.scryfall.io/normal/front/8/a/8a9f1f7e-2e6a-4af3-8272-68cee14b6156.jpg?1783911494,Creature — Devil,Igor Kieryluk
+Spiteful Repossession,5,2022,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/354790c1-ce19-4ed5-9cef-f2e2ee621578.jpg?1783923341,Sorcery,Stanton Feng
+Spiteful Sliver,3,2023,2.03,#ff1a1a,https://cards.scryfall.io/normal/front/0/1/01fb60c9-d10d-4966-b9bd-788fabc182d2.jpg?1783915430,Creature — Sliver,Johann Bodin
+Spit Flame,3,2025,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5fb4fa09-2864-4973-aa49-088043f6a6d1.jpg?1783907059,Instant,Chris Rahn
+Splinter Twin,4,2015,8.48,#ff1a1a,https://cards.scryfall.io/normal/front/5/8/580fbbf8-ba7e-4889-a5ea-d066f3ea8cea.jpg?1783938401,Enchantment — Aura,Goran Josic
+Squee- Dubious Monarch,3,2022,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/3/c/3cd907ed-9c68-4bd6-af92-6244909fdf8b.jpg?1783921310,Legendary Creature — Goblin Noble,Zoltan Boros
+Squee- Goblin Nabob,3,2019,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2bca6f8b-6e6a-43dd-b6a4-9eedfcc24281.jpg?1783932752,Legendary Creature — Goblin,Greg Staples
+Squee- the Immortal,3,2022,1.14,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a8232acd-4645-489c-8cf1-4efdc75d9322.jpg?1783923257,Legendary Creature — Goblin,Svetlin Velinov
+Stadium Headliner,1,2025,1.07,#ff1a1a,https://cards.scryfall.io/normal/front/3/7/37d4ab2a-a06a-4768-b5e1-e1def957d7f4.jpg?1783907352,Creature — Goblin Warrior,Ralph Horsley
+Staggershock,3,2010,1.09,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7c7eeca0-a4cf-455f-888c-57571cf3555d.jpg?1783941945,Instant,Raymond Swanland
+Stalking Vengeance,7,2022,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/c/4/c4ab472c-22b6-473e-b7b0-df2454eb930c.jpg?1783923256,Creature — Avatar,Anthony S. Waters
+Stand or Fall,4,2000,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/60c34970-a106-490c-ac37-6156eb7f34ce.jpg?1783945679,Enchantment,Matt Cavotta
+Star Athlete,3,2024,0.83,#ff1a1a,https://cards.scryfall.io/normal/front/5/c/5c7c23a6-53ff-4588-838c-7936cb9eb86b.jpg?1783909656,Creature — Human Warrior,Andrey Kuzinskiy
+Star of Extinction,7,2023,1.49,#ff1a1a,https://cards.scryfall.io/normal/front/5/2/526d13cb-3616-4ac8-9ac0-04c729d447b2.jpg?1783915642,Sorcery,Chris Rahn
+Starstorm,2,2022,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/7/2/728b356a-e2ec-4c44-bd0a-bb9a5427a1ad.jpg?1783923956,Instant,Jonas De Ro
+Steal the Show,3,2026,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7ac6649f-980e-4404-9c05-458c30578ecc.jpg?1783903663,Sorcery,Pauline Voss
+Steamflogger Boss,4,2007,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/007ce039-def1-4039-a0a0-ba72e8872dc5.jpg?1783943101,Creature — Goblin Rigger,Warren Mahy
+Steamflogger of the Month,5,2017,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9d536048-86fd-4ea0-bd1c-5a82c76d58b7.jpg?1783935418,Creature — Goblin Rigger,Warren Mahy
+Stensia Uprising,4,2021,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df71a8c1-25af-4e6a-9197-11b96b959b46.jpg?1783924823,Enchantment,Dan Murayama Scott
+Stet- Draconic Proofreader,6,2020,0.15,#d78f42,https://cards.scryfall.io/normal/front/d/5/d57a6d9d-f0e9-4c5a-bacf-7a6c30d65b08.jpg?1783931329,Legendary Creature — Dragon Bureaucrat,Dmitry Burmak
+Stigma Lasher,2,2008,3.47,#ff1a1a,https://cards.scryfall.io/normal/front/c/e/ce5d1fd4-0543-46ce-bcea-1695fc04e85b.jpg?1783942681,Creature — Elemental Shaman,Aleksi Briclot
+Stingerback Terror,4,2024,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/d/8/d84d6e52-5c35-47bc-b160-876a3b0fcbe1.jpg?1783911814,Creature — Scorpion Dragon,Slawomir Maniak
+Stolen Strategy,5,2022,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/6/e/6e37dde2-2ad4-46c6-ab69-8487f8a2bdb6.jpg?1783922416,Enchantment,Dmitry Burmak
+Stone Idol Trap,6,2010,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/44dee4b3-f3c1-4ef5-8dfa-fa10c860be1e.jpg?1783942047,Instant — Trap,Jung Park
+Stone Rain,3,2021,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f60687e5-9384-4453-833e-2c76f25bfac5.jpg?1783927429,Sorcery,Justin Hernandez & Alexis Hernandez
+Stormbreath Dragon,5,2025,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/3637d9b8-87bb-478d-bfb1-59ddab7b5e4c.jpg?1783907059,Creature — Dragon,Slawomir Maniak
+Storm Herald,3,2020,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/e/0/e0594aa2-1c53-4271-a0d0-9002c07f3697.jpg?1783931544,Creature — Human Shaman,Aleksi Briclot
+Storm-Kiln Artist,4,2026,18.82,#ff1a1a,https://cards.scryfall.io/normal/front/9/a/9a6f8a6e-cc77-41d8-b753-bb3c5a5c4f48.jpg?1783903511,Creature — Dwarf Shaman,Mica Angela Hendricks
+Storm King's Thunder,3,2022,4.14,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/78a655b3-969f-40d7-9d69-61abf338df86.jpg?1783922730,Instant,Alexander Mokhov
+Storm of Memories,5,2025,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/253266de-0eeb-46c7-9912-145586661fc4.jpg?1783904817,Sorcery,NIJIMAARC
+Stormscale Anarch,4,2006,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/0/0/00dbd0ef-9888-4489-ba4a-65128308fb11.jpg?1783943417,Creature — Lizard Shaman,Ralph Horsley
+Stormscale Scion,6,2025,3.15,#ff1a1a,https://cards.scryfall.io/normal/front/0/a/0ac43386-bd32-425c-8776-cec00b064cbc.jpg?1783907349,Creature — Dragon,Andrew Mar
+Stormsplitter,4,2024,2.27,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/56f214d3-6b93-40db-a693-55e491c8a283.jpg?1783910816,Creature — Otter Wizard,Lius Lasahido
+Storm's Wrath,4,2025,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/6/d/6d064aff-711f-4670-b786-a74265bdf44a.jpg?1783907059,Sorcery,Yeong-Hao Han
+Strago and Relm,3,2025,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/a/8/a8c971d0-9ac4-4b34-ae19-1152c1c9dac1.jpg?1783906354,Legendary Creature — Human Wizard,Darius Zablockis
+Strangle,1,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/b/6/b63ca355-d66d-4259-8d6e-34ec2ba71e6e.jpg?1783916411,Sorcery,Sidharth Chaturvedi
+Stranglehold,4,2017,7.45,#ff1a1a,https://cards.scryfall.io/normal/front/d/a/da81e6e9-90f2-4dad-894c-1952f05264c2.jpg?1783936272,Enchantment,John Stanko
+Strategy- Schmategy,2,2020,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/6159df84-64a3-4252-99d8-30971b07cec5.jpg?1783931328,Sorcery,Daniel Gelon
+Stromkirk Noble,1,2024,0.12,#ff1a1a,https://cards.scryfall.io/normal/front/0/f/0f306c7e-cacc-4c26-a3f1-fad4f3ff7cf3.jpg?1783908921,Creature — Vampire Noble,James Ryman
+Stromkirk Occultist,3,2021,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/8/a/8a631816-f5c0-4608-9078-0486a0bf6a49.jpg?1783924945,Creature — Vampire Horror,Magali Villeneuve
+Stronghold Gambit,2,2000,5.32,#ff1a1a,https://cards.scryfall.io/normal/front/0/d/0d18050e-9aad-471e-a6ae-66e5fa2bbb6f.jpg?1783945817,Sorcery,Greg Hildebrandt & Tim Hildebrandt
+Structural Assault,5,2022,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/c/b/cbdb50e3-fe15-4431-b9bd-c4de65820734.jpg?1783923111,Sorcery,Liiga Smilshkalne
+Subira- Tulzidi Caravanner,3,2020,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/0/3/034b8d6d-95ea-434a-967a-e6675a7ce88a.jpg?1783930684,Legendary Creature — Human Shaman,Leesha Hannigan
+Subterranean Spirit,5,1996,1.0,#ff1a1a,https://cards.scryfall.io/normal/front/1/3/132e8aac-9698-45fa-8d64-b460fd5deffc.jpg?1783947072,Creature — Elemental Spirit,John Bolton
+Subterranean Tremors,1,2016,6.4,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b9510b8-6601-4116-8713-ff7649c000eb.jpg?1783937345,Sorcery,Filip Burburan
+Sudden Demise,1,2017,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/9/3/9336cb8a-13d4-4d97-9111-1326a9028df8.jpg?1783936146,Sorcery,Dan Murayama Scott
+Sulfuric Vapors,4,1998,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/e/1/e133997f-1620-4fe9-8275-057edc998fba.jpg?1783946323,Enchantment,Lawrence Snelly
+Sulfuric Vortex,3,2023,1.22,#ff1a1a,https://cards.scryfall.io/normal/front/3/2/3253a624-50cc-4a8a-9b0c-9902aa53775f.jpg?1783918451,Enchantment,Greg Staples
+Summon: Brynhildr,2,2025,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/8/a/8ab5429a-1075-49aa-9608-0610080fbf7a.jpg?1784182953,Enchantment Creature — Saga Knight,Kevin Glint
+Summon: Esper Valigarmanda,4,2025,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/7/f/7f0298b4-c7ca-49b8-baaa-b9fad4c2bfd5.jpg?1783906354,Enchantment Creature — Saga Drake,Fiona Hsieh
+Summon: G.F. Cerberus,4,2025,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d0e5cbd4-401b-4456-80bf-d90beadfd1f8.jpg?1784182970,Enchantment Creature — Saga Dog,Kevin Glint
+Summon: Kujata,6,2025,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/ba934866-efd0-4126-b1ff-9c7e82b73bd6.jpg?1783906353,Enchantment Creature — Saga Ox,Alexandre Honoré
+Sunbird's Invocation,6,2021,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/7/5/75c1eb6a-2183-4f60-b075-f7289df35be7.jpg?1783927539,Enchantment,Christine Choi
+Sundering Stroke,7,2019,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/24b7a774-ca49-4291-8a19-cb5e475b10d5.jpg?1783932615,Sorcery,Stanton Feng
+Sunrise Sovereign,6,2018,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9ee59bd3-062b-428c-868c-d68d9009d966.jpg?1783934735,Creature — Giant Warrior,William O'Connor
+Sunspine Lynx,4,2024,1.99,#ff1a1a,https://cards.scryfall.io/normal/front/8/9/8995ceaf-b7e0-423c-8f3e-25212d522502.jpg?1783910815,Creature — Elemental Cat,Martin Wittfooth
+Sunstreak Phoenix,4,2021,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/9/7/97de6e92-e0e8-444e-baba-09c97510b1ab.jpg?1783925590,Creature — Phoenix,Brian Valeza
+Surge to Victory,6,2026,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5345934-60eb-417c-9716-477882c4796d.jpg?1783903770,Sorcery,Grzegorz Rutkowski
+Surly Badgersaur,4,2020,14.76,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7ba507e2-fe5e-4947-aada-20184aa09700.jpg?1783931211,Creature — Badger Dinosaur,Izzy
+Surtland Flinger,5,2021,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4a628052-8175-495f-bfab-eeb3a0388e4e.jpg?1783928121,Creature — Giant Berserker,Dmitry Burmak
+Surtr- Fiery Jötun,5,2024,11.77,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/be38985c-f7a9-4885-9035-09390b4b754a.jpg?1783910891,Legendary Creature — Giant God Warrior,Evan Shipard
+Sweltering Suns,3,2017,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f11cd406-c6ae-4018-ae45-4e5577aa82ae.jpg?1783936482,Sorcery,Raymond Swanland
+Synth Eradicator,3,2024,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/8/7/87fc7b54-26e5-4b0d-b2bb-be8f977f752b.jpg?1783912401,Artifact Creature — Synth Soldier,Kekai Kotaki
+Tahngarth- Talruum Hero,5,2001,0.78,#ff1a1a,https://cards.scryfall.io/normal/front/c/1/c1778f37-af01-4f8c-ab9d-a4c60abf7e78.jpg?1783945614,Legendary Creature — Minotaur Warrior,Dave Dorman
+Tannuk- Steadfast Second,4,2025,1.28,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/44607ed3-9523-40ac-9f61-0edd011cf762.jpg?1783905946,Legendary Creature — Kavu Pilot,Raymond Swanland
+Tarox Bladewing,5,2007,0.42,#ff1a1a,https://cards.scryfall.io/normal/front/0/b/0b06bd73-c45a-4560-bd8d-413608c5f89e.jpg?1783943100,Legendary Creature — Dragon,Aleksi Briclot
+Task Mage Assembly,3,2000,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/258a9cdd-c626-404e-b82d-01091f11f107.jpg?1783945775,Enchantment,Val Mayerik
+Taurean Mauler,3,2025,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/3/9/39938a5a-385b-47ba-a07b-8917cba14fd3.jpg?1783907058,Creature — Shapeshifter,Dominick Domingo
+Tectonic Break,2,1999,9.31,#ff1a1a,https://cards.scryfall.io/normal/front/9/d/9de0ee5d-10f6-4152-8416-1f2b749b439d.jpg?1783945933,Sorcery,Rebecca Guay
+Tectonic Giant,4,2024,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/4134a2aa-623c-49fc-bd87-26b861860ad5.jpg?1783909612,Creature — Elemental Giant,Slawomir Maniak
+Tectonic Hellion,7,2019,0.22,#ff1a1a,https://cards.scryfall.io/normal/front/1/b/1b86be51-1b0b-49d0-917c-508f12c85c17.jpg?1783932804,Creature — Hellion,Piotr Dura
+Tectonic Instability,3,2000,3.87,#ff1a1a,https://cards.scryfall.io/normal/front/0/4/0476cc6b-ecc6-44d6-9f44-a90d4ee85daa.jpg?1783945678,Enchantment,Rob Alexander
+Tectonic Reformation,2,2020,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/6/5/656c3e32-8928-4b99-b79c-5761c592aa3d.jpg?1783931168,Enchantment,James Paick
+Telim'Tor,5,1996,0.86,#ff1a1a,https://cards.scryfall.io/normal/front/3/3/33cc89c8-a3ea-469e-b499-f48acec4f538.jpg?1783947072,Legendary Creature — Human Knight,Kev Walker
+Telim'Tor's Edict,1,1996,1.56,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/088a60f0-2224-4e00-a06a-1d376c8d82a4.jpg?1783947071,Instant,Kev Walker
+Tempest Efreet,4,1995,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/c/2/c2ea6dfe-64d6-451a-bd34-31546996e711.jpg?1783947822,Creature — Efreet,NéNé Thomas
+Tempestra- Dame of Games,2,2026,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/4/c/4ccb74c9-046a-4d6b-b8c2-641e2a238d52.jpg?1783904166,Legendary Creature — Elemental Illusion,Hokyoung Kim
+Temporal Firestorm,5,2022,0.12,#d78f42,https://cards.scryfall.io/normal/front/9/d/9d690340-75f1-4733-bde5-2d60fd02f060.jpg?1783921309,Sorcery,Néstor Ossandón Leal
+Tempt with Mayhem,3,2024,1.45,#ff1a1a,https://cards.scryfall.io/normal/front/7/a/7af47a1b-8dc8-47d4-ab89-f6f07160a71a.jpg?1783911420,Instant,Deruchenko Alexander
+Tempt with Vengeance,1,2025,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/4/4/44ffb919-7b7c-4b7f-b616-cff8369409f2.jpg?1783907057,Sorcery,Ryan Barger
+Tephraderm,5,2002,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/4/1/41b65eba-140b-4c1d-b796-8134b7c1ede8.jpg?1783945047,Creature — Beast,Paolo Parente
+Terminal Velocity,6,2025,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1d18dc06-16f0-4a3b-8d52-dbf4aa2c393d.jpg?1783905945,Sorcery,Xabi Gaztelua
+Territorial Aetherkite,6,2025,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/c/1/c1e2f2af-dbba-4e4c-9c60-ac4d245e1431.jpg?1783907750,Creature — Cat Dragon,Lars Grant-West
+Territorial Dispute,6,1999,0.44,#ff1a1a,https://cards.scryfall.io/normal/front/4/f/4fa8a13a-f09f-4b10-8fab-3ea4fdc643d1.jpg?1783945933,Enchantment,Mike Ploog
+Territorial Gorger,4,2016,0.11,#ff1a1a,https://cards.scryfall.io/normal/front/b/3/b3525ad1-3c17-4959-ab61-ae0e784c526a.jpg?1783937186,Creature — Gremlin,Lius Lasahido
+Territorial Hellkite,4,2025,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/f/a/faad2d44-1443-42c3-9d3e-b78951b1e851.jpg?1783907054,Creature — Dragon,Jonas De Ro
+Territory Forge,5,2024,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/7/1/71059bc8-f63a-4d9c-9d08-2e995e74cc59.jpg?1783912000,Artifact,Mirko Failoni
+Terror of Mount Velus,7,2026,4.05,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/4047b1c3-06eb-400d-993d-69b5210977ee.jpg?1783903946,Creature — Dragon,Billy Christian
+Terror of the Peaks,5,2024,28.96,#ff1a1a,https://cards.scryfall.io/normal/front/9/0/904ff94a-4db4-44a6-8593-89c32905b3fc.jpg?1783911813,Creature — Dragon,Joshua Raphael
+Tersa Lightshatter,3,2025,0.97,#ff1a1a,https://cards.scryfall.io/normal/front/9/9/99e96b34-b1c4-4647-a38e-2cf1aedaaace.jpg?1783907351,Legendary Creature — Orc Wizard,Olivier Bernard
+Tesak- Judith's Hellhound,4,2024,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0e563c13-7204-4cda-9b62-d46931fabcef.jpg?1783913042,Legendary Creature — Elemental Dog,Anna Podedworna
+The Akroan War,4,2022,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/78161e60-878a-45a2-aced-40b739bd0a07.jpg?1783922432,Enchantment — Saga,Steven Belledin
+The Big Idea,6,2017,0.32,#d78f42,https://cards.scryfall.io/normal/front/2/e/2ec4563d-1a83-402c-b209-0e1f740a6523.jpg?1783935426,Legendary Creature — Brainiac Villain,Bram Sels
+The Brothers' War,4,2022,1.1,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/5615a50b-3b8b-4d31-b351-1725b730ef0b.jpg?1783919715,Enchantment — Saga,Mark Poole
+The Countdown Is at One,5,2017,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4afb8115-3a47-4d7e-a3ed-b2e81ca27255.jpg?1783935424,Sorcery,Jesper Ejsing
+The Elder Dragon War,4,2022,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0c52c7d4-a350-4518-8c9a-72cf7b14603d.jpg?1783921321,Enchantment — Saga,Filip Burburan
+The Fire Crystal,4,2025,5.93,#ff1a1a,https://cards.scryfall.io/normal/front/e/a/ea430b17-2014-4b8e-b53f-43bcfc06f7cd.jpg?1783906605,Legendary Artifact,Pablo Mendoza
+The First Eruption,3,2018,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0efc241f-64b5-4e28-b14a-b3f19ca6e7b5.jpg?1783934996,Enchantment — Saga,Steven Belledin
+The Flux,4,2023,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/0/2/026611f8-ae07-464f-afe5-6e94bcfac05e.jpg?1783914650,Enchantment — Saga,Alexander Gering
+The Immortal Weapons,5,2026,0.66,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/40295a9b-3a5a-402e-8baf-546cdad223b0.jpg?1783903099,Legendary Creature — Human Warrior Hero,David Palumbo
+The Last Agni Kai,2,2025,2.04,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/61eaebc6-7575-48ed-b212-ff8b0c7ae694.jpg?1783904955,Instant,Pablo Rivera
+The Legend of Roku // Avatar Roku,4,2025,9.65,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Legendary Creature — Avatar,Song Qijin
+Themberchaud,7,2025,18.33,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1dc40449-0660-4350-900c-ec9b2aaefe1c.jpg?1783906765,Legendary Creature — Dragon,Edgar Sánchez Hidalgo
+The Motherlode- Excavator,5,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/3/b/3b9df394-522c-4458-bc36-cf24ad763718.jpg?1783912403,Legendary Artifact Creature — Robot,Josu Solano
+The Parting of the Ways,6,2023,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/6/5/65015afb-cfdb-4373-a0db-0ca5e95c49a1.jpg?1783914649,Enchantment — Saga,Syd Mills
+There and Back Again,5,2023,5.28,#ff1a1a,https://cards.scryfall.io/normal/front/9/3/939b0bd0-24ea-45de-a2d3-37bbf6a3e6f9.jpg?1783916275,Enchantment — Saga,Jarel Threat
+The Reaver Cleaver,3,2022,18.6,#ff1a1a,https://cards.scryfall.io/normal/front/5/b/5bcd1591-b5b9-49fc-9f2a-45f31ed1871e.jpg?1783921476,Legendary Artifact — Equipment,Yigit Koroglu
+The Red Terror,4,2022,6.05,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1d16f75d-988d-4417-9a5e-549b785f9dc4.jpg?1783920885,Legendary Creature — Tyranid,Bryan Sola
+The Rollercrusher Ride,3,2024,0.63,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg?1783909462,Legendary Enchantment,Deruchenko Alexander
+The Scarlet Witch,3,2026,0.74,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/407e8993-e56d-477d-ab85-d10a2522eab3.jpg?1783902924,Legendary Creature — Mutant Warlock Hero,Magali Villeneuve
+The Sound of Drums,3,2023,3.79,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5ff2141a-a3ed-4ad0-9338-560502b1c85c.jpg?1783914646,Enchantment — Aura,Alexandr Leskinen
+The Spear of Leonidas,3,2024,0.96,#ff1a1a,https://cards.scryfall.io/normal/front/1/6/160d6ce7-2452-41a2-aa70-41e1b8045c54.jpg?1783910977,Legendary Artifact — Equipment,Narendra Bintara Adi
+The Vision and Scarlet Witch,4,2026,63.28,#ff1a1a,https://cards.scryfall.io/normal/front/9/3/930afb5f-54b7-4cca-8c28-3e48938f3a43.jpg?1783903042,Legendary Artifact Creature — Mutant Hero,Tyler Walpole
+Thieves' Auction,7,2003,4.11,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c9e8ad32-a701-4b77-bb7e-0e440e4072da.jpg?1783944695,Sorcery,Kevin Murphy
+Thor- Asgard's Avenger,4,2026,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/3/5/3513c041-7147-467d-845d-3d1c83fb3328.jpg?1783903026,Legendary Creature — God Warrior Hero,Wayne Reynolds
+Thor- God of Thunder,5,2026,13.34,#ff1a1a,https://cards.scryfall.io/normal/front/c/d/cddd314c-c271-475a-b076-01a8599c8015.jpg?1783902923,Legendary Creature — God Warrior Hero,Jesper Ejsing
+Thor- Guardian of Midgard,5,2026,3.5,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/36a1069a-5282-42cf-809f-9cf273a1148c.jpg?1783903110,Legendary Creature — God Warrior Hero,Thanh Tuấn
+Thorin- Mountain-king,4,2026,33.89,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/117347af-0dd7-4350-901d-8c8a81387e22.jpg?1783902784,Legendary Creature — Dwarf Noble,Javier Charro
+Thorncaster Sliver,5,2013,1.31,#ff1a1a,https://cards.scryfall.io/normal/front/3/6/3655d837-945f-4ff5-8952-cff5f7b2d18f.jpg?1783939908,Creature — Sliver,Trevor Claxton
+Thoughts of Ruin,4,2005,4.0,#ff1a1a,https://cards.scryfall.io/normal/front/2/a/2a0f2db3-41a6-4283-9812-46b6ae6d1df6.jpg?1783944143,Sorcery,John Avon
+Three-Headed Goblin,5,2017,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/e/3/e35c6dd7-84eb-42ff-a950-705bc0d1811e.jpg?1783935413,Creature — Goblin Mutant,Mike Burns
+Thrill-Kill Disciple,3,2024,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/5/6/5628e781-9f12-49ed-a575-6b467d39510b.jpg?1783912400,Creature — Human Mercenary,Mathias Kollros
+Thrill of Possibility,2,2025,2.43,#ff1a1a,https://cards.scryfall.io/normal/front/2/f/2f8e351a-ce09-4f7d-8b4e-bcffcab66aa1.jpg?1784575980,Instant,David Rapoza
+Throes of Chaos,4,2026,5.55,#ff1a1a,https://cards.scryfall.io/normal/front/d/5/d5623bcd-abc8-40fb-a6cf-d517fcb3dd4f.jpg?1783903390,Sorcery,Wizard of Barge
+Through the Breach,5,2025,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/c/9/c90a3430-f6d9-4432-84d3-9952d2b82003.jpg?1783908110,Instant — Arcane,Randy Vargas
+Thunderblade Charge,3,2007,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/88a85be1-9de5-4f96-9fd1-15f3f17c4bea.jpg?1783943100,Sorcery,Justin Murray
+Thunderblust,5,2015,0.52,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/249ec37d-c4ed-4af6-8c30-bcec13c108fd.jpg?1783938401,Creature — Elemental,Dan Murayama Scott
+Thunderbreak Regent,4,2025,0.59,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/06624919-bb3e-458c-9301-0bb22d8b556c.jpg?1783907054,Creature — Dragon,Ryan Pancoast
+Thunder Dragon,7,2022,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/9/f/9ff75ff4-495f-4a0c-9d98-69eff1b3fa32.jpg?1783922416,Creature — Dragon,Chris Rahn
+Thundering Raiju,4,2022,0.55,#ff1a1a,https://cards.scryfall.io/normal/front/e/c/ec1a2920-6d39-4276-921c-65cc16a45f17.jpg?1783923858,Creature — Spirit,Xavier Ribeiro
+Thunderkin Awakener,2,2019,0.4,#ff1a1a,https://cards.scryfall.io/normal/front/2/8/289b649b-c93a-44ad-bdd6-866f8b2f1bc2.jpg?1783932968,Creature — Elemental Shaman,Yongjae Choi
+Thundermane Dragon,4,2025,0.76,#ff1a1a,https://cards.scryfall.io/normal/front/7/c/7ca93b31-d6ec-4265-b2ff-d46090086f07.jpg?1783907172,Creature — Dragon,Slawomir Maniak
+Thundermare,6,2005,0.92,#ff1a1a,https://cards.scryfall.io/normal/front/7/0/7068c0c3-4ec9-4c02-84db-42b609df545f.jpg?1783943945,Creature — Elemental Horse,Bob Eggleton
+Thundermaw Hellkite,5,2017,2.49,#ff1a1a,https://cards.scryfall.io/normal/front/a/7/a75f6bb4-ab06-42ca-a0df-326d9a098a26.jpg?1783935524,Creature — Dragon,Svetlin Velinov
+Thunderscape Master,4,2000,0.36,#d78f42,https://cards.scryfall.io/normal/front/2/2/22abdc2f-bdc8-46c4-8ce2-f06befedbc32.jpg?1783945678,Creature — Human Wizard,Scott M. Fischer
+Tibalt's Trickery,2,2021,9.71,#ff1a1a,https://cards.scryfall.io/normal/front/d/d/dd921e27-3e08-438c-bec2-723226d35175.jpg?1783928223,Instant,Anna Podedworna
+Tide of War,6,2004,1.56,#ff1a1a,https://cards.scryfall.io/normal/front/4/3/43b5bd60-87ed-41d2-bbcb-bd4a40a772c9.jpg?1783944293,Enchantment,Wayne Reynolds
+Tilonalli's Skinshifter,3,2017,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aab2765d-cfc4-4381-8cce-adce5aaf05ad.jpg?1783935734,Creature — Human Shaman,Jason Rainville
+Tilonalli's Summoner,2,2018,0.54,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b107726-3a44-4b0f-86ef-4dbbf4473e7e.jpg?1783935291,Creature — Human Shaman,Lius Lasahido
+Titania- Proud Pummeler,4,2026,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/3/1/31255422-9afa-416c-90b2-62baf1d02cca.jpg?1783903279,Legendary Creature — Human Villain,Filipe Pagliuso
+Titan of Eternal Fire,6,2020,0.14,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aa82067a-21af-4f2b-b5e6-9bf3c452d0a9.jpg?1783931168,Creature — Giant,Aleksi Briclot
+Titan's Revenge,2,2008,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/b/1/b1b0f9ca-b752-4dd6-982b-06bb3a27ddbc.jpg?1783942782,Sorcery,Christopher Moeller
+Tokka & Rahzar- Unsupervised,3,2026,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8bc5a0ac-5979-43ce-8a65-98c5f09f4aa6.jpg?1783904165,Legendary Creature — Turtle Wolf Mutant,Narendra Bintara Adi
+Tooth and Claw,4,2013,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca3d7a67-5652-4811-a2f8-0dd82c1d56e8.jpg?1783939665,Enchantment,Val Mayerik
+Toralf- God of Fury // Toralf's Hammer,4,2021,5.51,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact — Equipment,Tyler Jacobson
+Torbran- Thane of Red Fell,4,2019,3.67,#ff1a1a,https://cards.scryfall.io/normal/front/7/9/79f591cd-d277-4ba5-b1bf-1c09cac9cb8a.jpg?1783932614,Legendary Creature — Dwarf Noble,Grzegorz Rutkowski
+Torchling,5,2017,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/a/2/a2ba03cd-1347-46e6-9117-2b22ce62a645.jpg?1783936145,Creature — Shapeshifter,rk post
+Tormenting Voice,2,2025,4.27,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e9148e58-ca86-4b92-affd-df6d0e95196a.jpg?1783905160,Sorcery,Igor Krstic
+Torrent of Lava,2,1996,0.81,#ff1a1a,https://cards.scryfall.io/normal/front/1/9/19528a24-4968-4742-a2d1-06f94e60f290.jpg?1783947070,Sorcery,Kathryn Rathke
+Torrent Sculptor // Flamethrower Sonata,4,2021,0.21,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Merfolk Wizard // Sorcery,Slawomir Maniak
+Total War,4,1995,2.49,#ff1a1a,https://cards.scryfall.io/normal/front/6/1/6107388b-ec1e-401e-a407-a821c908ed8d.jpg?1783947482,Enchantment,Drew Tucker
+Trained Orgg,7,2001,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/1/4/14a83031-8b57-41d2-b586-bb4dcf16136a.jpg?1783945442,Creature — Orgg,Alex Horley-Orlandelli
+Transforming Flourish,3,2025,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/9/1/914fdddb-cf66-4631-94e7-ce682a99fcf8.jpg?1783907169,Instant,Xavier Ribeiro
+Transmogrify,4,2020,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/f/2/f2fa5133-c238-47e8-befd-3729a3e4303a.jpg?1783930682,Sorcery,Craig J Spearing
+Trash for Treasure,3,2016,1.63,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f1c031c7-656b-4bd5-9b59-c03420cc2399.jpg?1783937062,Sorcery,Lars Grant-West
+Treasonous Ogre,4,2025,28.44,#ff1a1a,https://cards.scryfall.io/normal/front/6/b/6bc3b304-4109-4f67-b0b0-f1c1de66ff0e.jpg?1783906756,Creature — Ogre Shaman,Jay Howell
+Treasure Nabber,3,2023,2.67,#ff1a1a,https://cards.scryfall.io/normal/front/5/f/5facc43f-f865-45ad-888b-398f6e07b947.jpg?1783915641,Creature — Goblin Rogue,Alex Konstad
+Triple Triad,6,2025,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d9a1de36-7f47-4b28-bb56-38d7e5bed82f.jpg?1783906594,Enchantment,Ben Wootten
+Trumpeting Carnosaur,6,2023,2.12,#ff1a1a,https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg?1783913753,Creature — Dinosaur,Lars Grant-West
+Tuktuk the Explorer,3,2020,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/b/1/b17f5403-7692-41ca-a3c9-b81c31bddc00.jpg?1783930156,Legendary Creature — Goblin,Volkan Baǵa
+Tundra Fumarole,3,2021,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/b/2/b251aa7c-d011-4b52-ab92-415d536c0182.jpg?1783928221,Snow Sorcery,Simon Dominic
+Tunnel Ignus,2,2010,0.53,#ff1a1a,https://cards.scryfall.io/normal/front/c/3/c3016e6b-32b2-4fa7-91c0-ec8fbe345760.jpg?1783941721,Creature — Elemental,Scott Chou
+Turf War,5,2022,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/5/e/5e7fecbd-66f6-44b7-8fe4-b9b5bfce3e2c.jpg?1783923358,Enchantment,Victor Adame Minguez
+Twinflame,2,2026,0.8,#ff1a1a,https://cards.scryfall.io/normal/front/8/5/85c863ef-b266-410d-87b3-ced791f99966.jpg?1783903769,Sorcery,Chase Stone
+Twinflame Tyrant,5,2024,27.03,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg?1783909099,Creature — Dragon,Xabi Gaztelua
+Twist Allegiance,7,2005,0.41,#ff1a1a,https://cards.scryfall.io/normal/front/2/4/24b6607c-0c34-4ffc-b1b7-154417492766.jpg?1783944187,Sorcery,Wayne Reynolds
+Two-Headed Dragon,6,2010,0.95,#ff1a1a,https://cards.scryfall.io/normal/front/6/9/69e8136d-beab-4783-839c-2d60c26cf5b1.jpg?1783941906,Creature — Dragon,Sam Wood
+Two-Headed Giant,4,2018,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/6/f/6f86c365-3ce5-45e5-b610-6f2587f99b42.jpg?1783934986,Creature — Giant Warrior,Simon Dominic
+Two-Headed Giant of Foriys,5,1993,68.99,#ff1a1a,https://cards.scryfall.io/normal/front/6/7/67299451-5302-4639-a4bc-6109521a2c0c.jpg?1783948551,Creature — Giant,Anson Maddocks
+Tyrant of Discord,7,2012,4.28,#ff1a1a,https://cards.scryfall.io/normal/front/e/8/e8f7c8ea-e9c1-4d78-972c-15c4014915a0.jpg?1783940673,Creature — Elemental,Richard Wright
+Tyrant of Kher Ridges,6,2022,0.19,#ff1a1a,https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg?1783920058,Creature — Dragon,Karl Kopinski
+Tyrant of Valakut,7,2016,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/f/3/f388be9e-332e-4199-9f30-862d631fa26b.jpg?1783937905,Creature — Dragon,Tyler Jacobson
+Tyrant's Familiar,7,2018,0.9,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/08076c82-edb6-4c3c-abda-3d3ad7bdd78f.jpg?1783934734,Creature — Dragon,Todd Lockwood
+Ultimate Magic: Meteor,6,2025,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5b0f0fd-574a-4ae7-ab55-b815112d6b3a.jpg?1783906353,Sorcery,Ashley Mackenzie
+Umaro- Raging Yeti,6,2025,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/3/1/31aed8e9-44be-4e7c-85ac-a084eaecaea7.jpg?1783906353,Legendary Creature — Yeti Berserker,Norikatsu Miyoshi
+Uncivil Unrest,5,2023,18.44,#ff1a1a,https://cards.scryfall.io/normal/front/3/1/31afae93-d3c7-49c3-9f00-2cd9621e0ff8.jpg?1783917279,Enchantment,Lorenzo Mastroianni
+Underworld Breach,2,2020,10.17,#ff1a1a,https://cards.scryfall.io/normal/front/0/e/0e51d796-7279-4c06-87f0-37adbdaa41df.jpg?1783931543,Enchantment,Lie Setiawan
+Undying Flames,6,2005,0.33,#ff1a1a,https://cards.scryfall.io/normal/front/6/0/606206c7-1a8a-46f4-b368-cf18e02f3df8.jpg?1783944142,Sorcery,Tsutomu Kawade
+Unexpected Windfall,4,2025,4.11,#ff1a1a,https://cards.scryfall.io/normal/front/3/3/33ba9e5a-d078-4a47-b181-0ca7d1596919.jpg?1783905383,Instant,John Romita Sr.
+Unholy Heat,1,2024,1.98,#ff1a1a,https://cards.scryfall.io/normal/front/8/2/8288ca17-88b2-4ad4-9918-5624543e9048.jpg?1783909278,Instant,Josh Hass
+Unleash Fury,2,2025,1.28,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/2578f3b5-c233-4f44-8b10-5a9dc311add5.jpg?1783905120,Instant,Bastien L. Deharme
+Unpredictable Cyclone,5,2020,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3a0462f6-a027-43c0-8e01-c0591d9a45d9.jpg?1783931041,Enchantment,Noah Bradley
+Unquenchable Fury,3,2022,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/d/b/db6b3f71-d833-4548-8d66-1d51da08d8b9.jpg?1783923990,Enchantment — Aura,Livia Prima
+Unstable Hulk,3,2003,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/8/8/889cfde2-42fa-4278-ae4e-7e4dd993cda8.jpg?1783944902,Creature — Goblin Mutant,Ron Spencer
+Urabrask- Heretic Praetor,5,2022,1.53,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d9a4ec18-1da4-43c6-a79a-03fbd4aef3db.jpg?1783923111,Legendary Creature — Phyrexian Praetor,Simon Dominic
+Urabrask's Forge,3,2023,1.13,#ff1a1a,https://cards.scryfall.io/normal/front/6/8/68f9f9d8-9ea0-4608-a79c-a09a87918186.jpg?1783918022,Artifact,Lie Setiawan
+Urabrask // The Great Work,4,2023,17.29,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Phyrexian Praetor // Enchantment — Saga,Campbell White
+Urabrask the Hidden,5,2022,4.39,#ff1a1a,https://cards.scryfall.io/normal/front/9/3/93970fae-19f7-41dd-9750-ca428ae1de7a.jpg?1783922415,Legendary Creature — Phyrexian Praetor,Brad Rigney
+Urza's Rage,3,2015,0.12,#ff1a1a,https://cards.scryfall.io/normal/front/8/e/8ecb1e80-9514-4b96-ab06-3225ebe386d9.jpg?1783938074,Instant,Jim Murray
+Utvara Hellkite,8,2024,17.86,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df459109-d6ab-4b1d-9570-c7677ff4a014.jpg?1783913307,Creature — Dragon,Mark Zug
+Uvilda- Dean of Perfection // Nassari- Dean of Expression,3,2021,0.25,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Djinn Wizard // Legendary Creature — Efreet Shaman,Jason Rainville
+Vaan- Street Thief,3,2025,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/5/0/50e1ec29-9de3-4f1b-b818-057e030d475b.jpg?1783906593,Legendary Creature — Human Scout,Jake Murray
+Valakut Awakening // Valakut Stoneforge,3,2020,17.38,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Instant // Land,Campbell White
+Valakut Exploration,3,2020,3.77,#ff1a1a,https://cards.scryfall.io/normal/front/1/8/18cb7bf6-9c7c-4e62-a678-7b75862e2f64.jpg?1783929344,Enchantment,Jesper Ejsing
+Valley Flamecaller,3,2024,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/a/0/a0812db4-b7d1-4cf7-aaa5-9c0e784079a1.jpg?1783910814,Creature — Lizard Warlock,Justin Gerard
+Vance's Blasting Cannons // Spitfire Bastion,4,2017,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Enchantment // Legendary Land,Jonas De Ro
+Vandalblast,1,2025,2.57,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4a9c4a7d-9a48-4388-b0af-6fc509f74523.jpg?1783907436,Sorcery,Miguel Mercado
+Varchild- Betrayer of Kjeldor,3,2018,7.03,#ff1a1a,https://cards.scryfall.io/normal/front/7/8/7849b360-afad-4f50-b455-3d118f7bfcd0.jpg?1783934335,Legendary Creature — Human Knight,Lucas Graciano
+Vault 21: House Gambit,2,2024,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/4/0/40972644-a284-4c7c-a451-d70eff7488ab.jpg?1783912400,Enchantment — Saga,Kieran Yanner
+Velukan Dragon,7,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/1/e/1ef829f1-eaa7-43e7-acef-5bb688ca6077.jpg?1783910575,Creature — Dragon,Daren Bader
+Vengeful Ancestor,4,2025,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/b/c/bcaa3213-6fc9-43c7-9819-657e16a578f1.jpg?1783907054,Creature — Spirit Dragon,Mark Zug
+Vengeful Firebrand,4,2008,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/e/5/e5db7e33-188f-4d66-a58b-7b5c5760a773.jpg?1783942781,Creature — Elemental Warrior,William O'Connor
+Verix Bladewing,4,2025,0.29,#ff1a1a,https://cards.scryfall.io/normal/front/5/d/5d951996-3379-431d-bbb0-a7d099e72e4e.jpg?1783907053,Legendary Creature — Dragon,XiaoDi Jin
+Veronica- Dissident Scribe,3,2024,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/2/3/2325aa29-7050-42a5-a0b4-c162db2192c9.jpg?1783912399,Legendary Creature — Human Artificer Rogue,Pascal Quidault
+Veteran Brawlers,2,2000,2.1,#ff1a1a,https://cards.scryfall.io/normal/front/e/e/ee4d3acb-68be-409d-beb7-92a7cbc0402f.jpg?1783945774,Creature — Human Soldier,Paolo Parente
+Vexing Devil,1,2025,0.71,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/ba50e7df-9dec-4df8-94a5-5883bbedf0cb.jpg?1783908108,Creature — Devil,Lucas Graciano
+Viashino Sandswimmer,4,1998,0.51,#ff1a1a,https://cards.scryfall.io/normal/front/0/7/0790607f-51b7-40ff-80f9-4f7f5cd2d63c.jpg?1783946322,Creature — Lizard,Pete Venters
+Vicious Shadows,7,2008,1.88,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d040791e-eee4-4eef-ace1-507216a5d268.jpg?1783942556,Enchantment,Joshua Hagler
+Village Pillagers,5,2026,0.35,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a1e34ec4-6a85-4e22-9be9-f27dda5752d6.jpg?1783904602,Creature — Goblin Warrior,Paolo Parente
+Vincent- Vengeful Atoner,3,2025,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9e53d0b2-eeb0-4d54-86e5-723e05aaf6da.jpg?1783906353,Legendary Creature — Assassin,Lius Lasahido
+Vindictive Flamestoker,1,2023,0.26,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f67e7a16-ff30-4fb9-9fcb-6561eec50caf.jpg?1783918021,Creature — Phyrexian Wizard,Xavier Ribeiro
+Virtue of Courage // Embereth Blaze,5,2023,2.35,#ff1a1a,https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1783915088,Enchantment // Instant — Adventure,Piotr Dura
+Visions of Phyrexia,4,2022,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/e/9/e922ef35-b62a-4cf8-9282-319f6de150b0.jpg?1783920057,Enchantment,Dominik Mayer
+Visions of Ruin,4,2021,0.49,#ff1a1a,https://cards.scryfall.io/normal/front/8/0/803a93c7-d8e4-4cda-8fa0-d9cd50b7d977.jpg?1783925369,Sorcery,Andrew Mar
+Vivi's Persistence,2,2025,42.88,#ff1a1a,https://cards.scryfall.io/normal/front/b/e/be6ba2e4-e657-4a2d-8f5f-255376d861b3.jpg?1783904652,Instant,Erion Makuo
+Volatile Arsonist // Dire-Strain Anarchist,5,2021,0.61,#ff1a1a,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Werewolf // Creature — Werewolf,Gabor Szikszai
+Volatile Chimera,3,2016,0.15,#ff1a1a,https://cards.scryfall.io/normal/front/f/6/f6d3334c-7cf6-4e50-bece-d1ce462cfce8.jpg?1783937345,Creature — Elemental Chimera,Mathias Kollros
+Volcanic Dragon,6,1999,0.58,#ff1a1a,https://cards.scryfall.io/normal/front/8/d/8d52d5ae-49b2-4bc2-a539-381192f329d4.jpg?1783946025,Creature — Dragon,Janine Johnston
+Volcanic Fallout,3,2010,1.23,#ff1a1a,https://cards.scryfall.io/normal/front/8/d/8d3a69d2-518d-4b70-a03e-6d02a525f9ad.jpg?1783942074,Instant,Jim Pavelec
+Volcanic Offering,5,2018,3.22,#ff1a1a,https://cards.scryfall.io/normal/front/4/c/4c30b821-09ec-4b66-9963-f97e3ef5005c.jpg?1783934733,Instant,Eric Velhagen
+Volcanic Salvo,12,2026,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fdd9dda5-0386-45a4-aec1-853137281934.jpg?1783903771,Sorcery,Torstein Nordstrand
+Volcanic Torrent,5,2025,0.69,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1d5a5e01-bfe1-474a-82b7-4b4981c3b2f4.jpg?1783904850,Sorcery,Viacom
+Volcanic Vision,7,2021,0.66,#ff1a1a,https://cards.scryfall.io/normal/front/f/9/f973e1a6-c6f9-47f5-9bf0-b7fa06959bd4.jpg?1783927538,Sorcery,Liiga Smilshkalne
+Volcano Hellion,4,2007,0.82,#ff1a1a,https://cards.scryfall.io/normal/front/0/2/026b1a54-ab62-431d-a23e-5890d3932c7e.jpg?1783943145,Creature — Hellion,Wayne Reynolds
+Voldaren Thrillseeker,3,2023,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1dbcd466-fb99-4388-a118-4534b85544f0.jpg?1783916978,Creature — Vampire Warrior,Viko Menezes
+Volley of Boulders,9,2012,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/aecab75c-25e5-4465-9c0a-28c2f6dc2ce5.jpg?1783940755,Sorcery,Tony Szczudlo
+Voracious Dragon,5,2011,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/f/b/fbda3a22-2aff-49db-8779-38551142b860.jpg?1783941338,Creature — Dragon,Dominick Domingo
+Vorthos- Steward of Myth,2,2022,0.28,#d78f42,https://cards.scryfall.io/normal/front/b/d/bd42cab5-3285-48bf-a8f2-f57a474565ad.jpg?1783920559,Legendary Creature — Human Gamer,Caroline Gariba
+Vulshok Battlemaster,5,2003,0.5,#ff1a1a,https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg?1783944537,Creature — Human Warrior,Kev Walker
+Vulshok Factory,3,2023,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/b/1/b1c40dd7-6839-49ae-9901-443fd5748877.jpg?1783918158,Artifact,Cristi Balanescu
+Wake of Destruction,6,1999,4.6,#ff1a1a,https://cards.scryfall.io/normal/front/0/c/0c070f12-0342-48d5-ab0e-4fc4701c3669.jpg?1783946064,Sorcery,Todd Lockwood
+Wall of Opposition,5,1994,7.43,#ff1a1a,https://cards.scryfall.io/normal/front/2/b/2b3d1430-9978-4983-a4fd-d1fa8dea2169.jpg?1783948053,Creature — Wall,Harold McNeill
+Waltz of Rage,5,2024,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg?1783909459,Sorcery,Mathias Kollros
+Wanda's Vision,5,2026,8.06,#ff1a1a,https://cards.scryfall.io/normal/front/4/3/43cf33cc-c1ac-4196-aa82-b27083694f64.jpg?1783903042,Enchantment,Peter Scanlan
+Wand of Wonder,4,2022,2.4,#ff1a1a,https://cards.scryfall.io/normal/front/d/f/df67ec01-9d4c-4ae1-9c8a-f94d649c81bc.jpg?1783922726,Artifact,Xavier Ribeiro
+War Elemental,3,2003,4.55,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg?1783944535,Creature — Elemental,Anthony S. Waters
+War Machine- Avenging Arsenal,5,2026,0.61,#ff1a1a,https://cards.scryfall.io/normal/front/8/c/8c62621f-20b2-4950-a74a-7c2e4fc02e54.jpg?1783903278,Legendary Artifact Creature — Human Hero,David Seeley
+Warmaker Gunship,3,2025,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/9/e/9e5957f4-1cae-4989-8b40-27fc6e2fcf5e.jpg?1783905944,Artifact — Spacecraft,Julian Kok Joon Wen
+Warmonger Hellkite,6,2022,0.31,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bbedbf64-cd51-4f40-9735-272bd86fdf84.jpg?1783922414,Creature — Dragon,Trevor Claxton
+Warp World,8,2009,1.82,#ff1a1a,https://cards.scryfall.io/normal/front/a/a/aa6e1fb5-a06b-4e10-8cc7-785e0f0b298e.jpg?1783942367,Sorcery,Ron Spencer
+Warrior's Oath,2,2022,17.36,#ff1a1a,https://cards.scryfall.io/normal/front/6/5/65e10759-e862-4b69-8b58-474df2cdae29.jpg?1783921877,Sorcery,Eric Deschamps
+War's Toll,4,2018,10.3,#ff1a1a,https://cards.scryfall.io/normal/front/3/a/3a08f7fe-8ca9-4604-85c8-9050298730ea.jpg?1783934810,Enchantment,Dana Knutson
+Warstorm Surge,6,2022,0.91,#ff1a1a,https://cards.scryfall.io/normal/front/d/b/dbe1bfe0-0be7-496d-94db-e8028d4d9493.jpg?1783922416,Enchantment,Raymond Swanland
+Wartime Protestors,4,2025,0.27,#ff1a1a,https://cards.scryfall.io/normal/front/b/a/bac81940-d717-49ff-83b2-16a22bb2c988.jpg?1783904950,Creature — Human Rebel Ally,Yosuke Adachi
+Wayward Guide-Beast,1,2020,0.18,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d00f8ab0-61cd-4721-b974-a2516da77d39.jpg?1783929344,Creature — Beast,Filip Burburan
+Weapons Manufacturing,2,2025,1.87,#ff1a1a,https://cards.scryfall.io/normal/front/a/0/a058f1a6-318c-4bba-981e-ace079ada806.jpg?1783905943,Enchantment,Marco Gorlei
+Wheel of Fate,0,2021,3.65,#ff1a1a,https://cards.scryfall.io/normal/front/c/7/c7937e12-76d9-4030-a68c-7a93a3c852cb.jpg?1783927784,Sorcery,Kev Walker
+Wheel of Misfortune,3,2020,7.98,#ff1a1a,https://cards.scryfall.io/normal/front/7/4/74177b51-a300-49d9-8ea7-557b19cf80c7.jpg?1783928800,Sorcery,J.P. Targete
+Wheel of Potential,3,2024,0.23,#ff1a1a,https://cards.scryfall.io/normal/front/c/4/c4eb9a82-91f7-4741-a029-a07a3ff6af78.jpg?1783911264,Sorcery,Drew Baker
+Where Ancients Tread,5,2013,0.79,#ff1a1a,https://cards.scryfall.io/normal/front/a/b/abf25a2a-961c-42ef-8d76-aa089720b12c.jpg?1783939663,Enchantment,Zoltan Boros & Gabor Szikszai
+Whims of the Fates,6,2016,0.21,#ff1a1a,https://cards.scryfall.io/normal/front/a/e/aeb8d3fc-99e4-49dd-b1f1-bb479b361743.jpg?1783937061,Sorcery,Seb McKinnon
+Widespread Panic,3,2013,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/d/9/d9e1b37f-8168-4dc0-858f-434ee96ff748.jpg?1783939664,Enchantment,Dave Kendall
+Widespread Thieving,3,2022,0.28,#d78f42,https://cards.scryfall.io/normal/front/c/d/cd22723d-855f-4b31-827f-a4e388ebbc07.jpg?1783923111,Enchantment,Andrew Mar
+Wild Evocation,6,2010,1.1,#ff1a1a,https://cards.scryfall.io/normal/front/b/3/b39aea56-5c56-4241-81c9-928c3253d7c9.jpg?1783941801,Enchantment,Chippy
+Wildfire,6,2015,1.87,#ff1a1a,https://cards.scryfall.io/normal/front/c/5/c5924430-1904-47b9-bcf0-3379babd395c.jpg?1783938401,Sorcery,Rob Alexander
+Wildfire Devils,4,2021,0.45,#ff1a1a,https://cards.scryfall.io/normal/front/f/2/f2181ef5-963a-4e3b-805d-b3a04f4bef5e.jpg?1783927538,Creature — Devil,Izzy
+Wildfire Eternal,4,2017,0.24,#ff1a1a,https://cards.scryfall.io/normal/front/f/d/fd845479-619a-4262-b445-d93975c183b4.jpg?1783936023,Creature — Zombie Jackal Cleric,Magali Villeneuve
+Wild-Magic Sorcerer,4,2022,5.84,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5de7331-d0c6-46a5-b08d-0e032db63223.jpg?1783922412,Creature — Orc Shaman Sorcerer,Aaron J. Riley
+Wild Research,3,2001,1.51,#d78f42,https://cards.scryfall.io/normal/front/8/f/8f00e6f1-e854-40b0-855d-7e0d7d233850.jpg?1783945342,Enchantment,Gary Ruddell
+Wild Ricochet,4,2020,0.34,#ff1a1a,https://cards.scryfall.io/normal/front/8/d/8d3dddfa-9579-42d7-867b-7e37b83b3eeb.jpg?1783928710,Instant,Dan Murayama Scott
+Wild Wasteland,3,2024,1.58,#ff1a1a,https://cards.scryfall.io/normal/front/c/a/ca1024d6-c5f1-48f5-9081-fb90d0c46fdb.jpg?1783912401,Enchantment,Mathias Kollros
+Will of the Jeskai,4,2025,2.92,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d05bac1f-d455-4528-93b2-a94c29b5dc2c.jpg?1783907169,Sorcery,Jessica Fong
+Winds of Change,1,1997,13.43,#ff1a1a,https://cards.scryfall.io/normal/front/7/3/735b8aec-62d4-46db-9a68-a6c69cb6fd98.jpg?1783946810,Sorcery,Adam Rex
+Winter Sky,1,1995,1.85,#ff1a1a,https://cards.scryfall.io/normal/front/a/f/af1035f3-3027-4a41-834c-55222b13c2bc.jpg?1783947282,Sorcery,Mike Kimble
+Wish,3,2021,0.54,#ff1a1a,https://cards.scryfall.io/normal/front/3/e/3ed021d2-e2bc-44b3-8934-4bd02e0a42ec.jpg?1783926471,Sorcery,Ekaterina Burmak
+Witch Hunt,5,2013,0.37,#ff1a1a,https://cards.scryfall.io/normal/front/1/d/1db6d2a4-183e-47ff-bebe-efefd4bcc4be.jpg?1783939664,Enchantment,Karl Kopinski
+Wolf of Devil's Breach,5,2016,0.38,#ff1a1a,https://cards.scryfall.io/normal/front/f/e/fedce04c-e7bc-4db0-94a1-66131761512c.jpg?1783937738,Creature — Elemental Wolf,Jack Wang
+Word of Seizing,5,2020,0.17,#ff1a1a,https://cards.scryfall.io/normal/front/4/a/4aa93215-9848-42d4-a386-6a248c2a1742.jpg?1783928709,Instant,Vance Kovacs
+Words of War,3,2002,0.6,#ff1a1a,https://cards.scryfall.io/normal/front/2/5/2593a6a6-dc21-4742-acb8-f7092931b1ce.jpg?1783945046,Enchantment,Justin Sweet
+World at War,5,2010,9.67,#ff1a1a,https://cards.scryfall.io/normal/front/a/4/a47a05ad-fe86-481e-b770-e1760be4f852.jpg?1783941970,Sorcery,Igor Kieryluk
+Worldfire,9,2012,33.54,#ff1a1a,https://cards.scryfall.io/normal/front/2/e/2ef3d4b5-0453-4bf0-b018-23b0c3b9ae11.jpg?1783940477,Sorcery,Izzy
+Worldgorger Dragon,6,2023,1.95,#ff1a1a,https://cards.scryfall.io/normal/front/3/3/33dde6e0-d0a7-4432-a3f4-b48234f4e055.jpg?1783918449,Creature — Nightmare Dragon,Néstor Ossandón Leal
+Worldheart Phoenix,4,2009,0.11,#d78f42,https://cards.scryfall.io/normal/front/7/3/73922629-5e85-451f-8ad6-4c8a60aab935.jpg?1783942477,Creature — Phoenix,Aleksi Briclot
+Wrathful Raptors,5,2023,4.19,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/49243e92-93e3-4090-b4f7-86fa4ca2fef5.jpg?1783913908,Creature — Dinosaur,April Prime
+Wrathful Red Dragon,5,2022,5.3,#ff1a1a,https://cards.scryfall.io/normal/front/a/c/acd207de-eec3-4d82-b8b9-b1e60a7bad12.jpg?1783922724,Creature — Dragon,Dan Murayama Scott
+Wrecking Ogre,5,2013,0.2,#ff1a1a,https://cards.scryfall.io/normal/front/8/7/87f1a27c-c576-4c34-873f-6faf020c2773.jpg?1783940120,Creature — Ogre Warrior,Nils Hamm
+Wyll- Blade of Frontiers,2,2022,0.6,#ff1a1a,https://cards.scryfall.io/normal/front/5/e/5e9d4562-964d-48ce-b03f-7cb491fa040d.jpg?1783922724,Legendary Creature — Human Warlock,Mads Ahm
+Wyll's Reversal,3,2022,3.52,#ff1a1a,https://cards.scryfall.io/normal/front/3/d/3d8df219-1da0-4311-b9bb-c74b5fa55293.jpg?1783922723,Instant,Irina Nordsol
+Xorn,3,2021,7.52,#ff1a1a,https://cards.scryfall.io/normal/front/f/7/f73fdf76-e3a6-49d0-bfb0-4b7cdbd4271e.jpg?1783926470,Creature — Elemental,Yigit Koroglu
+Yellow Scarves General,4,1999,37.72,#ff1a1a,https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg?1783946103,Creature — Human Soldier,Chen Weidong
+Yet Another Aether Vortex,5,2020,0.16,#ff1a1a,https://cards.scryfall.io/normal/front/e/5/e5d85779-89f6-4f4e-b34a-d44a6d15ce06.jpg?1783931327,Enchantment,David Day
+Yidaro- Wandering Monster,7,2020,0.39,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b540c7c6-5b9e-4606-ac84-e583a62a3647.jpg?1783931041,Legendary Creature — Dinosaur Turtle,Jesper Ejsing
+You Find Some Prisoners,2,2026,0.99,#ff1a1a,https://cards.scryfall.io/normal/front/d/0/d0edf3df-4c36-4015-896b-a873bcb2893f.jpg?1783904226,Instant,Adam Volker
+Young Pyromancer,2,2020,0.43,#ff1a1a,https://cards.scryfall.io/normal/front/2/d/2dd80b9f-5c35-438b-ba52-da0e3e8ff781.jpg?1783930749,Creature — Human Shaman,Cynthia Sheppard
+Yuan Shao- the Indecisive,5,1999,132.34,#ff1a1a,https://cards.scryfall.io/normal/front/5/e/5e9b3794-d0f0-4d28-85cb-22492e195ae1.jpg?1783946103,Legendary Creature — Human Soldier,Inoue Junichi
+Yuffie- Materia Hunter,3,2025,0.25,#ff1a1a,https://cards.scryfall.io/normal/front/1/1/117bb5db-4a1c-4704-b0b5-c67b45ac2f52.jpg?1783906353,Legendary Creature — Human Ninja,Touge369
+Zada- Hedron Grinder,4,2015,0.48,#ff1a1a,https://cards.scryfall.io/normal/front/f/c/fc0969f1-92a0-47c3-8eff-d106fbef2f7e.jpg?1783938190,Legendary Creature — Goblin Ally,Chris Rallis
+Zalto- Fire Giant Duke,5,2021,0.62,#ff1a1a,https://cards.scryfall.io/normal/front/9/c/9c6da066-accb-4c09-9acb-4de263dadad3.jpg?1783926468,Legendary Creature — Giant Barbarian,Zezhou Chen
+Zariel- Archduke of Avernus,4,2021,2.41,#ff1a1a,https://cards.scryfall.io/normal/front/7/b/7be5b866-d479-4698-98b2-87a973f6b8f6.jpg?1783926467,Legendary Planeswalker — Zariel,Heonhwa
+Zealous Conscripts,5,2025,0.32,#ff1a1a,https://cards.scryfall.io/normal/front/b/5/b5ca6c08-bfe0-4021-b6ad-e235c8905661.jpg?1783908106,Creature — Human Warrior,Steve Prescott
+Zell Dincht,3,2025,0.36,#ff1a1a,https://cards.scryfall.io/normal/front/1/3/135d6b27-9168-4513-9d7d-56edae048857.jpg?1783906593,Legendary Creature — Human Monk,Kevin Sidharta
+Zenith Festival,2,2025,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/8/c/8cffd86b-1f4a-4e1c-a5a0-f467ecd8f63b.jpg?1783907169,Sorcery,Ben Wootten
+Zhao- the Moon Slayer,2,2025,0.3,#ff1a1a,https://cards.scryfall.io/normal/front/f/1/f1015bf5-de98-41f3-b6b1-ed95f7465944.jpg?1783904949,Legendary Creature — Human Soldier,Toraji
+Zirilan of the Claw,5,1996,9.14,#ff1a1a,https://cards.scryfall.io/normal/front/a/1/a105b7f4-c93b-4b54-acf8-7212907d9cd6.jpg?1783947070,Legendary Creature — Lizard Shaman,Andrew Robinson
+Zo-Zu the Punisher,3,2017,9.02,#ff1a1a,https://cards.scryfall.io/normal/front/e/7/e7c927d6-911d-4a37-89a2-6c500edf4dd7.jpg?1783936566,Legendary Creature — Goblin Warrior,Wayne Reynolds
+Zuko- Firebending Master,2,2025,9.41,#ff1a1a,https://cards.scryfall.io/normal/front/4/9/496a4fa5-b3e5-4020-b432-6d353095aa33.jpg?1783904817,Legendary Creature — Human Noble Ally,Kinota Eishi
+Zurgo Bellstriker,1,2015,0.28,#ff1a1a,https://cards.scryfall.io/normal/front/b/b/bbac6d75-59ab-4d7d-87ae-46875abf8cc7.jpg?1783938583,Legendary Creature — Orc Warrior,Jason Rainville
+Zurzoth- Chaos Rider,3,2022,1.75,#ff1a1a,https://cards.scryfall.io/normal/front/c/6/c62990d7-a337-4fc3-859c-63bc1dade1b9.jpg?1783923255,Legendary Creature — Devil,Dmitry Burmak

--- a/magic_card_csv_files_by_color/U.csv
+++ b/magic_card_csv_files_by_color/U.csv
@@ -1,0 +1,1607 @@
+name,cmc,release_year,price,color,image,type_line,artist
+Abhorrent Oculus,3,2024,14.89,#341aff,https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg?1783909500,Creature — Eye,Bryan Sola
+Aboleth Spawn,3,2022,8.48,#341aff,https://cards.scryfall.io/normal/front/5/1/51889b3f-082a-40e9-8be7-11f8c1a7a9a8.jpg?1783922509,Creature — Fish Horror,Sam Burley
+Aboshan- Cephalid Emperor,6,2001,0.52,#341aff,https://cards.scryfall.io/normal/front/8/2/82db4a41-03e8-4f0c-946c-a98fc5c9f7c8.jpg?1783945269,Legendary Creature — Octopus Noble,Christopher Moeller
+Abstract Performance,6,2026,0.22,#341aff,https://cards.scryfall.io/normal/front/2/7/2795c812-0850-4405-b968-b624deaccd55.jpg?1783903863,Sorcery,Alessandra Pisano
+Academy Elite,4,2016,0.22,#341aff,https://cards.scryfall.io/normal/front/f/3/f3728fbb-3a99-443a-b514-40f9990669c5.jpg?1783937075,Creature — Human Wizard,Volkan Baǵa
+Academy Loremaster,2,2022,0.24,#341aff,https://cards.scryfall.io/normal/front/9/f/9fca4c4f-a77b-483e-9da4-574ba2e3d179.jpg?1783921356,Creature — Human Wizard,Marcela Medeiros
+Access Denied,5,2022,2.78,#341aff,https://cards.scryfall.io/normal/front/1/6/1642df77-6fe8-47cf-b750-ca4dd9b331ba.jpg?1783923996,Instant,Johan Grenier
+Acquire,5,2004,2.87,#341aff,https://cards.scryfall.io/normal/front/9/9/993957c7-5d61-4c98-826d-b657aed667e1.jpg?1783944407,Sorcery,Daren Bader
+Adaptive Training Post,3,2025,0.26,#341aff,https://cards.scryfall.io/normal/front/6/5/654a1564-0356-44ad-b1ab-8c1a556fc244.jpg?1783907183,Artifact,Ben Maier
+Admiral's Order,3,2018,0.32,#341aff,https://cards.scryfall.io/normal/front/8/0/80dc0310-afd9-49b4-b58f-a0e91120c38c.jpg?1783935329,Instant,Slawomir Maniak
+Adric- Mathematical Genius,2,2023,0.32,#341aff,https://cards.scryfall.io/normal/front/1/f/1f290a17-699e-420d-8322-3e28300a0d2e.jpg?1783914673,Legendary Creature — Human Artificer,Billy Christian
+Aeon Chronicler,5,2021,0.35,#341aff,https://cards.scryfall.io/normal/front/5/c/5cec8dcc-8ebb-4640-a5f3-90e6e62c27e5.jpg?1783927854,Creature — Avatar,Dan Dos Santos
+Aerial Caravan,6,1999,0.38,#341aff,https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg?1783945971,Creature — Human Soldier,DiTerlizzi
+Aether Barrier,3,2000,5.1,#341aff,https://cards.scryfall.io/normal/front/3/6/36298f9f-12cc-43bd-adda-ccabd67a9568.jpg?1783945839,Enchantment,David Martin
+Aether Channeler,3,2022,0.35,#341aff,https://cards.scryfall.io/normal/front/6/0/60afeb75-2c1e-4634-8c83-88b1dddb77c2.jpg?1783921355,Creature — Human Wizard,Caio Monteiro
+Aether Gale,5,2024,0.32,#341aff,https://cards.scryfall.io/normal/front/f/9/f956bdf3-6b1d-4730-98f6-ba89d3a12b8b.jpg?1783909628,Sorcery,Jack Wang
+Aether Gust,2,2021,1.8,#341aff,https://cards.scryfall.io/normal/front/b/c/bcc1aa91-ec97-4fe8-b4b1-a213f050f956.jpg?1783924583,Instant,Mateus Manhanini
+Aetherize,4,2024,22.52,#341aff,https://cards.scryfall.io/normal/front/7/9/7993b049-09d8-4c1a-9455-bb092249e0b6.jpg?1783909218,Instant,Peach Momoko
+Aetherling,6,2013,0.3,#341aff,https://cards.scryfall.io/normal/front/9/c/9c93313b-cf43-47e9-a911-717b4d14b0b5.jpg?1783940042,Creature — Shapeshifter,Tyler Jacobson
+Aethersnatch,6,2015,1.15,#341aff,https://cards.scryfall.io/normal/front/0/c/0ce562a9-ca35-4f31-8618-bc26d3d40169.jpg?1783938115,Instant,Aaron Miller
+Aetherspouts,5,2021,0.72,#341aff,https://cards.scryfall.io/normal/front/b/5/b5cb6da6-d43b-4ad1-bb77-9eeb6d15240c.jpg?1783925347,Instant,Dan Murayama Scott
+Aethersquall Ancient,7,2016,0.18,#341aff,https://cards.scryfall.io/normal/front/5/5/55127a25-dc64-4f26-ae50-ed7247c22ae6.jpg?1783937223,Creature — Leviathan,Sam Burley
+Aethertide Whale,6,2017,0.08,#341aff,https://cards.scryfall.io/normal/front/3/8/38722c25-13a7-47af-a4cd-90722f289499.jpg?1783936774,Creature — Whale,Steven Belledin
+Agent of Treachery,7,2019,5.03,#341aff,https://cards.scryfall.io/normal/front/c/c/cc6686e6-4535-49be-b0b3-e76464656cd2.jpg?1783933017,Creature — Human Rogue,Igor Kieryluk
+Akal Pakal- First Among Equals,3,2023,0.21,#341aff,https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg?1783913800,Legendary Creature — Human Advisor,Ryan Pancoast
+Alandra- Sky Dreamer,4,2024,9.33,#341aff,https://cards.scryfall.io/normal/front/5/4/54bf48d4-e350-4ca7-87da-ce04fefd4610.jpg?1783913021,Legendary Creature — Merfolk Wizard,Caroline Gariba
+Alexander Clamilton,3,2020,0.47,#d78f42,https://cards.scryfall.io/normal/front/a/1/a1572109-df70-4335-aac2-1670fe99be54.jpg?1783931346,Legendary Creature — Clamfolk Advisor Rebel,Dmitry Burmak
+Alexi- Zephyr Mage,5,2000,0.52,#341aff,https://cards.scryfall.io/normal/front/6/f/6f8fc0b0-4a23-47ed-b61b-a4505fcfc5d2.jpg?1783945793,Legendary Creature — Human Spellshaper,Mark Zug
+Alhammarret- High Arbiter,7,2015,0.22,#341aff,https://cards.scryfall.io/normal/front/4/2/4200b101-19d3-4442-bddd-3eb77d5f99a9.jpg?1783938355,Legendary Creature — Sphinx,Richard Wright
+All of History- All at Once,4,2023,0.29,#341aff,https://cards.scryfall.io/normal/front/b/b/bb6c639c-0b8a-4369-b7d0-57aa1f83279a.jpg?1783914674,Sorcery,Néstor Ossandón Leal
+All-Seeing Arbiter,6,2022,0.35,#341aff,https://cards.scryfall.io/normal/front/c/8/c832c0b8-aefa-459c-8de8-aa32400612cd.jpg?1783923151,Creature — Avatar,Robin Olausson
+Alphinaud Leveilleur,4,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/6/5/65331e86-1ff3-45e4-b789-7afec4ca9bd5.jpg?1783906363,Legendary Creature — Elf Wizard,Justyna Dura
+Alrund- God of the Cosmos // Hakka- Whispering Raven,5,2021,1.07,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Creature — Bird,Kieran Yanner
+Alrund's Epiphany,7,2021,4.51,#341aff,https://cards.scryfall.io/normal/front/c/9/c94fcb53-a7bd-4a80-a536-9fb0eb24261a.jpg?1783928270,Sorcery,Kieran Yanner
+Alter Reality,2,2002,1.95,#341aff,https://cards.scryfall.io/normal/front/6/4/64cd68be-6e6a-4577-8465-a892463b6d6c.jpg?1783945166,Instant,Justin Sweet
+Ambassador Laquatus,3,2007,1.07,#341aff,https://cards.scryfall.io/normal/front/b/2/b261067f-b5de-41cc-ba9e-6ef4c061e170.jpg?1783943062,Legendary Creature — Merfolk Wizard,Jim Murray
+Ambiguity,4,2004,0.77,#341aff,https://cards.scryfall.io/normal/front/6/f/6f834c86-cd38-40bf-9aad-b4098895de86.jpg?1783944260,Enchantment,Stephen Daniele
+Ambling Stormshell,5,2025,0.26,#341aff,https://cards.scryfall.io/normal/front/c/7/c74d4a57-0f66-4965-9ed7-f88a08aa1d15.jpg?1783907403,Creature — Turtle,Carlos Palma Cruchaga
+Aminatou's Augury,8,2024,0.35,#341aff,https://cards.scryfall.io/normal/front/5/0/503448da-d14f-4759-85b6-0db2e90e0241.jpg?1783909645,Sorcery,Loïc Canavaggia
+Amphibian Downpour,3,2024,1.36,#341aff,https://cards.scryfall.io/normal/front/2/d/2d8aeca5-622a-45be-8168-07e7c00e3092.jpg?1783911294,Enchantment — Aura,Omar Rayyan
+Amphin Mutineer,4,2025,0.2,#341aff,https://cards.scryfall.io/normal/front/9/6/967b5ed9-7275-4564-8bf9-2748fea2f387.jpg?1783907111,Creature — Salamander Pirate,Nicholas Gregory
+Amugaba,7,2001,0.36,#341aff,https://cards.scryfall.io/normal/front/8/d/8d73d1e7-79be-4b28-a480-b65b4f34f755.jpg?1783945268,Creature — Illusion,Heather Hudson
+Ancestral Knowledge,2,1997,7.62,#341aff,https://cards.scryfall.io/normal/front/0/5/05b90d72-00ac-4423-8cdf-e1471c6cd0ae.jpg?1783946744,Enchantment,Colin MacNeil
+Ancestral Memories,5,2001,0.34,#341aff,https://cards.scryfall.io/normal/front/1/0/100f0ca8-a66a-452f-be5f-17f631ba0ee0.jpg?1783945557,Sorcery,Rebecca Guay
+Ancestral Recall,1,1993,4999.95,#341aff,https://cards.scryfall.io/normal/front/2/d/2dd41293-d7c8-4422-9f0c-b3e96350f5c9.jpg?1783948580,Instant,Mark Poole
+Ancestral Vision,0,2025,0.3,#341aff,https://cards.scryfall.io/normal/front/9/e/9ec075ba-db56-4dcf-b1dc-fe6270b7ab36.jpg?1783907110,Sorcery,John Avon
+Ancient Silver Dragon,8,2022,56.65,#341aff,https://cards.scryfall.io/normal/front/c/e/ced18935-4ce9-466e-a88d-2b14ff8f989f.jpg?1783922795,Creature — Elder Dragon,Raoul Vitale
+Angler Turtle,7,2022,0.19,#341aff,https://cards.scryfall.io/normal/front/9/c/9c8d57fc-9695-45df-8b88-0048330608bd.jpg?1783922476,Creature — Turtle,Alex Konstad
+Animate Library,6,2017,0.47,#341aff,https://cards.scryfall.io/normal/front/a/d/add4f168-c69e-4045-9725-47208ef69935.jpg?1783935454,Enchantment — Aura,Raymond Swanland
+An Offer You Can't Refuse,1,2023,10.81,#341aff,https://cards.scryfall.io/normal/front/1/3/134200c4-88af-4772-9031-a59669e8c2ec.jpg?1783914809,Instant,Miho Irie
+Anthroplasm,4,1999,0.58,#341aff,https://cards.scryfall.io/normal/front/0/8/089e2bc7-0063-47bf-8f66-48bed6eb046b.jpg?1783946250,Creature — Shapeshifter,Ron Spencer
+An Unearthly Child,3,2023,0.23,#341aff,https://cards.scryfall.io/normal/front/7/2/72b20b07-2983-4b5e-9351-b8d7a5bcd72a.jpg?1783914674,Enchantment — Saga,Kieran Yanner
+Apprentice Wizard,3,1994,6.84,#341aff,https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg?1783947945,Creature — Human Wizard,Dan Frazier
+April O'Neil- Hacktivist,4,2026,0.33,#341aff,https://cards.scryfall.io/normal/front/f/0/f0147f6d-b797-4d5e-aca2-a9d309896eca.jpg?1783904119,Legendary Creature — Human Scientist,Xabi Gaztelua
+April O'Neil- Human Element,4,2026,5.52,#341aff,https://cards.scryfall.io/normal/front/c/d/cd6d7bba-2de4-49fe-8e07-a7c00c6bfc96.jpg?1783904139,Legendary Creature — Human Detective,Fahmi Fauzi
+April O'Neil- Live on the Scene,2,2026,0.25,#341aff,https://cards.scryfall.io/normal/front/7/2/7265ab42-5434-4127-acd6-8905ab63d62d.jpg?1783904171,Legendary Creature — Human Detective,Jakob Eirich
+Arbiter of the Ideal,6,2014,0.26,#341aff,https://cards.scryfall.io/normal/front/3/2/32e58ba3-4202-4f91-b27f-7528d27c1d5c.jpg?1783939573,Creature — Sphinx,Svetlin Velinov
+Arcane Adaptation,3,2017,2.77,#341aff,https://cards.scryfall.io/normal/front/b/f/bf3edaaf-cf63-4e17-94ae-9d9991d9fb5f.jpg?1783935787,Enchantment,Mark Behm
+Arcane Artisan,3,2021,0.32,#341aff,https://cards.scryfall.io/normal/front/b/a/ba946cfb-a729-406b-be35-0defaf95283e.jpg?1783928326,Creature — Human Wizard,Tommy Arnold
+Arcane Denial,2,2026,7.28,#341aff,https://cards.scryfall.io/normal/front/a/9/a92394e2-00d3-4106-86ff-e9823e346a97.jpg?1783904247,Instant,Lee Woo-chul
+Arcane Endeavor,7,2021,0.45,#341aff,https://cards.scryfall.io/normal/front/7/8/7886d4e9-003c-4978-a48d-4743fbc38985.jpg?1783926255,Sorcery,Justyna Dura
+Arcane Heist,4,2024,3.5,#341aff,https://cards.scryfall.io/normal/front/3/c/3ceb13f4-ac9e-4ddd-9170-545f8d37b87a.jpg?1783911969,Sorcery,Anna Pavleeva
+Arcane Melee,5,2013,0.35,#341aff,https://cards.scryfall.io/normal/front/9/e/9ea8fd24-311a-4745-804e-46b2abbe217a.jpg?1783939686,Enchantment,Jaime Jones
+Arcane Savant,5,2016,0.16,#341aff,https://cards.scryfall.io/normal/front/0/e/0e7466e5-9443-4b38-a7e9-e0d615a35667.jpg?1783937360,Creature — Human Wizard,Chris Rallis
+Arcanis the Omnipotent,6,2026,0.28,#341aff,https://cards.scryfall.io/normal/front/9/d/9d31e3e3-f398-4c0e-a2c9-4c614a4d41de.jpg?1783903955,Legendary Creature — Wizard,Justin Sweet
+Archaeomancer,4,2026,2.25,#341aff,https://cards.scryfall.io/normal/front/d/5/d583783f-623c-40dd-9dac-0937d65f9341.jpg?1783903580,Creature — Human Wizard,Aurore Folny
+Archive Trap,5,2009,1.75,#341aff,https://cards.scryfall.io/normal/front/6/7/67bb2ca9-32b8-442d-b6a0-d624a87f5af8.jpg?1783942166,Instant — Trap,Jason Felix
+Archivist,4,2005,0.37,#341aff,https://cards.scryfall.io/normal/front/2/f/2f025c11-feeb-429b-9518-f24d70596601.jpg?1783944068,Creature — Human Wizard,Donato Giancola
+Archivist of Gondor,3,2023,0.28,#341aff,https://cards.scryfall.io/normal/front/e/c/ec691418-1075-477f-b0df-f0d064588baf.jpg?1783916032,Creature — Human Advisor,Wisnu Tan
+Archmage Ascension,3,2009,4.77,#341aff,https://cards.scryfall.io/normal/front/d/b/dbfe803d-88d7-4ad2-b3d8-c41c123d8bf3.jpg?1783942166,Enchantment,Christopher Moeller
+Archmage Emeritus,4,2026,0.48,#341aff,https://cards.scryfall.io/normal/front/d/d/dd547601-d650-4a02-a3a4-890bcef03a7c.jpg?1783903793,Creature — Human Wizard,Caio Monteiro
+Archmage of Echoes,5,2023,15.76,#341aff,https://cards.scryfall.io/normal/front/c/8/c8a40d37-6bd7-4476-9968-36b1988f36e2.jpg?1783914988,Creature — Faerie Wizard,Olena Richards
+Archmage of Runes,5,2024,3.46,#341aff,https://cards.scryfall.io/normal/front/3/3/334b5018-2da9-49f1-9d09-83d312ecfb02.jpg?1783909121,Creature — Giant Wizard,Kai Carpenter
+Archmage's Charm,3,2019,1.95,#341aff,https://cards.scryfall.io/normal/front/5/7/57b852b6-4388-4a41-a5c0-bba37a5c1451.jpg?1783933150,Instant,Alayna Danner
+Archmage's Newt,2,2024,0.18,#341aff,https://cards.scryfall.io/normal/front/a/4/a440bbd6-8e51-4db1-90d9-7fa9fc327ad5.jpg?1783911850,Creature — Salamander Mount,Edgar Sánchez Hidalgo
+Arcum Dagsson,4,2020,18.36,#341aff,https://cards.scryfall.io/normal/front/f/5/f5ecf811-2efc-4fa6-9af8-ef09f559ec1a.jpg?1783930205,Legendary Creature — Human Artificer,Pete Venters
+Argent Sphinx,4,2015,0.16,#341aff,https://cards.scryfall.io/normal/front/9/9/99d03f11-7448-47de-9fb4-3ceaf08dc1d4.jpg?1783938422,Creature — Sphinx,Chris Rahn
+Artificer Class,2,2022,16.01,#341aff,https://cards.scryfall.io/normal/front/c/f/cf4e9335-06e3-4b27-8fd8-3e44ece89a36.jpg?1783922510,Enchantment — Class,Jim Nelson
+Artificer's Intuition,2,2004,4.93,#341aff,https://cards.scryfall.io/normal/front/a/b/abe37c88-afd7-45ac-9f84-f4bd881a1462.jpg?1783944406,Enchantment,Wayne England
+Artificial Evolution,1,2002,4.81,#341aff,https://cards.scryfall.io/normal/front/f/4/f46894d1-2503-43fa-938e-7bbf19101d13.jpg?1783945088,Instant,Greg Staples
+Artisan of Forms,2,2013,0.32,#341aff,https://cards.scryfall.io/normal/front/a/7/a7f10198-1eef-4577-b375-b900b15060e1.jpg?1783939802,Creature — Human Wizard,Min Yum
+Ascendant Spirit,1,2021,0.32,#341aff,https://cards.scryfall.io/normal/front/e/a/ea56de43-c0fd-4627-846d-41a962b95f17.jpg?1783928269,Snow Creature — Spirit,Lie Setiawan
+As Foretold,3,2022,1.73,#341aff,https://cards.scryfall.io/normal/front/c/4/c468b523-84fc-4657-adef-acc1eec6ef2e.jpg?1783921922,Enchantment,Tommy Arnold
+Ashiok's Erasure,4,2020,0.25,#341aff,https://cards.scryfall.io/normal/front/d/5/d568c679-8421-4184-a73c-b18c4164fea5.jpg?1783931586,Enchantment,Zezhou Chen
+Ashling- Rekindled // Ashling- Rimebound,2,2026,1.15,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elemental Sorcerer // Legendary Creature — Elemental Wizard,Ilse Gort
+Asinine Antics,4,2023,0.88,#341aff,https://cards.scryfall.io/normal/front/5/0/50b96a97-0d7d-4e05-9e2f-0b99a039b655.jpg?1783915124,Sorcery,Brent Hollowell
+Astral Dragon,8,2022,19.87,#341aff,https://cards.scryfall.io/normal/front/6/7/670fbc63-4c9b-4e57-b53e-4ca4d7a224ba.jpg?1783922511,Creature — Dragon,Anastasia Ovchinnikova
+Astrologian's Planisphere,2,2025,0.28,#341aff,https://cards.scryfall.io/normal/front/b/f/bfa4e927-1d6f-4a64-9801-7d168a5ef3f6.jpg?1783906640,Artifact — Equipment,Josephine Chang
+Atemsis- All-Seeing,6,2019,0.39,#341aff,https://cards.scryfall.io/normal/front/b/8/b8f527d1-25c0-49b9-83d5-1278ca72d009.jpg?1783933016,Legendary Creature — Sphinx,Ryan Pancoast
+Attunement,3,1998,25.42,#341aff,https://cards.scryfall.io/normal/front/f/6/f6723528-8b2c-4beb-a465-800300faf158.jpg?1783946364,Enchantment,Randy Gallegos
+Augmenter Pugilist // Echoing Equation,3,2021,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Troll Druid // Sorcery,Volkan Baǵa
+Aura Thief,4,1999,15.73,#341aff,https://cards.scryfall.io/normal/front/8/a/8ae591d2-b9d3-4bc5-bcec-5d3d79a13b41.jpg?1783946081,Creature — Illusion,Ron Spears
+Aurora Shifter,2,2024,0.43,#341aff,https://cards.scryfall.io/normal/front/d/7/d76fd397-64ea-4dca-b901-86ce101cb70e.jpg?1783911426,Creature — Shapeshifter,Justyna Dura
+Auton Soldier,6,2023,10.92,#341aff,https://cards.scryfall.io/normal/front/4/c/4cc35b82-a233-4460-968e-d90980fb2074.jpg?1783914672,Artifact Creature — Alien Soldier,Greg Opalinski
+Avatar of Me,4,2020,0.22,#341aff,https://cards.scryfall.io/normal/front/8/d/8da4dcb0-285e-4948-8155-4b536bce202d.jpg?1783931345,Creature — Avatar,Greg Hildebrandt
+Avatar of Will,8,2000,1.6,#341aff,https://cards.scryfall.io/normal/front/b/f/bf65efc7-6ab5-4116-b003-1f028af80939.jpg?1783945792,Creature — Avatar,rk post
+Aven Courier,2,2022,2.58,#341aff,https://cards.scryfall.io/normal/front/7/b/7bb0e478-c359-4523-a1e1-ba711a8cb8e0.jpg?1783923373,Creature — Bird Advisor,Lars Grant-West
+Avizoa,4,1997,0.51,#341aff,https://cards.scryfall.io/normal/front/a/9/a993986c-e8f1-41b1-86e6-c72021c53b87.jpg?1783946742,Creature — Jellyfish,Paolo Parente
+Azami- Lady of Scrolls,5,2023,0.38,#341aff,https://cards.scryfall.io/normal/front/f/a/fa727656-fb33-485b-9378-18b80cad42b9.jpg?1783915706,Legendary Creature — Human Wizard,Ittoku
+Azure Beastbinder,2,2024,0.4,#341aff,https://cards.scryfall.io/normal/front/2/1/211af1bf-910b-41a5-b928-f378188d1871.jpg?1783910852,Creature — Rat Rogue,Adam Paquette
+Baboon Spirit,3,2025,0.28,#341aff,https://cards.scryfall.io/normal/front/8/b/8b5a7f24-63df-40fa-9200-c862544b0ffa.jpg?1783904830,Creature — Monkey Spirit,Daniel Romanovsky
+Back from the Brink,6,2011,0.21,#341aff,https://cards.scryfall.io/normal/front/b/4/b4bba140-5c06-4542-9ae0-b2517104ab7c.jpg?1783940981,Enchantment,Anthony Palumbo
+Back to Basics,3,2018,6.46,#341aff,https://cards.scryfall.io/normal/front/0/6/0600d6c2-0f72-4e79-a55d-1f06dffa48c2.jpg?1783933849,Enchantment,Terese Nielsen
+Baki's Curse,4,1995,0.46,#341aff,https://cards.scryfall.io/normal/front/e/3/e3261b4c-7963-4ca0-875d-77b7c8571b3f.jpg?1783947298,Sorcery,Nicola Leonard
+Balance of Power,5,2003,0.32,#341aff,https://cards.scryfall.io/normal/front/8/3/83f46988-c3ee-42e9-ade6-0b6302b8b952.jpg?1783944813,Sorcery,Adam Rex
+Baral- Chief of Compliance,2,2017,2.76,#341aff,https://cards.scryfall.io/normal/front/6/0/60e16d94-1166-4050-8554-686e153a7f80.jpg?1783936774,Legendary Creature — Human Wizard,Wesley Burt
+Baral's Expertise,5,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/d/5/d5beecd5-4267-454d-87db-24d476e1f352.jpg?1783907109,Sorcery,Todd Lockwood
+Barrin- Master Wizard,3,1998,3.97,#341aff,https://cards.scryfall.io/normal/front/e/c/ec79e35f-9e78-462d-8b71-4f044e2eff90.jpg?1783946364,Legendary Creature — Human Wizard,Michael Sutfin
+Barrin- Tolarian Archmage,3,2020,0.37,#341aff,https://cards.scryfall.io/normal/front/c/b/cb078fbb-beb9-4c0b-be93-ed1e73e6f8d8.jpg?1783930730,Legendary Creature — Human Wizard,Ryan Pancoast
+Battlefield Thaumaturge,2,2014,0.31,#341aff,https://cards.scryfall.io/normal/front/4/6/467ffc93-b107-457c-af04-a1b682a4b886.jpg?1783939450,Creature — Human Wizard,Mike Sass
+Battle of Wits,5,2012,0.2,#341aff,https://cards.scryfall.io/normal/front/b/4/b4be15a4-693f-4e22-a46c-38bb440c073c.jpg?1783940509,Enchantment,Jason Chan
+Baxter- Fly in the Ointment,4,2026,0.32,#341aff,https://cards.scryfall.io/normal/front/f/5/f5ee290f-03cd-48a8-ba6e-d934cb3f4ff4.jpg?1783904171,Legendary Creature — Insect Mutant Scientist,Michele Giorgi
+Bazaar of Wonders,5,1996,2.59,#341aff,https://cards.scryfall.io/normal/front/7/8/78e7a165-e135-4b85-943d-8352b6e65870.jpg?1783947112,World Enchantment,Liz Danforth
+Bazaar Trademage,3,2019,0.15,#341aff,https://cards.scryfall.io/normal/front/9/d/9d75faf7-fc27-4fc2-9e80-e35232c42542.jpg?1783933150,Creature — Human Wizard,Christopher Moeller
+Beacon of Tomorrows,8,2017,3.23,#341aff,https://cards.scryfall.io/normal/front/1/b/1bf05e3d-601a-481b-8880-24058a3442e9.jpg?1783936579,Sorcery,Jeremy Jarvis
+Become the Pilot,5,2023,0.24,#341aff,https://cards.scryfall.io/normal/front/1/5/15927163-f203-4d45-b78f-70eafb941bfd.jpg?1783914672,Enchantment — Aura,Irina Nordsol
+Beguiler of Wills,5,2012,2.17,#341aff,https://cards.scryfall.io/normal/front/e/2/e21ae024-d565-48a1-8004-5aa320a5d24d.jpg?1783940846,Creature — Human Wizard,Eric Deschamps
+Benthic Behemoth,8,2001,0.68,#341aff,https://cards.scryfall.io/normal/front/1/9/19577bda-2728-40c8-a262-26051e6c226b.jpg?1783945553,Creature — Serpent,Heather Hudson
+Benthic Biomancer,1,2023,0.21,#341aff,https://cards.scryfall.io/normal/front/b/8/b83dd3a5-d9cc-470d-a9d0-bf9d270e9eb6.jpg?1783913890,Creature — Merfolk Wizard Mutant,Daarken
+Bident of Thassa,4,2023,0.4,#341aff,https://cards.scryfall.io/normal/front/9/4/94751d5e-7693-44af-b1b5-e440677dc7a2.jpg?1783913890,Legendary Enchantment Artifact,Yeong-Hao Han
+Bilbo- Thief in the Night,2,2026,41.46,#341aff,https://cards.scryfall.io/normal/front/4/8/484c7f83-8339-4ae1-8350-68ce1f7d05a3.jpg?1783902786,Legendary Creature — Halfling Rogue,Nia Kovalevski
+Blade of Shared Souls,3,2023,0.3,#341aff,https://cards.scryfall.io/normal/front/2/7/277aeb73-4c7c-4132-b9f9-55181d57e75d.jpg?1783918068,Artifact — Equipment,Volkan Baǵa
+Blatant Thievery,7,2015,5.99,#341aff,https://cards.scryfall.io/normal/front/0/2/0210b3b4-d253-464f-b533-b79bf67d47a4.jpg?1783938095,Sorcery,Ron Spencer
+Blessed Reincarnation,4,2015,0.14,#341aff,https://cards.scryfall.io/normal/front/4/0/401cd79d-638e-43b4-8d0c-d7af05c55a1a.jpg?1783938610,Instant,Kev Walker
+Blighted Agent,2,2023,5.81,#341aff,https://cards.scryfall.io/normal/front/0/1/01842079-5c70-4e87-a1c5-c814a44ba0f5.jpg?1783917381,Creature — Phyrexian Human Rogue,Anthony Francisco
+Blind Seer,4,2000,0.89,#341aff,https://cards.scryfall.io/normal/front/5/c/5c54ec26-c7f1-4258-9cc9-1709987f293c.jpg?1783945710,Legendary Creature — Human Wizard,Dave Dorman
+Blinkmoth Infusion,14,2004,2.0,#341aff,https://cards.scryfall.io/normal/front/c/c/ccb4d9a3-e7f6-41e2-9545-4682efd71f46.jpg?1783944405,Instant,Alan Pollack
+Blitzball Stadium,1,2025,0.24,#341aff,https://cards.scryfall.io/normal/front/7/7/771808d9-d0c8-418b-ab6c-1ae6fc07ca20.jpg?1783906363,Artifact,Piotr Dura
+Blizzard Elemental,7,1999,0.44,#341aff,https://cards.scryfall.io/normal/front/5/9/5949c5a7-9656-466a-add8-1800973fefee.jpg?1783946081,Creature — Elemental,Thomas M. Baxa
+Blue Mage's Cane,3,2025,0.26,#341aff,https://cards.scryfall.io/normal/front/9/b/9b3cfc13-db4e-4ec3-8444-f715bcd43be6.jpg?1783906363,Artifact — Equipment,Eglė Mosakaitė
+Blue Sun's Twilight,2,2023,0.47,#341aff,https://cards.scryfall.io/normal/front/3/a/3a836e6b-6854-4f6f-bc78-2da1fd4dd224.jpg?1783918068,Sorcery,Piotr Dura
+Blue Sun's Zenith,3,2018,2.74,#341aff,https://cards.scryfall.io/normal/front/5/0/500a2aa4-712f-41be-920e-f2f448ff83d0.jpg?1783935183,Instant,Izzy
+B.O.B. (Bevy of Beebles),5,2020,0.36,#341aff,https://cards.scryfall.io/normal/front/7/e/7e41ecd9-8875-4765-a9a9-372f948b5ad7.jpg?1783931345,Legendary Planeswalker — B.O.B.,Jeff Miracola
+Body Double,5,2017,0.32,#341aff,https://cards.scryfall.io/normal/front/7/4/747e3598-878d-4f23-bb6c-f169f2ef5ebe.jpg?1783935919,Creature — Shapeshifter,Winona Nelson
+Body of Knowledge,5,2024,0.33,#341aff,https://cards.scryfall.io/normal/front/1/8/185b2e8f-ab37-42e4-b3a1-f38b19a2e05a.jpg?1783909628,Creature — Avatar,Clint Cearley
+Borne Upon a Wind,2,2023,4.13,#341aff,https://cards.scryfall.io/normal/front/a/9/a9379675-1a32-4e2b-8aaf-5f908c595f31.jpg?1783916321,Instant,Alexander Mokhov
+Braided Net // Braided Quipu,3,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact // Artifact,Diego Gisbert
+Braids- Conjurer Adept,4,2023,0.45,#341aff,https://cards.scryfall.io/normal/front/9/e/9ea0a701-1349-4d32-9fe7-8a2563c9613d.jpg?1783915705,Legendary Creature — Human Wizard,Zoltan Boros & Gabor Szikszai
+Brain Freeze,2,2026,3.35,#341aff,https://cards.scryfall.io/normal/front/f/4/f403af12-6114-4121-b421-3448e084864c.jpg?1783903930,Instant,Benjamin Ee
+Brainstorm,1,2026,2.4,#341aff,https://cards.scryfall.io/normal/front/8/b/8bb0a0cf-5b04-4d68-bf7a-7131ae50d06b.jpg?1783904181,Instant,Mateus Santolouco & Ronda Pattison
+Brazen Borrower // Petty Theft,3,2026,0.48,#341aff,https://cards.scryfall.io/normal/front/2/5/25d309d6-9e56-441e-bd29-5c903d5221bf.jpg?1783903792,Creature — Faerie Rogue // Instant — Adventure,Eric Deschamps
+Breaching Leviathan,9,2014,5.45,#341aff,https://cards.scryfall.io/normal/front/e/0/e02e3d91-7723-46b8-a393-855b6e89d877.jpg?1783938873,Creature — Leviathan,Tomasz Jedruszek
+Breaking Wave,4,2000,0.7,#341aff,https://cards.scryfall.io/normal/front/1/b/1b39cd77-97aa-4099-8405-366f82079758.jpg?1783945710,Sorcery,Carl Critchlow
+Breath of the Sleepless,4,2021,0.27,#341aff,https://cards.scryfall.io/normal/front/8/c/8c59af37-5c01-4f65-97f6-2478aa29949a.jpg?1783925004,Enchantment,Robin Olausson
+Bribery,5,2023,5.85,#341aff,https://cards.scryfall.io/normal/front/4/9/49fd737a-d7da-421b-a741-d6d0d213299f.jpg?1783915705,Sorcery,Kai Carpenter
+Bringer of the Blue Dawn,9,2004,4.81,#d78f42,https://cards.scryfall.io/normal/front/4/5/45dc82a0-f054-4614-a7b9-4c5a7c9d2a77.jpg?1783944405,Creature — Bringer,Greg Staples
+Broodstar,10,2009,1.0,#341aff,https://cards.scryfall.io/normal/front/2/8/28309edb-f255-4b29-b7b6-e36e23ba0690.jpg?1783942335,Creature — Beast,Glen Angus
+Bruce Banner // The Incredible Hulk,1,2026,7.2,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Scientist Hero // Legendary Creature — Gamma Berserker Hero,Tommy Arnold
+Bruvac the Grandiloquent,3,2024,45.89,#341aff,https://cards.scryfall.io/normal/front/2/c/2ce2d73f-3f64-44db-a2bc-a8f4a37dc487.jpg?1783913340,Legendary Creature — Human Advisor,Ekaterina Burmak
+Bureaucracy,5,1998,1.1,#341aff,https://cards.scryfall.io/normal/front/4/3/43417d07-725e-4c3d-99d2-bbbfbdeee770.jpg?1783946434,Enchantment,Mark Zug
+Cackling Counterpart,3,2024,0.33,#341aff,https://cards.scryfall.io/normal/front/e/b/eb26e2dd-a81b-46a5-9208-c6b3d2548fbb.jpg?1783909643,Instant,Zezhou Chen
+Callous Oppressor,3,2002,1.71,#341aff,https://cards.scryfall.io/normal/front/b/3/b3dd3ce7-e0e3-4412-9983-ff933584f59b.jpg?1783945086,Creature — Octopus,Justin Sweet
+Call to the Kindred,4,2012,1.02,#341aff,https://cards.scryfall.io/normal/front/e/e/ee35f96c-6060-4456-897e-27b74c8c2137.jpg?1783940846,Enchantment — Aura,Jason A. Engle
+Cancel,3,2010,3.67,#341aff,https://cards.scryfall.io/normal/front/b/c/bc4d6368-03dc-488a-9a6b-07a549a87572.jpg?1783942076,Instant,Izzy
+Capricious Sorcerer,3,1997,2.24,#341aff,https://cards.scryfall.io/normal/front/b/8/b8d5eec0-0afe-4af9-ba1b-70282df8cd0a.jpg?1783946843,Creature — Human Wizard Sorcerer,Zina Saunders
+Captain of the Mists,3,2016,0.21,#341aff,https://cards.scryfall.io/normal/front/a/a/aa959355-ffac-442c-9c59-b2a654b4b400.jpg?1783937852,Creature — Human Wizard,Allen Williams
+Capture of Jingzhou,5,2023,10.11,#341aff,https://cards.scryfall.io/normal/front/f/8/f87d0298-f76b-4ea8-82c4-5861c4539d8b.jpg?1783915704,Sorcery,Jack Wei
+Careful Study,1,2024,9.05,#341aff,https://cards.scryfall.io/normal/front/0/f/0feefb72-f6fa-4897-b2cf-6f14a3e5d466.jpg?1783909213,Sorcery,Tyler Walpole
+Case of the Ransacked Lab,3,2024,0.47,#341aff,https://cards.scryfall.io/normal/front/1/6/16a9a596-61de-4fcf-aae0-41836c3deca5.jpg?1783912914,Enchantment — Case,Borja Pindado
+Case of the Shifting Visage,3,2024,0.32,#341aff,https://cards.scryfall.io/normal/front/6/5/65463a1b-39c1-4fc8-8de2-85224de810ac.jpg?1783913049,Enchantment — Case,Chris Seaman
+Cast Through Time,7,2010,2.19,#341aff,https://cards.scryfall.io/normal/front/c/9/c9850489-c056-4b17-8743-a5b514d8edf4.jpg?1783942000,Enchantment,Zoltan Boros & Gabor Szikszai
+Cavalier of Gales,5,2019,2.91,#341aff,https://cards.scryfall.io/normal/front/a/5/a5356b11-e505-4838-aecb-327689eeead1.jpg?1783933012,Creature — Elemental Knight,Viktor Titov
+Cemetery Illuminator,3,2021,0.44,#341aff,https://cards.scryfall.io/normal/front/5/f/5f619464-dc3b-4265-b4e4-2578034bf5bf.jpg?1783924900,Creature — Spirit,Uriah Voth
+Central Elevator // Promising Stairs,7,2024,0.31,#341aff,https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1783909499,Enchantment — Room // Enchantment — Room,Cristi Balanescu
+Cephalid Constable,3,2007,5.25,#341aff,https://cards.scryfall.io/normal/front/8/2/82c5272d-df5b-4c21-9bff-4d6245b8d2a6.jpg?1783943061,Creature — Octopus Wizard,Alan Pollack
+Cephalid Facetaker,3,2022,5.2,#341aff,https://cards.scryfall.io/normal/front/a/7/a77d91f7-f7c9-47e4-b5c5-46c921335e42.jpg?1783923372,Creature — Octopus Rogue,Uriah Voth
+Cephalid Retainer,4,2001,0.21,#341aff,https://cards.scryfall.io/normal/front/7/8/78480527-cfd6-4065-b702-82de4694f9bb.jpg?1783945265,Creature — Octopus,Tony Szczudlo
+Cephalid Shrine,3,2001,0.29,#341aff,https://cards.scryfall.io/normal/front/1/3/137e0ac1-3bf2-4583-b44f-c9fe8d7e8882.jpg?1783945264,Enchantment,Wayne England
+Cephalid Vandal,2,2002,0.33,#341aff,https://cards.scryfall.io/normal/front/2/5/2500976f-a329-4a51-bcc1-cafe39bc3ccf.jpg?1783945165,Creature — Octopus Rogue,Alex Horley-Orlandelli
+Cerulean Sphinx,6,2005,0.25,#341aff,https://cards.scryfall.io/normal/front/d/c/dc95d4a6-ad4b-46c5-8a75-e70102363844.jpg?1783943690,Creature — Sphinx,Jim Murray
+Cetavolver,2,2001,0.32,#d78f42,https://cards.scryfall.io/normal/front/6/9/69063cc2-4f6e-4cce-bb09-ccd57b69b993.jpg?1783945354,Creature — Volver,Gary Ruddell
+Chain of Vapor,1,2025,18.22,#341aff,https://cards.scryfall.io/normal/front/3/a/3acd188d-1e9f-4fec-8b88-2f64c6733682.jpg?1783905085,Instant,Kozato
+Chain Stasis,1,1995,2.18,#341aff,https://cards.scryfall.io/normal/front/f/1/f14f0c52-67c2-4302-82bd-fbb4e3c6d4f4.jpg?1783947298,Instant,Pat Lewis
+Chakra Meditation,3,2025,0.29,#341aff,https://cards.scryfall.io/normal/front/9/8/98392aac-2c1c-4cff-ad14-0e2f51439012.jpg?1783904829,Enchantment,Hori Airi
+Champion of Wits,3,2022,0.16,#341aff,https://cards.scryfall.io/normal/front/4/8/489e339b-3bc6-4221-9734-d796b65910d2.jpg?1783923284,Creature — Snake Wizard,Even Amundsen
+Champions of the Shoal,4,2026,0.22,#341aff,https://cards.scryfall.io/normal/front/e/1/e1acdd9c-4a6d-4373-950c-f5539b54679f.jpg?1783904491,Creature — Merfolk Soldier,Daniel Zrom
+Chancellor of the Spires,7,2011,0.39,#341aff,https://cards.scryfall.io/normal/front/b/1/b1e06e16-96fa-4611-b4a9-512eeeeddd3c.jpg?1783941321,Creature — Phyrexian Sphinx,Nils Hamm
+Change of Plans,2,2022,11.88,#341aff,https://cards.scryfall.io/normal/front/7/c/7cc7f675-3e56-4e5a-9618-9a9ba8e0310d.jpg?1783923372,Instant,Campbell White
+Charisma,3,1999,11.95,#341aff,https://cards.scryfall.io/normal/front/6/3/63565b03-28e9-4534-b085-d5803e2623bb.jpg?1783945969,Enchantment — Aura,Terese Nielsen
+Charix- the Raging Isle,4,2020,0.45,#341aff,https://cards.scryfall.io/normal/front/e/8/e83a6804-1e3c-428c-af5e-1d56ba11c108.jpg?1783929402,Legendary Creature — Leviathan Crab,Viktor Titov
+Chasm Skulker,3,2023,0.52,#341aff,https://cards.scryfall.io/normal/front/7/9/794e01e7-430c-43cf-ba2b-1028cd088148.jpg?1783917173,Creature — Squid Horror,Jack Wang
+Chicken à la King,3,2020,0.22,#341aff,https://cards.scryfall.io/normal/front/e/f/efcbd4ef-3bf4-4f22-9069-2a11c9619a43.jpg?1783931344,Creature — Bird Noble,Mark Zug
+Chief Engineer,2,2016,0.87,#341aff,https://cards.scryfall.io/normal/front/8/c/8c67872b-f375-42b9-b81c-3c8c52c0c24e.jpg?1783937073,Creature — Vedalken Artificer,Steven Belledin
+Chisei- Heart of Oceans,4,2005,1.53,#341aff,https://cards.scryfall.io/normal/front/6/c/6c359b1a-d441-4763-96c7-e5c010eae53f.jpg?1783944209,Legendary Creature — Spirit,Matt Cavotta
+Chrome Host Seedshark,3,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/0/4/04e02176-16ee-4676-8b33-cedebdb18cbc.jpg?1783906045,Creature — Phyrexian Shark,Donato Giancola
+Chromescale Drake,9,2004,0.39,#341aff,https://cards.scryfall.io/normal/front/d/2/d22aa7ef-da34-49c1-9aac-67d129ffa6fe.jpg?1783944450,Creature — Drake,Ben Thompson
+Chromeshell Crab,5,2019,0.31,#341aff,https://cards.scryfall.io/normal/front/c/9/c91cf95f-5007-409c-b891-00e10a3477e0.jpg?1783932783,Creature — Crab Beast,Joseph Meehan
+Chronatog,2,1997,11.76,#341aff,https://cards.scryfall.io/normal/front/0/5/05ada02f-04e9-4269-b04a-97a7eaac2c46.jpg?1783947001,Creature — Atog,Christopher Rush
+Chronozoa,4,2007,7.75,#341aff,https://cards.scryfall.io/normal/front/a/7/a77c1ac0-5548-42b0-aa46-d532b3518632.jpg?1783943162,Creature — Illusion,James Wong
+Circular Logic,3,2024,4.85,#341aff,https://cards.scryfall.io/normal/front/0/3/0392db52-c77c-4310-be26-7daccc661d07.jpg?1783913086,Instant,Alexander Khabbazi
+Cleaver Skaab,4,2021,4.43,#341aff,https://cards.scryfall.io/normal/front/3/0/30498d6c-29e2-4d05-a5bc-e2e623c5704d.jpg?1783925380,Creature — Zombie Horror,Johann Bodin
+Clever Impersonator,4,2019,4.07,#341aff,https://cards.scryfall.io/normal/front/c/0/c0516453-3e6a-4b7f-8df6-72a6e207169a.jpg?1783932783,Creature — Shapeshifter,Slawomir Maniak
+Clocknapper,5,2017,0.31,#341aff,https://cards.scryfall.io/normal/front/1/4/14e34f0b-f94b-49fb-a667-8c11dd9d59d4.jpg?1783935451,Creature — Human Spy,Marco Teixeira
+Clone,4,2013,0.62,#341aff,https://cards.scryfall.io/normal/front/5/e/5e648262-3b9b-4c58-8e29-48356e3cb064.jpg?1783939937,Creature — Shapeshifter,Kev Walker
+Clone Legion,9,2022,3.23,#341aff,https://cards.scryfall.io/normal/front/f/5/f5ebe939-fef3-4085-808c-41ff97e83a7e.jpg?1783923282,Sorcery,Svetlin Velinov
+Cloudhoof Kirin,5,2005,0.52,#341aff,https://cards.scryfall.io/normal/front/4/2/42aa0d70-8d66-47aa-9228-25dcdb4e7dad.jpg?1783944167,Legendary Creature — Kirin Spirit,Randy Gallegos
+Coastal Breach,7,2016,3.74,#341aff,https://cards.scryfall.io/normal/front/b/f/bf8b550a-c86f-4684-a4f6-14e75172324f.jpg?1783937090,Sorcery,Titus Lunter
+Coastal Piracy,4,2003,3.14,#341aff,https://cards.scryfall.io/normal/front/2/1/21d65495-4d73-46fa-bd38-155f4639649a.jpg?1783944810,Enchantment,Matthew D. Wilson
+Coastal Wizard,4,1998,2.99,#341aff,https://cards.scryfall.io/normal/front/0/b/0b8c7377-1404-44a4-9689-1fc6cdc286c8.jpg?1783946487,Creature — Human Wizard,Edward P. Beard, Jr.
+Coax from the Blind Eternities,3,2016,0.14,#341aff,https://cards.scryfall.io/normal/front/7/4/740ad768-2be0-4e5a-9d60-6c7ec4bdc107.jpg?1783937505,Sorcery,Jaime Jones
+Cognivore,8,2001,0.46,#341aff,https://cards.scryfall.io/normal/front/7/d/7de76ff6-d065-4db1-b28d-4a4ccb1cc0fa.jpg?1783945262,Creature — Lhurgoyf,Adam Rex
+Collective Restraint,4,2000,14.64,#341aff,https://cards.scryfall.io/normal/front/d/7/d71daa57-ac02-4dd9-8c90-d38bdd45fb51.jpg?1783945709,Enchantment,Alan Rabinowitz
+Colossal Whale,7,2013,0.23,#341aff,https://cards.scryfall.io/normal/front/f/7/f7f7caca-14ee-4d6a-97c3-e19898f86635.jpg?1783939936,Creature — Whale,Adam Paquette
+Commandeer,7,2023,3.13,#341aff,https://cards.scryfall.io/normal/front/d/c/dca0a9a8-5ebc-43a3-8450-420ab6b7b76e.jpg?1783915704,Instant,John Matson
+Commander's Insight,3,2026,0.24,#341aff,https://cards.scryfall.io/normal/front/1/a/1a40e4da-a631-4423-b70f-701b27b09f79.jpg?1783903823,Instant,Carly Milligan
+Commence the Endgame,6,2019,0.31,#341aff,https://cards.scryfall.io/normal/front/2/0/209d70a2-c8c1-4072-ab1f-57804b55a09a.jpg?1783933467,Instant,Noah Bradley
+Commit // Memory,10,2023,0.36,#341aff,https://cards.scryfall.io/normal/front/8/5/855af9a8-31fc-4290-8204-04ee026f8853.jpg?1783913889,Instant // Sorcery,Ryan Alexander Lee
+Complete the Circuit,6,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/c/d/cdf5de96-9418-48f1-a18e-01a0108c4f97.jpg?1783917038,Instant,Eelis Kyttanen
+Compulsive Research,3,2021,0.32,#341aff,https://cards.scryfall.io/normal/front/0/f/0f578fbf-c3c7-4407-9fda-3c13b165798c.jpg?1783927440,Sorcery,Kristina Collantes
+Confirm Suspicions,5,2024,0.25,#341aff,https://cards.scryfall.io/normal/front/1/d/1d1463af-8f22-4771-af19-3799ffe706b8.jpg?1783913020,Instant,David Gaillet
+Confiscation Coup,5,2016,0.17,#341aff,https://cards.scryfall.io/normal/front/6/d/6daf453f-54be-4346-831d-a0434aa086fe.jpg?1783937222,Sorcery,Joseph Meehan
+Confounding Conundrum,2,2020,0.32,#341aff,https://cards.scryfall.io/normal/front/9/5/95e37936-913e-4b16-a5a8-8aed733d702d.jpg?1783929399,Enchantment,Bryan Sola
+Conjured Currency,6,2012,0.29,#341aff,https://cards.scryfall.io/normal/front/a/7/a7c2ea6e-7d29-4526-b135-9bbb1eed9d4a.jpg?1783940370,Enchantment,Steve Argyle
+Consecrated Sphinx,6,2022,32.39,#341aff,https://cards.scryfall.io/normal/front/c/9/c9bd60fc-2777-44bc-b314-a792e8e48360.jpg?1783921921,Creature — Sphinx,Mark Zug
+Conspiracy Unraveler,7,2024,0.28,#341aff,https://cards.scryfall.io/normal/front/8/8/88e791fc-bf9f-49b6-b5f2-a24d4b3e360e.jpg?1783912913,Creature — Sphinx Detective,Wayne Reynolds
+Consult the Star Charts,2,2025,2.41,#341aff,https://cards.scryfall.io/normal/front/a/1/a16a6555-2e3a-4587-aacd-0307d696b26c.jpg?1783905984,Instant,Antonio José Manzanedo
+Consuming Tide,4,2021,0.56,#341aff,https://cards.scryfall.io/normal/front/5/8/5865f0f1-28a6-49ac-b61e-135845075d1f.jpg?1783924899,Sorcery,Viko Menezes
+Control Magic,4,2016,0.72,#341aff,https://cards.scryfall.io/normal/front/c/7/c7e90849-ca7a-4f66-871e-1cb4b59aefcf.jpg?1783937619,Enchantment — Aura,Terese Nielsen
+Conundrum Sphinx,4,2018,0.32,#341aff,https://cards.scryfall.io/normal/front/2/9/2905cea6-77cb-4d9b-93f4-e22211af25e1.jpg?1783934311,Creature — Sphinx,Michael Komarck
+Copy Catchers,2,2024,0.25,#341aff,https://cards.scryfall.io/normal/front/a/f/af6b5cec-49fa-4f8d-8493-4bb7f3e291e8.jpg?1783913048,Creature — Faerie,Edgar Sánchez Hidalgo
+Copy Enchantment,3,2024,1.82,#341aff,https://cards.scryfall.io/normal/front/c/e/ce82b316-8982-41bf-a990-6b776a9e83ac.jpg?1783913339,Enchantment,Joel Thomas
+Copy Land,3,2024,1.26,#341aff,https://cards.scryfall.io/normal/front/c/3/c3d44c0e-733b-4ad3-b45b-6a3b09c12fb0.jpg?1783911424,Enchantment,Hristo D. Chukov
+Coralhelm Chronicler,3,2020,0.13,#341aff,https://cards.scryfall.io/normal/front/5/0/50b54524-8345-4b47-913f-d883a1cbe3a1.jpg?1783929399,Creature — Merfolk Wizard,Lie Setiawan
+Coralhelm Commander,2,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/4/6/46246d37-dfce-4977-854e-ee79d47cea05.jpg?1783913889,Creature — Merfolk Soldier,Jaime Jones
+Corsair Captain,3,2024,0.24,#341aff,https://cards.scryfall.io/normal/front/d/5/d5017dbc-07fd-45ea-9629-7c584144e8be.jpg?1783908963,Creature — Human Pirate,Victor Adame Minguez
+Corsairs of Umbar,4,2023,0.36,#341aff,https://cards.scryfall.io/normal/front/1/5/159727a9-0bc4-497d-8fb2-4a66923726d8.jpg?1783916032,Creature — Human Pirate,Narendra Bintara Adi
+Cosima- God of the Voyage // The Omenkeel,3,2021,1.33,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact — Vehicle,Micah Epstein
+Cosi's Trickster,1,2009,0.5,#341aff,https://cards.scryfall.io/normal/front/e/1/e1eb7372-481a-44a6-937d-21430ee02ff9.jpg?1783942165,Creature — Merfolk Wizard,Igor Kieryluk
+Cosmic Epiphany,6,2022,0.19,#341aff,https://cards.scryfall.io/normal/front/7/9/79718dbe-d5d6-4f24-b514-5c392963f021.jpg?1783921245,Sorcery,Eli Minaya
+Cosmos Charger,4,2021,0.26,#341aff,https://cards.scryfall.io/normal/front/4/e/4ec318c6-b718-436f-b9e8-e0c6154e5010.jpg?1783928268,Creature — Horse Spirit,Nils Hamm
+Counterbalance,2,2025,6.85,#341aff,https://cards.scryfall.io/normal/front/3/f/3fd8a7bf-c679-470a-8e56-d3f59b7ba488.jpg?1783906078,Enchantment,Diego Andrade
+Counterbore,5,2008,0.35,#341aff,https://cards.scryfall.io/normal/front/f/4/f4228b80-d87d-4ebe-ae92-04e4a7d0dc43.jpg?1783942762,Instant,Wayne England
+Counterlash,6,2012,0.31,#341aff,https://cards.scryfall.io/normal/front/d/3/d3ec2c57-8e67-472d-8f2e-0492d311f130.jpg?1783940844,Instant,Austin Hsu
+Counterspell,2,2026,10.63,#341aff,https://cards.scryfall.io/normal/front/3/7/379f4020-a58c-484d-9b44-72b200884079.jpg?1783903320,Instant,Adi Granov
+Court of Cunning,3,2020,4.31,#341aff,https://cards.scryfall.io/normal/front/2/f/2f585f52-7b07-4453-b543-9654d314aa36.jpg?1783928864,Enchantment,Yeong-Hao Han
+Court of Vantress,4,2023,5.94,#341aff,https://cards.scryfall.io/normal/front/b/6/b6f78616-f54e-43d0-b2ae-9ed06fe4dd9f.jpg?1783914984,Enchantment,Nino Vecia
+Covenant of Minds,5,2016,0.24,#341aff,https://cards.scryfall.io/normal/front/0/d/0df0e2eb-753a-4dd1-8b08-f741683e089d.jpg?1783937326,Sorcery,Dan Seagrave
+Coveted Falcon,3,2024,0.29,#341aff,https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg?1783912913,Artifact Creature — Bird,Madeline Boni
+Cowardice,5,2005,0.54,#341aff,https://cards.scryfall.io/normal/front/6/7/67c3cf8f-c2f6-4ad0-83f9-960e5d74fc3e.jpg?1783944058,Enchantment,Michael Sutfin
+Crafty Cutpurse,4,2021,0.34,#341aff,https://cards.scryfall.io/normal/front/1/1/117d84f7-45c5-4cfc-a5cd-c44416b48417.jpg?1783927566,Creature — Human Pirate,Grzegorz Rutkowski
+Cresting Mosasaurus,8,2023,4.76,#341aff,https://cards.scryfall.io/normal/front/b/6/b6011e4b-a8a7-4cad-a276-c1022b45edc3.jpg?1783913640,Creature — Dinosaur,Chris Rallis
+Cruel Fate,5,1997,0.46,#341aff,https://cards.scryfall.io/normal/front/4/4/44bea0d4-946e-4cb8-b6f1-50231d52bfbe.jpg?1783946841,Sorcery,Adrian Smith
+Crush of Tentacles,6,2016,1.99,#341aff,https://cards.scryfall.io/normal/front/b/e/be1434e1-a0d6-4028-918b-1e2d17d3a227.jpg?1783937919,Sorcery,Jama Jurabaev
+Cryptic Coat,3,2024,0.26,#341aff,https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg?1783912915,Artifact — Equipment,Julia Metzger
+Cryptic Command,4,2017,6.3,#341aff,https://cards.scryfall.io/normal/front/3/0/30f6fca9-003b-4f6b-9d6e-1e88adda4155.jpg?1783935549,Instant,Jason Rainville
+Cryptoplasm,3,2011,0.6,#341aff,https://cards.scryfall.io/normal/front/1/5/15a31710-c1d6-45e4-9dbe-a75453a74da0.jpg?1783941388,Creature — Shapeshifter,Eric Deschamps
+Crystalline Resonance,3,2020,0.26,#341aff,https://cards.scryfall.io/normal/front/9/3/93f20664-c3d0-4dbd-93dc-4f69a0cbff46.jpg?1783931222,Enchantment,Joe Slucher
+Crystal Skull- Isu Spyglass,4,2024,1.95,#341aff,https://cards.scryfall.io/normal/front/b/1/b10fa72b-6742-4b65-8654-ac70b6240e38.jpg?1783910985,Legendary Artifact,Thanh Tuấn
+Crystal Spray,3,2000,17.75,#341aff,https://cards.scryfall.io/normal/front/8/7/8798a4f1-34bb-449d-a8cc-faf8bda8e0ab.jpg?1783945709,Instant,Jeff Miracola
+Cultural Exchange,6,2001,5.95,#341aff,https://cards.scryfall.io/normal/front/d/4/d4f38d07-829c-4311-a61b-2785cf2266ef.jpg?1783945262,Sorcery,Daren Bader
+Cunning Wish,3,2002,8.92,#341aff,https://cards.scryfall.io/normal/front/c/a/ca097675-5e82-493d-beab-9fc11efd7492.jpg?1783945130,Instant,Jim Nelson
+Curator of Destinies,6,2024,0.18,#341aff,https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg?1783909120,Creature — Sphinx,Ralph Horsley
+Curator of Mysteries,4,2021,0.32,#341aff,https://cards.scryfall.io/normal/front/9/8/98b959ad-8920-4b28-a954-f733bf36bde8.jpg?1783926225,Creature — Sphinx,Christine Choi
+Curie- Emergent Intelligence,2,2024,0.4,#341aff,https://cards.scryfall.io/normal/front/5/4/54870f19-96f3-4cde-ae44-a9c5bbb0dbc1.jpg?1783912413,Legendary Artifact Creature — Robot,Daniel Romanovsky
+Curiosity Crafter,4,2026,0.39,#341aff,https://cards.scryfall.io/normal/front/9/3/930d830b-5e6a-422a-806e-fd7275517deb.jpg?1783903793,Creature — Bird Wizard,Rudy Siswanto
+Curse of Echoes,5,2012,0.54,#341aff,https://cards.scryfall.io/normal/front/1/4/147dbe42-665a-4e21-b405-d17554d5efcf.jpg?1783940842,Enchantment — Aura Curse,Slawomir Maniak
+Curse of Surveillance,5,2021,0.17,#341aff,https://cards.scryfall.io/normal/front/d/6/d6a5b3b2-4f27-4c97-9d87-d7bdcc06d36a.jpg?1783925645,Enchantment — Aura Curse,Igor Kieryluk
+Curse of the Swine,2,2026,0.3,#341aff,https://cards.scryfall.io/normal/front/9/1/91eb9067-0bc7-4497-ba9c-c1ea41e5a379.jpg?1783903795,Sorcery,James Ryman
+Curse of Unbinding,7,2021,1.18,#341aff,https://cards.scryfall.io/normal/front/6/b/6b56ccbc-efc7-4c5c-84be-b63f8c4cd63c.jpg?1783925380,Enchantment — Aura Curse,Sebastian Giacobino
+Cut Your Losses,6,2022,2.37,#341aff,https://cards.scryfall.io/normal/front/3/1/31184dd0-4080-44c1-a3e0-f6d10a4d1fcb.jpg?1783923147,Sorcery,Dominik Mayer
+Cyber Conversion,2,2023,1.03,#341aff,https://cards.scryfall.io/normal/front/e/4/e4ce5aa7-70cb-4ab2-9a25-4363aa2b370f.jpg?1783914673,Instant,Eddie Schillo
+Cyberdrive Awakener,6,2025,1.88,#341aff,https://cards.scryfall.io/normal/front/1/9/19bf6b74-b236-42eb-8c88-d715cece6357.jpg?1783906045,Artifact Creature — Construct,Zezhou Chen
+Cyclone Summoner,7,2021,0.3,#341aff,https://cards.scryfall.io/normal/front/b/2/b2d40071-cadf-48de-a8ed-d55adbfab632.jpg?1783928266,Creature — Giant Wizard,Andrey Kuzinskiy
+Cyclonic Rift,2,2024,40.76,#341aff,https://cards.scryfall.io/normal/front/d/f/dfb7c4b9-f2f4-4d4e-baf2-86551c8150fe.jpg?1783913339,Instant,Isis
+Cytoplast Manipulator,4,2006,5.57,#341aff,https://cards.scryfall.io/normal/front/c/f/cfb6b06d-b132-44e9-a743-61187afb6152.jpg?1783943439,Creature — Human Wizard Mutant,Dan Murayama Scott
+Dance of Many,2,1997,0.51,#341aff,https://cards.scryfall.io/normal/front/5/1/51ff8402-7bfe-441a-8c6e-6a9ee9608911.jpg?1783946950,Enchantment,Sandra Everingham
+Danny Pink,4,2023,16.57,#341aff,https://cards.scryfall.io/normal/front/b/f/bf5e0a50-304c-4b3f-b5f7-1ca1213c0282.jpg?1783914672,Legendary Creature — Human Soldier Advisor,Daniel Correia
+Daring Apprentice,3,2005,0.41,#341aff,https://cards.scryfall.io/normal/front/6/c/6c5becbf-77ac-4bd2-912d-7f7c944c2a0b.jpg?1783944056,Creature — Human Wizard,Dany Orizio
+Daring Saboteur,2,2017,0.17,#341aff,https://cards.scryfall.io/normal/front/5/7/57cb012c-947c-4281-8619-1384acf6df54.jpg?1783935785,Creature — Human Pirate,Victor Adame Minguez
+Daring Thief,3,2014,0.25,#341aff,https://cards.scryfall.io/normal/front/c/9/c9d9378d-e553-48b5-8a23-59a35329eda2.jpg?1783939448,Creature — Human Rogue,Johann Bodin
+Day of the Dragons,7,2021,0.2,#341aff,https://cards.scryfall.io/normal/front/7/6/76e4dd1d-b0bd-4fcf-b5c5-fe203af2fe8e.jpg?1783928325,Enchantment,Matthew D. Wilson
+Day's Undoing,3,2023,1.51,#341aff,https://cards.scryfall.io/normal/front/a/c/ac13a82d-43f5-4b96-bf5f-18e33fae921b.jpg?1783915703,Sorcery,Jonas De Ro
+Daze,2,2026,1.1,#341aff,https://cards.scryfall.io/normal/front/9/d/9d9a5654-6795-4799-ae3b-5827bfdf7a97.jpg?1783903928,Instant,Lenka Šimečková
+Dazzling Sphinx,5,2024,0.39,#341aff,https://cards.scryfall.io/normal/front/2/d/2ddac591-825b-4304-858c-9dc9b311805b.jpg?1783911943,Creature — Sphinx,Oriana Menendez
+Deadeye Navigator,6,2025,4.17,#341aff,https://cards.scryfall.io/normal/front/4/f/4f0791b5-fdb4-4378-8fd3-7e7367ffc05c.jpg?1783908166,Creature — Spirit,Lie Setiawan
+Deceptive Frostkite,2,2025,1.01,#341aff,https://cards.scryfall.io/normal/front/1/f/1f87120f-d2a7-4c06-aadd-3ed5729d7abf.jpg?1783907182,Creature — Dragon,Josu Solano
+Declaration of Naught,2,2008,17.09,#341aff,https://cards.scryfall.io/normal/front/2/e/2e67d62f-9629-463b-a445-4181f6fafd0f.jpg?1783942800,Enchantment,Rob Alexander
+Decoy Gambit,3,2020,0.3,#341aff,https://cards.scryfall.io/normal/front/3/9/39671ac5-c730-4ba2-a2d9-23d5ac13f12b.jpg?1783931222,Instant,Ravenna Tran
+Decree of Silence,8,2003,36.1,#341aff,https://cards.scryfall.io/normal/front/f/2/f2fc46e2-5e19-4999-a4cd-1e84697066c1.jpg?1783944888,Enchantment,Adam Rex
+Deekah- Fractal Theorist,5,2026,0.34,#341aff,https://cards.scryfall.io/normal/front/1/8/186e15a7-d97e-40df-adaa-96d9bd64f3ca.jpg?1783903791,Legendary Creature — Human Wizard,Donato Giancola
+Deepglow Skate,5,2025,0.36,#341aff,https://cards.scryfall.io/normal/front/6/f/6fb36f7b-6d31-413d-8392-ae4f8ca3c0c4.jpg?1783906045,Creature — Fish,Jason Kang
+Deeproot Pilgrimage,2,2023,1.6,#341aff,https://cards.scryfall.io/normal/front/e/2/e2449311-a705-4a31-a345-a36d436ae561.jpg?1783913797,Enchantment,Rémi Jacquot
+Deep-Sea Kraken,10,2017,1.79,#341aff,https://cards.scryfall.io/normal/front/d/f/df5a543e-8416-4f01-91f5-e1ed87f1a510.jpg?1783936580,Creature — Kraken,Christopher Moeller
+Defiler of Dreams,5,2022,0.39,#341aff,https://cards.scryfall.io/normal/front/8/8/881cc4a3-252b-4155-a34f-63d4b4f44442.jpg?1783921353,Creature — Phyrexian Sphinx,Ryan Pancoast
+Deflection,4,2003,0.39,#341aff,https://cards.scryfall.io/normal/front/2/1/217c899e-f624-4791-af64-b1b1e2ac53cd.jpg?1783944805,Instant,Jeremy Jarvis
+Delay,2,2024,2.86,#341aff,https://cards.scryfall.io/normal/front/2/d/2d256283-be94-4a34-805e-fc17503c7fbd.jpg?1783909711,Instant,Jordan Speer
+Delusions of Mediocrity,4,2001,1.43,#341aff,https://cards.scryfall.io/normal/front/a/b/ab43fba7-699e-4bb5-ab3e-b5b1c290340c.jpg?1783945549,Enchantment,Terese Nielsen
+Deluxe Dragster,5,2023,2.16,#341aff,https://cards.scryfall.io/normal/front/4/b/4b90313d-9f61-4788-a55e-1f8189bf1ef5.jpg?1783917287,Artifact — Vehicle,Gabor Szikszai
+Delver of Secrets // Insectile Aberration,1,2026,5.95,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Wizard // Creature — Human Insect,Florey & Scott Okumura
+Demilich,4,2021,0.62,#341aff,https://cards.scryfall.io/normal/front/0/a/0a1351ed-b9df-4a6d-aaa1-ec6db673d265.jpg?1783926516,Creature — Skeleton Wizard,Daniel Zrom
+Denethor- Stone Seer,2,2023,0.19,#d78f42,https://cards.scryfall.io/normal/front/d/3/d32d3d8a-7450-4a29-abc7-f472426f0c28.jpg?1783916033,Legendary Creature — Human Noble,Bruno Biazotto
+Denizen of the Deep,8,2023,0.21,#341aff,https://cards.scryfall.io/normal/front/c/a/ca7959e9-8ae7-49f7-acf9-a0fc2afa219e.jpg?1783918495,Creature — Serpent,Anson Maddocks
+Denying Wind,9,2000,0.6,#341aff,https://cards.scryfall.io/normal/front/1/5/15f236ce-41ad-4a49-a6f9-7853a2395a84.jpg?1783945793,Sorcery,Tony Szczudlo
+Dermoplasm,3,2003,0.33,#341aff,https://cards.scryfall.io/normal/front/c/f/cf2f5dca-e01f-41e3-bb6f-a60162118c6d.jpg?1783944923,Creature — Shapeshifter,John Avon
+Desertion,5,2016,0.96,#341aff,https://cards.scryfall.io/normal/front/b/3/b362151e-4ad6-4ae9-91e5-0e4a69d53ca5.jpg?1783937327,Instant,Richard Kane Ferguson
+Desynchronization,4,2024,4.94,#341aff,https://cards.scryfall.io/normal/front/3/d/3ddd3561-0143-40b7-81bc-640a978b8b15.jpg?1783910985,Instant,Lie Setiawan
+Detective of the Month,3,2024,0.38,#341aff,https://cards.scryfall.io/normal/front/e/6/e63e381d-142c-4622-ad78-8cacd5778355.jpg?1783913048,Creature — Human Detective,Stella Spente
+Devastation Tide,5,2018,0.51,#341aff,https://cards.scryfall.io/normal/front/2/d/2d493bd6-af71-45be-bd4c-1d8f94bca19e.jpg?1783934310,Sorcery,Raymond Swanland
+Dichotomancy,9,2007,0.35,#341aff,https://cards.scryfall.io/normal/front/6/1/61583ead-bccc-44d9-bd1d-2a13511990b5.jpg?1783943162,Sorcery,Steven Belledin
+Dictate of Kruphix,3,2024,0.38,#341aff,https://cards.scryfall.io/normal/front/b/5/b5e4087b-e692-4eb2-bb59-ff2a001d6dd4.jpg?1783908937,Enchantment,Daarken
+Dig Through Time,8,2026,0.25,#341aff,https://cards.scryfall.io/normal/front/0/2/020939d6-72f0-4aa0-9ac2-d16cc896cd7f.jpg?1783903792,Instant,Ryan Yee
+Diluvian Primordial,7,2024,0.63,#341aff,https://cards.scryfall.io/normal/front/e/b/eb14cd77-d37e-4849-816f-cd36e2a37765.jpg?1783911942,Creature — Avatar,Stephan Martiniere
+Diminishing Returns,4,2016,7.67,#341aff,https://cards.scryfall.io/normal/front/f/9/f9ed455f-95cd-48ca-8b0d-4db259347bb6.jpg?1783937617,Sorcery,Greg Opalinski
+Dirgur Focusmage // Braingeyser,3,2026,0.33,#341aff,https://cards.scryfall.io/normal/front/7/b/7bdabeba-0cfb-4953-b725-50a48164a044.jpg?1783903861,Creature — Djinn Monk // Sorcery,Andrew Mar
+Disallow,3,2017,2.06,#341aff,https://cards.scryfall.io/normal/front/2/5/25f05814-a5a5-460f-9d29-0ab03efecf4c.jpg?1783936774,Instant,Min Yum
+Disciple of the Ring,5,2022,0.35,#341aff,https://cards.scryfall.io/normal/front/5/a/5a885848-005f-4387-8982-40052b924076.jpg?1783921919,Creature — Human Wizard,Clint Cearley
+Discontinuity,6,2020,1.02,#341aff,https://cards.scryfall.io/normal/front/b/3/b33ba0a8-04e9-4df6-af20-a3ca4470cdcc.jpg?1783930730,Instant,Volkan Baǵa
+Dismiss into Dream,7,2013,0.74,#341aff,https://cards.scryfall.io/normal/front/a/f/af4cd7fe-639c-45a5-97af-9529904e3975.jpg?1783939935,Enchantment,Sam Wolfe Connelly
+Displacement Wave,2,2015,0.4,#341aff,https://cards.scryfall.io/normal/front/a/d/ad6fef1f-6cc9-4e24-a1be-fc313774f28d.jpg?1783938352,Sorcery,Seb McKinnon
+Displacer Kitten,4,2022,30.68,#341aff,https://cards.scryfall.io/normal/front/c/7/c7a401b8-29fb-46ef-a663-427f66724d5c.jpg?1783922795,Creature — Cat Beast,Campbell White
+Disrupting Shoal,2,2018,16.76,#341aff,https://cards.scryfall.io/normal/front/b/4/b46b20c4-f69b-45ed-8c9e-50847f215e73.jpg?1783933846,Instant — Arcane,Scott M. Fischer
+Disruptor of Currents,5,2026,0.28,#341aff,https://cards.scryfall.io/normal/front/4/c/4c6dbbaa-6844-4d7c-abbb-472a83bb99ab.jpg?1783904501,Creature — Merfolk Wizard,Pauline Voss
+Dissipation Field,4,2022,2.98,#341aff,https://cards.scryfall.io/normal/front/d/d/dd2d9f47-2bd2-4a97-90c7-beca18a8e7fa.jpg?1783922471,Enchantment,Matt Cavotta
+Distant Melody,4,2025,4.12,#341aff,https://cards.scryfall.io/normal/front/7/a/7a0edb6c-f397-401e-a0b0-6dee77d243a8.jpg?1783905159,Sorcery,Paul Scott Canavan
+Distant Memories,4,2011,0.3,#341aff,https://cards.scryfall.io/normal/front/1/5/158da0aa-8317-498b-89ed-2f84317fe256.jpg?1783941389,Sorcery,Karl Kopinski
+Distorting Wake,3,2014,0.61,#341aff,https://cards.scryfall.io/normal/front/7/7/77e28743-3694-48ef-9f16-0a3a4ff7e934.jpg?1783938850,Sorcery,Arnie Swekel
+Divert,1,2001,2.45,#341aff,https://cards.scryfall.io/normal/front/8/e/8eb6e9f8-a508-451e-8a72-5f9834ba5352.jpg?1783945261,Instant,Christopher Moeller
+Diviner of Mist,5,2025,0.28,#341aff,https://cards.scryfall.io/normal/front/c/2/c2880977-4e68-4f04-9218-e6ade72238f6.jpg?1783907183,Creature — Dragon,Lorenzo Mastroianni
+Diviner's Portent,3,2021,1.06,#341aff,https://cards.scryfall.io/normal/front/7/2/725b8b21-64f0-4449-ad65-c8144e64836f.jpg?1783926253,Instant,Lie Setiawan
+Djinn of Infinite Deceits,6,2017,0.77,#341aff,https://cards.scryfall.io/normal/front/8/f/8f0f3643-a355-4132-bce8-c306df3cf830.jpg?1783936294,Creature — Djinn,Robbie Trevino
+Djinn of the Lamp,7,1997,0.99,#341aff,https://cards.scryfall.io/normal/front/3/a/3a5e7b52-2663-4140-9758-f24b8b947876.jpg?1783946841,Creature — Djinn,DiTerlizzi
+Djinn of Wishes,5,2018,0.23,#341aff,https://cards.scryfall.io/normal/front/a/5/a5491962-ad47-4919-b59c-510408bed29e.jpg?1783934310,Creature — Djinn,Kev Walker
+Docent of Perfection // Final Iteration,5,2025,0.49,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Insect Horror // Creature — Eldrazi Insect,Nils Hamm
+Does Machines,2,2026,0.39,#341aff,https://cards.scryfall.io/normal/front/9/8/989da63a-2cbd-41a9-9bbb-99f4ad1c6a25.jpg?1783904118,Enchantment — Class,Aeron Ng
+Domestication,4,2013,0.11,#341aff,https://cards.scryfall.io/normal/front/7/b/7bf0b7e3-fe3f-4710-9b92-9ffdb242e92e.jpg?1783939935,Enchantment — Aura,Jesper Ejsing
+Dominating Licid,3,1998,1.63,#341aff,https://cards.scryfall.io/normal/front/e/3/e3e03323-43e8-4ddc-a874-211a97fd7648.jpg?1783946526,Creature — Licid,Heather Hudson
+Domineering Will,4,2022,0.41,#341aff,https://cards.scryfall.io/normal/front/e/8/e8c3836d-a08b-424c-aefe-e1585161edf7.jpg?1783922474,Instant,Mike Sass
+Donal- Herald of Wings,4,2021,0.43,#341aff,https://cards.scryfall.io/normal/front/7/0/70cf8d2b-5220-4fe9-b39d-6700f0b27cca.jpg?1783925009,Legendary Creature — Human Wizard,Wayne Reynolds
+Donate,3,1999,15.28,#341aff,https://cards.scryfall.io/normal/front/7/f/7f6d8ce9-f8c8-45ad-b74c-97fba0e2982e.jpg?1783946080,Sorcery,Jeff Miracola
+Donatello- Gadget Master,3,2026,0.38,#341aff,https://cards.scryfall.io/normal/front/8/b/8b5dd830-dab8-4628-845f-3d17973f9ffa.jpg?1783904117,Legendary Creature — Mutant Ninja Turtle,Svetlin Velinov
+Donatello- Mutant Mechanic,4,2026,1.14,#341aff,https://cards.scryfall.io/normal/front/3/2/3271b821-8efc-49e2-96fd-c48e2b2585c6.jpg?1783904116,Legendary Creature — Mutant Ninja Turtle,Zoltan Boros
+Donatello- Rad Scientist,6,2026,0.4,#341aff,https://cards.scryfall.io/normal/front/3/a/3a80b791-17e1-46be-bc65-ab96f52b23dd.jpg?1783904138,Legendary Creature — Mutant Ninja Turtle,Thomas Chamberlain-Keen
+Donatello- the Brains,3,2026,1.55,#341aff,https://cards.scryfall.io/normal/front/7/7/774716f4-d211-497a-be91-69cd700edbf2.jpg?1783904175,Legendary Creature — Mutant Ninja Turtle,Jason Rainville
+Donnie & April- Adorkable Duo,5,2026,0.36,#341aff,https://cards.scryfall.io/normal/front/7/b/7b4bdb8c-e19f-46bd-9743-edc26ee5c8e2.jpg?1783904139,Legendary Creature — Mutant Ninja Human Turtle,Le Vuong
+Dormant Gomazoa,3,2010,0.32,#341aff,https://cards.scryfall.io/normal/front/1/3/131d2925-d87c-415f-aa84-97f14030624e.jpg?1783941998,Creature — Jellyfish,Chris Rahn
+Double Down,4,2024,0.59,#341aff,https://cards.scryfall.io/normal/front/8/e/8ecccdf3-98c6-4aed-8757-913623efb677.jpg?1783911846,Enchantment,Javier Charro
+Dour Port-Mage,2,2024,2.27,#341aff,https://cards.scryfall.io/normal/front/6/4/6402133e-eed1-4a46-9667-8b7a310362c1.jpg?1783910852,Creature — Frog Wizard,Ryan Pancoast
+Drafna- Founder of Lat-Nam,2,2022,0.4,#341aff,https://cards.scryfall.io/normal/front/f/7/f7355905-2b3b-4191-a89c-a0fc1494928b.jpg?1783920112,Legendary Creature — Human Artificer Advisor,Lie Setiawan
+Dragonlord's Prerogative,6,2015,0.31,#341aff,https://cards.scryfall.io/normal/front/5/3/53f2d2b3-6e48-413e-ad8f-9ce40c7ff167.jpg?1783938609,Instant,Seb McKinnon
+Dragonologist,3,2025,1.07,#341aff,https://cards.scryfall.io/normal/front/8/8/8810ebb4-9e51-46f0-a54a-a0b4d77b762a.jpg?1783907397,Creature — Human Wizard,Mila Pesic
+Dragon Turtle,3,2021,0.34,#341aff,https://cards.scryfall.io/normal/front/d/4/d436ba80-386f-40ad-b0ca-a98cc50de964.jpg?1783926517,Creature — Dragon Turtle,Dan Murayama Scott
+Draining Whelk,6,2021,0.38,#341aff,https://cards.scryfall.io/normal/front/5/1/51eca246-591e-4ea8-8432-9f4c1f16a65e.jpg?1783927851,Creature — Illusion,Mark Tedin
+Drake Hatcher,2,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/b/c/bcaf4196-6bf3-47fa-b5c7-0e77f45cf820.jpg?1783909119,Creature — Human Wizard,Chris Rallis
+Drake Haven,3,2020,0.45,#341aff,https://cards.scryfall.io/normal/front/e/2/e2502a3a-2c1d-490e-b958-969dfc7f875a.jpg?1783931188,Enchantment,John Severin Brassell
+Dralnu's Pet,3,2001,0.26,#d78f42,https://cards.scryfall.io/normal/front/c/d/cd5f4daf-7b54-4425-a93a-19532dfb83ca.jpg?1783945626,Creature — Shapeshifter,Glen Angus
+Dramatic Reversal,2,2022,23.56,#341aff,https://cards.scryfall.io/normal/front/7/e/7e99bb96-dc40-4623-b133-b5def847477d.jpg?1783918775,Instant,Volta Creation
+Drawn from Dreams,4,2022,0.28,#341aff,https://cards.scryfall.io/normal/front/d/6/d61e811a-a744-40df-8d98-93f41a7bb0a0.jpg?1783923281,Sorcery,Chris Seaman
+Dreamborn Muse,4,2018,3.36,#341aff,https://cards.scryfall.io/normal/front/8/3/83ad2ba9-ab54-4abc-805d-dc9fe31bac7f.jpg?1783934765,Creature — Spirit,Kev Walker
+Dreamcaller Siren,4,2017,0.28,#341aff,https://cards.scryfall.io/normal/front/5/4/548c92c8-1ae1-48b4-8cbe-aa18f59c1efb.jpg?1783935782,Creature — Siren Pirate,Eric Deschamps
+Dream Eater,6,2024,0.23,#341aff,https://cards.scryfall.io/normal/front/c/7/c721d449-fc77-4d86-8baf-158181e37087.jpg?1783909628,Creature — Nightmare Sphinx,Daarken
+Dream Leash,5,2005,0.33,#341aff,https://cards.scryfall.io/normal/front/0/d/0de4fa3d-a144-4918-b032-7495ab2e1c8c.jpg?1783943688,Enchantment — Aura,Alex Horley-Orlandelli
+Dreamshackle Geist,3,2021,0.33,#341aff,https://cards.scryfall.io/normal/front/1/b/1b81d90b-708a-48c9-a478-e3b0a3d7e982.jpg?1783924894,Creature — Spirit,Andreas Zafiratos
+Dream Strix,3,2021,0.19,#341aff,https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg?1783927380,Creature — Bird Illusion,YW Tang
+Dreamtide Whale,3,2024,2.24,#341aff,https://cards.scryfall.io/normal/front/f/d/fd7dc03e-2a61-482a-b7eb-6cdb7f375fd8.jpg?1783911291,Creature — Whale,Ron Spears
+Dress Down,2,2021,0.54,#341aff,https://cards.scryfall.io/normal/front/0/4/04f9f061-67b8-4427-9fcb-b3ccfee8fc5d.jpg?1783926882,Enchantment,Iain McCaig
+Drifting Djinn,6,1998,0.65,#341aff,https://cards.scryfall.io/normal/front/9/7/971d0eda-91b8-48f2-a988-016bcc7ab35e.jpg?1783946361,Creature — Djinn,Carl Critchlow
+Drowned Secrets,2,2018,0.56,#341aff,https://cards.scryfall.io/normal/front/b/f/bfc98428-7a0f-445f-9d48-eeb76c3e10d6.jpg?1783934187,Enchantment,Alexander Forssberg
+Drown in Dreams,3,2021,2.48,#341aff,https://cards.scryfall.io/normal/front/a/f/af4d5acb-12d6-46d7-aaf9-3ace1520825a.jpg?1783925379,Instant,Olena Richards
+Duelist of the Mind,2,2024,0.3,#341aff,https://cards.scryfall.io/normal/front/2/b/2b58e47b-c165-4a58-aa2a-033a35645adc.jpg?1783911847,Creature — Human Advisor,Darren Tan
+Dulcet Sirens,3,2014,0.58,#341aff,https://cards.scryfall.io/normal/front/0/4/045e15fd-6e2b-40a9-89ba-2f4c9e445416.jpg?1783938871,Creature — Siren,Magali Villeneuve
+Dungeon Delver,2,2026,1.51,#341aff,https://cards.scryfall.io/normal/front/8/6/86142f1e-dd75-4c46-a58d-9386b69a9a1f.jpg?1783904226,Legendary Enchantment — Background,Josh Freydkis
+Dungeon Geists,4,2019,0.13,#341aff,https://cards.scryfall.io/normal/front/d/3/d3c81fda-c23d-437c-85f0-62d7b492ea32.jpg?1783933011,Creature — Spirit,Nils Hamm
+Duplicity,5,1997,0.36,#341aff,https://cards.scryfall.io/normal/front/d/5/d529cb33-292d-40e3-8cfe-db5eeb0d711e.jpg?1783946657,Enchantment,Dan Frazier
+Echocasting Symposium,6,2026,3.31,#341aff,https://cards.scryfall.io/normal/front/5/d/5d7086a7-dc42-468a-a2cf-a6f89030f947.jpg?1783903694,Sorcery — Lesson,Fajareka Setiawan
+Echo Mage,3,2013,0.32,#341aff,https://cards.scryfall.io/normal/front/8/b/8b76ba96-9630-44fb-849e-3c3848c03876.jpg?1783939683,Creature — Human Wizard,Matt Stewart
+Echo of Eons,6,2019,12.81,#341aff,https://cards.scryfall.io/normal/front/f/f/ff590af2-2d6c-4f16-a9b8-1a6dab6e9ad5.jpg?1783933147,Sorcery,Terese Nielsen
+Echo Storm,5,2023,0.3,#341aff,https://cards.scryfall.io/normal/front/7/5/75046d32-fb0b-4c25-9ffd-53db64ff6c9e.jpg?1783917171,Sorcery,Mark Poole
+Edgar- King of Figaro,6,2025,0.33,#341aff,https://cards.scryfall.io/normal/front/9/5/950ee302-5512-43c5-ac7c-b2b06f4177bf.jpg?1783906638,Legendary Creature — Human Artificer Noble,Jake Murray
+Elder Spawn,7,1994,14.06,#341aff,https://cards.scryfall.io/normal/front/9/9/99cc045e-01a8-4f14-a86d-0a67ec35d6b7.jpg?1783948077,Creature — Spawn,Jesper Myrfors
+Eligeth- Crossroads Augur,6,2020,0.32,#341aff,https://cards.scryfall.io/normal/front/1/a/1a0adf34-1a2b-497b-aaab-4b2b998ed8b3.jpg?1783928863,Legendary Creature — Sphinx,Yigit Koroglu
+Elite Arcanist,4,2013,0.27,#341aff,https://cards.scryfall.io/normal/front/9/9/99b225fe-c07d-4d8a-bf2b-c1777bd29061.jpg?1783939934,Creature — Human Wizard,James Zapata
+Elminster's Simulacrum,6,2022,2.24,#341aff,https://cards.scryfall.io/normal/front/3/5/351a6e6a-758d-417d-82c9-2c78db37d91e.jpg?1783922790,Instant,Irina Nordsol
+Eluge- the Shoreless Sea,4,2024,4.68,#341aff,https://cards.scryfall.io/normal/front/1/f/1f2bf6ba-cd1a-4382-9572-6dfbcf6ed0c6.jpg?1783910850,Legendary Creature — Elemental Fish,Chase Stone
+Elusive Otter // Grove's Bounty,1,2026,0.27,#d78f42,https://cards.scryfall.io/normal/front/b/d/bdb79d68-c3af-4091-b7db-005247191da8.jpg?1783903753,Creature — Otter // Sorcery — Adventure,Christina Kraus
+Elusive Tormentor // Insidious Mist,4,2016,0.25,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Vampire Wizard // Creature — Elemental,Izzy
+Elvish Mariner,3,2023,1.53,#341aff,https://cards.scryfall.io/normal/front/7/6/7604d357-4196-421f-a5c3-c7cbe79f35cb.jpg?1783916221,Creature — Elf Pilot,Axel Sauerwald
+Embargo,4,1999,1.01,#341aff,https://cards.scryfall.io/normal/front/3/f/3fca3c65-f20e-4978-bfbb-ee7f9e1d829f.jpg?1783945966,Enchantment,Nelson DeCastro
+Emeritus of Ideation // Ancestral Recall,5,2026,5.58,#341aff,https://cards.scryfall.io/normal/front/7/5/75961d36-acf6-425f-9698-0bf52af74f31.jpg?1783903694,Creature — Human Wizard // Instant,Evyn Fong
+Emissary Escort,2,2025,0.28,#341aff,https://cards.scryfall.io/normal/front/b/5/b52ba87f-3ac7-4f32-901c-d089df979f94.jpg?1783905982,Artifact Creature — Robot Soldier,Igor Grechanyi
+Emperor Mihail II,3,2023,0.38,#341aff,https://cards.scryfall.io/normal/front/4/4/444ccd33-e88f-4d37-8a99-e10096eef5d3.jpg?1783913888,Legendary Creature — Merfolk Noble,PINDURSKI
+Empress Galina,5,2000,13.26,#341aff,https://cards.scryfall.io/normal/front/6/8/6851dbc7-f072-41e7-a899-897445d99425.jpg?1783945708,Legendary Creature — Merfolk Noble,Matt Cavotta
+Empty the Laboratory,2,2021,1.03,#341aff,https://cards.scryfall.io/normal/front/1/9/191f6693-32d9-448d-8889-f98cf13c2277.jpg?1783925380,Sorcery,Tuan Duong Chu
+Emry- Lurker of the Loch,3,2025,0.59,#341aff,https://cards.scryfall.io/normal/front/c/9/c977d89a-bfd1-4e98-9d95-3e41c53dd188.jpg?1783906044,Legendary Creature — Merfolk Wizard,Livia Prima
+Encroaching Mycosynth,4,2023,0.42,#341aff,https://cards.scryfall.io/normal/front/6/5/65a2fcc9-2317-48a1-a5eb-234fb3300364.jpg?1783918066,Artifact,Martin de Diego Sádaba
+Endless Evil,3,2022,3.75,#341aff,https://cards.scryfall.io/normal/front/8/0/804b3378-b330-45d2-9e2c-602ec080f285.jpg?1783922508,Enchantment — Aura,Diego Gisbert
+Enduring Curiosity,4,2024,6.17,#341aff,https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg?1783909497,Enchantment Creature — Cat Glimmer,Julie Dillon
+Energy Field,2,1998,3.82,#341aff,https://cards.scryfall.io/normal/front/8/1/81ff5770-b207-41e1-97b7-b9347c72b407.jpg?1783946361,Enchantment,John Matson
+Energy Vortex,5,1996,0.78,#341aff,https://cards.scryfall.io/normal/front/8/7/87e060d7-42ed-49ab-bc5c-2f3210cbd0d1.jpg?1783947111,Enchantment,Tom Wänerstrand
+Engulf the Shore,4,2019,3.05,#341aff,https://cards.scryfall.io/normal/front/c/d/cdbcb537-86fb-4649-859d-c9da12327f85.jpg?1783931661,Instant,Cliff Childs
+Enigma Thief,7,2020,0.35,#341aff,https://cards.scryfall.io/normal/front/3/5/3536a97f-565b-45c6-a54b-96afd2a268ec.jpg?1783929495,Creature — Sphinx Rogue,Victor Adame Minguez
+Enter the Infinite,12,2013,6.01,#341aff,https://cards.scryfall.io/normal/front/6/1/612beb8f-2ab1-4a8b-84c5-c47d19d400ab.jpg?1783940138,Sorcery,Terese Nielsen
+Entity Tracker,3,2024,0.37,#341aff,https://cards.scryfall.io/normal/front/a/e/ae54d697-6d06-4af1-a617-8a47a6ab9c01.jpg?1783909496,Creature — Human Scout,Cristi Balanescu
+Entrancing Melody,2,2026,0.22,#341aff,https://cards.scryfall.io/normal/front/0/b/0b6bce62-87d2-458f-bc77-6fe032dacbd0.jpg?1783903791,Sorcery,Winona Nelson
+Eon Frolicker,4,2020,0.45,#341aff,https://cards.scryfall.io/normal/front/a/c/acaec4bf-69c8-43c1-960f-cb5b5bff660a.jpg?1783931221,Creature — Elemental Otter,Brian Valeza
+Epiphany at the Drownyard,1,2016,0.29,#341aff,https://cards.scryfall.io/normal/front/6/4/64b44364-8f83-4dcf-8458-0fd54a698524.jpg?1783937800,Instant,Titus Lunter
+Equilibrium,3,2001,3.59,#341aff,https://cards.scryfall.io/normal/front/d/f/dfbe8836-88c3-4f5d-88a0-73e54673960e.jpg?1783945549,Enchantment,Don Hazeltine
+Erayo- Soratami Ascendant // Erayo's Essence,2,2005,21.98,#341aff,https://cards.scryfall.io/normal/front/0/b/0b61d772-2d8b-4acf-9dd2-b2e8b03538c8.jpg?1783944164,Legendary Creature — Moonfolk Monk // Legendary Enchantment,Matt Cavotta
+Errant- Street Artist,1,2022,0.28,#341aff,https://cards.scryfall.io/normal/front/6/1/61d23407-9fe0-4cbf-b4b5-bc1e132c36e4.jpg?1783923146,Legendary Creature — Human Rogue,Justine Cruz
+Ertai's Familiar,2,1997,0.76,#341aff,https://cards.scryfall.io/normal/front/3/5/354c9de7-0cdf-4302-9d1a-ae17eca13053.jpg?1783946742,Creature — Illusion,Kipling West
+Ertai's Meddling,1,1997,2.02,#341aff,https://cards.scryfall.io/normal/front/3/5/35c7e7fa-1493-4ef8-9cdb-b02b07a1ad85.jpg?1783946657,Instant,Steve Luke
+Ertai- Wizard Adept,3,1998,12.81,#341aff,https://cards.scryfall.io/normal/front/9/1/91971e19-61ce-45ac-b700-9ffca5091a27.jpg?1783946525,Legendary Creature — Human Wizard,Terese Nielsen
+Escaped Shapeshifter,5,1997,1.06,#341aff,https://cards.scryfall.io/normal/front/e/0/e0171d4f-c871-4a7f-821a-82b7f401e9ca.jpg?1783946656,Creature — Shapeshifter,Douglas Shuler
+Esoteric Duplicator,3,2024,1.2,#341aff,https://cards.scryfall.io/normal/front/3/d/3dbb2755-97d9-492e-8697-5548160678c8.jpg?1783912002,Artifact — Clue,Anton Solovianchyk
+Estrid's Invocation,3,2024,0.39,#341aff,https://cards.scryfall.io/normal/front/8/9/8920e7e4-d89e-4ff9-8922-27fdc2f8ed6e.jpg?1783911217,Enchantment,Johannes Voss
+Eternal Dominion,10,2005,4.88,#341aff,https://cards.scryfall.io/normal/front/3/0/3067a9bd-991a-462d-862a-2518ae31c382.jpg?1783944164,Sorcery,Shishizaru
+Ethereal Forager,6,2020,0.33,#341aff,https://cards.scryfall.io/normal/front/9/7/97543d69-547e-41f8-9a4f-908e5eb0ee4a.jpg?1783931220,Creature — Elemental Whale,Nicholas Gregory
+Ethereal Investigator,4,2024,0.39,#341aff,https://cards.scryfall.io/normal/front/c/6/c675428b-2dc4-408d-9632-81c1a700090f.jpg?1783913017,Creature — Spirit,Sean Murray
+Etherium Sculptor,2,2022,18.81,#341aff,https://cards.scryfall.io/normal/front/e/7/e7f9bbf2-aa52-4daf-937e-29aef8810d35.jpg?1783921955,Artifact Creature — Vedalken Artificer,Rudy Siswanto
+Ethersworn Adjudicator,5,2023,0.43,#d78f42,https://cards.scryfall.io/normal/front/7/7/774ece27-ca6b-4e04-88ae-cfc774401bdc.jpg?1783917170,Artifact Creature — Vedalken Knight,Dan Murayama Scott
+Evacuation,5,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/b/1/b11037bc-e719-461e-a89e-9c026dfd9fd4.jpg?1783913887,Instant,Jason Rainville
+Even the Score,3,2022,0.47,#341aff,https://cards.scryfall.io/normal/front/c/6/c629217f-4a10-4d92-86f8-22dc4067a724.jpg?1783923145,Instant,Greg Opalinski
+Ever-Watching Threshold,3,2018,0.54,#341aff,https://cards.scryfall.io/normal/front/b/7/b711a0aa-90e5-4f16-9dc3-9cc331fc3101.jpg?1783934344,Enchantment,Ravenna Tran
+Evie Frye,2,2024,0.31,#341aff,https://cards.scryfall.io/normal/front/6/2/62f1ff84-d363-4aa2-b884-e9640cf62537.jpg?1783910982,Legendary Creature — Human Assassin,Lie Setiawan
+Exchange of Words,3,2022,0.89,#341aff,https://cards.scryfall.io/normal/front/8/c/8c28cebf-f849-4353-9dd1-c62f05c15d0f.jpg?1783920598,Enchantment,Zoltan Boros
+Exert Influence,5,2015,0.11,#341aff,https://cards.scryfall.io/normal/front/c/3/c35e9d13-ee4b-42f1-a154-18ab32947ad3.jpg?1783938208,Sorcery,Magali Villeneuve
+Exhaustion,3,1999,19.39,#341aff,https://cards.scryfall.io/normal/front/9/6/96ad34ed-c811-432d-b9c7-bff7c024cd4f.jpg?1783946124,Sorcery,Qu Xin
+Exhibition Tidecaller,1,2026,0.52,#341aff,https://cards.scryfall.io/normal/front/a/5/a58c364e-d0c5-41b9-8c8b-2e5a99468cc7.jpg?1783903694,Creature — Djinn Wizard,Tulio Brito
+Expansion Algorithm,2,2026,2.12,#341aff,https://cards.scryfall.io/normal/front/e/f/ef261999-1c18-46f3-bbd6-72911e14328f.jpg?1783903861,Sorcery,Serena Malyon
+Expropriate,9,2016,14.54,#341aff,https://cards.scryfall.io/normal/front/9/c/9c8a2a5a-cb9b-4582-a453-085da78584f9.jpg?1783937359,Sorcery,Zack Stella
+Extract,1,2001,5.08,#341aff,https://cards.scryfall.io/normal/front/9/7/97f99a3d-d811-4666-aac8-5957068157dc.jpg?1783945260,Sorcery,Matt Cavotta
+Extract Power,6,2026,0.29,#341aff,https://cards.scryfall.io/normal/front/1/1/11aaa7c6-c79d-48f9-af66-3b360d3b15b5.jpg?1783903293,Sorcery,Ioannis Fiore
+Extraordinary Journey,2,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/a/6/a69fb480-a9fc-4f09-ac4e-3ce52c485ea9.jpg?1783915121,Enchantment,Volkan Baǵa
+Extravagant Replication,6,2024,0.35,#341aff,https://cards.scryfall.io/normal/front/6/a/6a41dfae-bc7e-4105-8f7e-fd0109197ad8.jpg?1783909081,Enchantment,Pauline Voss
+Extravagant Spirit,4,1999,0.36,#341aff,https://cards.scryfall.io/normal/front/9/9/99243564-9dbd-420c-922d-c17854c99d2a.jpg?1783945966,Creature — Spirit,Edward P. Beard, Jr.
+Eye of the Storm,7,2005,1.32,#341aff,https://cards.scryfall.io/normal/front/4/9/49967eb9-5020-4f0a-8775-5114f6d96d75.jpg?1783943687,Enchantment,Hideaki Takamura
+Faces of the Past,3,2003,13.49,#341aff,https://cards.scryfall.io/normal/front/0/f/0f6dc35b-eb26-498f-ae35-0e860871446e.jpg?1783944887,Enchantment,Wayne England
+Fae of Wishes // Granted,2,2019,0.33,#341aff,https://cards.scryfall.io/normal/front/e/3/e3435fd6-8f51-4d99-a278-4ddb088acfe1.jpg?1783932659,Creature — Faerie Wizard // Sorcery — Adventure,Magali Villeneuve
+Faerie Artisans,4,2023,2.25,#341aff,https://cards.scryfall.io/normal/front/e/a/eaada60d-1857-4fc2-a997-d7775565221a.jpg?1783915699,Creature — Faerie Artificer,Tony Foti
+Faerie Formation,5,2019,0.52,#341aff,https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg?1783932552,Creature — Faerie,Ryan Yee
+Faerie Mastermind,2,2026,11.54,#341aff,https://cards.scryfall.io/normal/front/b/c/bc9a7599-3c7d-4b83-bff3-e3d1f20f1b0f.jpg?1783903820,Creature — Faerie Rogue,Kai Carpenter
+Faerie Slumber Party,6,2023,1.74,#341aff,https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg?1783915040,Sorcery,Lie Setiawan
+False Memories,2,2002,0.32,#341aff,https://cards.scryfall.io/normal/front/3/a/3a45ea90-03af-446e-9df3-ef64e9613f2c.jpg?1783945161,Instant,Ron Spencer
+Fantastic Elasticity,3,2026,0.35,#341aff,https://cards.scryfall.io/normal/front/3/5/35521ad2-f701-48d6-8686-537ef1f079da.jpg?1783903293,Sorcery,Mintautas Šukys
+Farsight Ritual,4,2023,0.23,#341aff,https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg?1783915120,Instant,Randy Gallegos
+Fated Infatuation,3,2014,0.52,#341aff,https://cards.scryfall.io/normal/front/9/e/9e5ba99d-d95d-4a3b-b6b6-a5e2589d538e.jpg?1783939569,Instant,Winona Nelson
+Fatespinner,3,2003,9.51,#341aff,https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg?1783944554,Creature — Human Wizard,rk post
+Fathom Trawl,5,2007,0.31,#341aff,https://cards.scryfall.io/normal/front/c/d/cd9c0bd7-f8a9-4d13-9a06-acc8bfb3d68b.jpg?1783942903,Sorcery,Paul Chadwick
+Fblthp- Lost on the Range,3,2024,0.35,#341aff,https://cards.scryfall.io/normal/front/0/1/01d3e6ea-4791-4948-af22-c1bd04c34c1e.jpg?1783911846,Legendary Creature — Homunculus,Brian Valeza
+Fblthp- the Lost,2,2024,0.36,#341aff,https://cards.scryfall.io/normal/front/7/9/79b2c547-0d9e-4fd7-a399-347ad908c70b.jpg?1783913337,Legendary Creature — Homunculus,Jesper Ejsing
+Fealty to the Realm,5,2023,0.29,#341aff,https://cards.scryfall.io/normal/front/0/1/017a5dbf-5773-448d-abf3-9a3d42bde9e5.jpg?1783916032,Enchantment — Aura,Lorenzo Mastroianni
+Fear of Sleep Paralysis,6,2024,0.41,#341aff,https://cards.scryfall.io/normal/front/8/4/845e9d68-11a9-4759-a031-13464d337e12.jpg?1783909663,Enchantment Creature — Nightmare,Joshua Raphael
+Field of Dreams,1,1994,138.54,#341aff,https://cards.scryfall.io/normal/front/6/a/6a63e119-3b1b-4964-a4b9-b10170ff542b.jpg?1783948076,World Enchantment,Kaja Foglio
+Fierce Guardianship,3,2023,55.35,#341aff,https://cards.scryfall.io/normal/front/f/7/f7f3dd95-bd14-4e0f-a388-444f9cf1b0dc.jpg?1783915698,Instant,Randy Vargas
+Finale of Revelation,2,2024,0.31,#341aff,https://cards.scryfall.io/normal/front/0/a/0a77e063-e8f6-4cb2-954e-74cf41ce73da.jpg?1783908936,Sorcery,Johann Bodin
+Final-Word Phantom,3,2024,1.98,#341aff,https://cards.scryfall.io/normal/front/7/a/7a51d392-58dc-483e-81f7-2d51e64e54ff.jpg?1783913049,Creature — Spirit Detective,Anthony Devine
+Five Hundred Year Diary,4,2023,0.36,#341aff,https://cards.scryfall.io/normal/front/8/9/89c1ebc5-6775-47f3-be43-e59b281eba55.jpg?1783914670,Legendary Artifact — Book Clue,Kieran Yanner
+Flare of Denial,3,2024,3.43,#341aff,https://cards.scryfall.io/normal/front/7/1/71a98efb-9b0a-496b-ac21-8d70527ea544.jpg?1783911290,Instant,Jason A. Engle
+Flash,2,2018,1.77,#341aff,https://cards.scryfall.io/normal/front/d/3/d31459c2-9656-4e9a-bb72-71a910e8570b.jpg?1783935178,Instant,Naomi Baker
+Flash Photography,4,2025,37.6,#341aff,https://cards.scryfall.io/normal/front/2/b/2bca2cd2-4d4a-44e4-87c3-732692b77921.jpg?1783904649,Sorcery,Winona Nelson
+Flatline,3,2023,0.39,#341aff,https://cards.scryfall.io/normal/front/b/a/baea4cd3-cc62-4138-ac2e-5c96c70bbcce.jpg?1783914670,Instant,Filipe Pagliuso
+Flawless Forgery,5,2022,0.2,#341aff,https://cards.scryfall.io/normal/front/1/c/1c808629-ee2b-4f3e-a316-7182fbc38d34.jpg?1783923371,Sorcery,Durion
+Fleeting Image,3,2005,0.16,#341aff,https://cards.scryfall.io/normal/front/5/6/564b8cc4-3392-4307-a5e4-5f04e52da3ab.jpg?1783944050,Creature — Illusion,Dave Dorman
+Fleet Swallower,7,2017,1.27,#341aff,https://cards.scryfall.io/normal/front/7/e/7edbde38-1653-4eb5-b196-8881375781cb.jpg?1783935781,Creature — Fish,Tomasz Jedruszek
+Flesh Duplicate,2,2023,7.77,#341aff,https://cards.scryfall.io/normal/front/5/1/512e9bd2-77b9-4c1c-8d30-e6249dbd930e.jpg?1783914670,Creature — Shapeshifter Rebel,Kekai Kotaki
+Flitterwing Nuisance,1,2026,0.38,#341aff,https://cards.scryfall.io/normal/front/a/d/ad0f6536-5295-4835-8883-35d711dfe6de.jpg?1783904491,Creature — Faerie Rogue,Evyn Fong
+Flooded Shoreline,2,1997,2.0,#341aff,https://cards.scryfall.io/normal/front/4/9/49db9f58-380f-496e-9d3d-6776d30fb564.jpg?1783947001,Enchantment,Romas Kukalis
+Flood of Tears,6,2021,1.16,#341aff,https://cards.scryfall.io/normal/front/4/4/440383de-d56a-47dd-ba8a-fae61f57f83b.jpg?1783924966,Sorcery,Adam Paquette
+Fluros of Myra's Marvels,4,2022,0.15,#341aff,https://cards.scryfall.io/normal/front/4/c/4c974d9a-40a6-4072-90b2-01c3b3461a75.jpg?1783920595,Legendary Creature — Merfolk Performer,Gaboleps
+Flusterstorm,1,2017,8.48,#341aff,https://cards.scryfall.io/normal/front/f/9/f900eeb7-7c45-44bc-ad3a-0bbe594ecf50.jpg?1783935548,Instant,Erica Yang
+Folio of Fancies,2,2019,2.39,#341aff,https://cards.scryfall.io/normal/front/6/a/6afc67d1-1018-4a15-ab5f-377fd11dcd3d.jpg?1783932658,Artifact — Book,Colin Boyer
+Followed Footsteps,5,2016,3.19,#341aff,https://cards.scryfall.io/normal/front/f/e/fe153c49-da2d-42b0-a6d1-77508b0fe8a9.jpg?1783937325,Enchantment — Aura,Glen Angus
+Follow the Bodies,3,2024,0.31,#341aff,https://cards.scryfall.io/normal/front/5/2/52ecb9ef-37bc-4327-9ae6-bcef6e2fdb94.jpg?1783913048,Sorcery,Alfven Ato
+Font of Magic,4,2022,0.41,#341aff,https://cards.scryfall.io/normal/front/1/3/137ee879-bbc3-4e11-b103-3cc604867b1c.jpg?1783922788,Enchantment,Francis Tneh
+Forced Fruition,6,2007,7.02,#341aff,https://cards.scryfall.io/normal/front/f/7/f7ea1c6e-c0af-40b0-b492-8d71f496903e.jpg?1783942903,Enchantment,William O'Connor
+Force of Negation,3,2022,54.41,#341aff,https://cards.scryfall.io/normal/front/1/8/1825a719-1b2a-4af9-9cd2-7cb497cd0317.jpg?1783921916,Instant,Paul Scott Canavan
+Force of Will,5,2023,62.64,#341aff,https://cards.scryfall.io/normal/front/8/9/89f612d6-7c59-4a7b-a87d-45f789e88ba5.jpg?1783918494,Instant,Donato Giancola
+Forensic Gadgeteer,3,2024,1.69,#341aff,https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg?1783912910,Creature — Vedalken Artificer Detective,Volkan Baǵa
+Forger's Foundry,3,2024,0.37,#341aff,https://cards.scryfall.io/normal/front/1/6/16c32c5a-e011-4729-a4a0-b2deac7d5056.jpg?1783911969,Artifact,Rockey Chen
+Forget,2,1999,0.36,#341aff,https://cards.scryfall.io/normal/front/8/c/8cc8e367-1aa4-43b6-b17a-01bfb097f620.jpg?1783946199,Sorcery,Mike Kimble
+Forgotten Creation,4,2022,0.26,#341aff,https://cards.scryfall.io/normal/front/1/d/1d314354-1fb1-498c-8342-ecafac9ff37a.jpg?1783922473,Creature — Zombie Horror,Izzy
+Fortune Teller's Talent,1,2024,0.5,#341aff,https://cards.scryfall.io/normal/front/a/1/a1d43877-20ab-4e84-a597-4b5e03a6bf90.jpg?1783910734,Enchantment — Class,Jarel Threat
+Fractured Sanity,3,2022,3.43,#341aff,https://cards.scryfall.io/normal/front/8/1/81875876-c1a0-4f64-8dfc-39217b5e4020.jpg?1783922470,Sorcery,Drew Tucker
+Frantic Search,3,2025,6.5,#341aff,https://cards.scryfall.io/normal/front/f/b/fbb61ee0-5dba-4e46-814f-8b7c7703a501.jpg?1783905572,Instant,Javier Charro & Scott Okumura
+Fraying Sanity,3,2017,0.69,#341aff,https://cards.scryfall.io/normal/front/7/9/79e5c1ab-eebd-41ca-a1ca-29b00370f6e8.jpg?1783936053,Enchantment — Aura Curse,Ryan Alexander Lee
+Free-for-All,4,1998,2.29,#341aff,https://cards.scryfall.io/normal/front/6/3/630efac8-3033-4c2d-9127-b3b2f78bb136.jpg?1783946431,Enchantment,Claymore J. Flapdoodle
+Frost Titan,6,2014,0.42,#341aff,https://cards.scryfall.io/normal/front/b/b/bb9eec79-1926-46eb-b9e0-6ba12a441495.jpg?1783938850,Creature — Giant,Mike Bierek
+Future Flight,4,2025,0.69,#341aff,https://cards.scryfall.io/normal/front/6/2/62a8b9a4-86cd-4fb3-bda6-a044a79cc6fd.jpg?1783905373,Enchantment — Aura,Lie Setiawan
+Future Sight,5,2019,0.36,#341aff,https://cards.scryfall.io/normal/front/6/3/639cb483-ffe2-4abc-a050-5cdc8aebd5a2.jpg?1783933144,Enchantment,Dan Murayama Scott
+Gadwick- the Wizened,3,2019,0.68,#341aff,https://cards.scryfall.io/normal/front/6/2/62ddce0d-f22a-4fcd-9a4a-d71938750ba1.jpg?1783932660,Legendary Creature — Human Wizard,Colin Boyer
+Galecaster Colossus,7,2017,2.59,#341aff,https://cards.scryfall.io/normal/front/9/e/9e57f6be-44d0-4823-a130-b79dbd025994.jpg?1783935950,Creature — Giant Wizard,Darek Zabrocki
+Galerider Sliver,1,2023,6.65,#341aff,https://cards.scryfall.io/normal/front/5/6/566dc671-b666-4003-a3a6-ff5b081bca54.jpg?1783915441,Creature — Sliver,Campbell White
+Gale's Redirection,5,2022,0.36,#341aff,https://cards.scryfall.io/normal/front/1/f/1f5ddcf8-c87b-4a26-b226-8593f517a74a.jpg?1783922788,Instant,Yeong-Hao Han
+Gale- Waterdeep Prodigy,3,2022,0.41,#341aff,https://cards.scryfall.io/normal/front/6/7/67edf31f-ed67-4617-bf73-28a939a232a7.jpg?1783922788,Legendary Creature — Human Wizard,Cristi Balanescu
+Game Plan,6,2018,0.63,#341aff,https://cards.scryfall.io/normal/front/b/c/bc068891-c251-4eee-b5ca-342d9df33bdc.jpg?1783934867,Sorcery,Seb McKinnon
+Gandalf- Friend of the Shire,4,2023,20.36,#341aff,https://cards.scryfall.io/normal/front/d/7/d745f592-8d4d-46f4-b631-c014da1ab3a9.jpg?1783915182,Legendary Creature — Avatar Wizard,Bakshi Productions
+Gather Specimens,6,2008,1.51,#341aff,https://cards.scryfall.io/normal/front/b/b/bbadf982-f22e-4f4f-b5c9-ac387f25c15f.jpg?1783942574,Instant,Michael Bruinsma
+Genestealer Patriarch,5,2022,0.35,#341aff,https://cards.scryfall.io/normal/front/a/0/a0df01d1-6131-4ef7-abea-ba084f3b0954.jpg?1783920938,Creature — Tyranid,Games Workshop
+Geology Enthusiast,5,2022,0.32,#341aff,https://cards.scryfall.io/normal/front/d/b/dbb1f21c-60fa-4fcc-844b-25bf5b47fd1f.jpg?1783919995,Creature — Human Artificer,Fajareka Setiawan
+Geralf's Masterpiece,5,2016,0.31,#341aff,https://cards.scryfall.io/normal/front/f/0/f00d28b8-2ed8-4266-a870-d308f9ebd5da.jpg?1783937797,Creature — Zombie Horror,Daarken
+Geralf's Mindcrusher,6,2012,0.29,#341aff,https://cards.scryfall.io/normal/front/6/8/68ac8b5f-4d95-43fc-bf23-10247986a746.jpg?1783940843,Creature — Zombie Horror,Steven Belledin
+Geralf- the Fleshwright,3,2024,1.16,#341aff,https://cards.scryfall.io/normal/front/a/f/afe3b678-b340-4c53-bbf6-19252a809d73.jpg?1783911846,Legendary Creature — Human Warlock,Chris Rahn
+Geralf- Visionary Stitcher,3,2021,1.05,#341aff,https://cards.scryfall.io/normal/front/6/9/69890076-9cc4-434f-8618-63b00fdf4515.jpg?1783924892,Legendary Creature — Human Wizard,Bryan Sola
+Ghostly Flicker,3,2025,5.2,#341aff,https://cards.scryfall.io/normal/front/f/5/f5adfbfd-11e8-43e0-997e-e83d9fcc674d.jpg?1783905127,Instant,Dominik Mayer
+Ghostly Pilferer,2,2024,3.37,#341aff,https://cards.scryfall.io/normal/front/2/f/2f6a3605-950d-488b-8e4f-e2c339ef48dc.jpg?1783911942,Creature — Spirit Rogue,Craig J Spearing
+Gifts Ungiven,4,2022,4.9,#341aff,https://cards.scryfall.io/normal/front/c/c/cc950b6c-0346-4939-b36b-9f10a75f7a32.jpg?1783921916,Instant,Chris Rallis
+Gigantoplasm,4,2015,0.62,#341aff,https://cards.scryfall.io/normal/front/2/7/27163b43-61e2-495c-b544-55c349eba99c.jpg?1783938115,Creature — Shapeshifter,Kev Walker
+Gilded Drake,2,1998,196.06,#341aff,https://cards.scryfall.io/normal/front/8/d/8de3fdae-cc2c-4a14-b15b-4fe1a983dfbf.jpg?1783946361,Creature — Drake,Bob Eggleton
+Gitaxian Probe,1,2025,17.76,#341aff,https://cards.scryfall.io/normal/front/1/f/1fbb4493-23db-4c91-a3e0-17b139f5d00f.jpg?1783906078,Sorcery,Pedro Correa
+Glamerdye,2,2008,2.27,#341aff,https://cards.scryfall.io/normal/front/8/2/829a0a1c-761f-4a7f-b59a-c889d995f446.jpg?1783942691,Instant,Ralph Horsley
+Glasspool Mimic // Glasspool Shore,3,2020,6.39,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Shapeshifter Rogue // Land,Johan Grenier
+Glen Elendra Archmage,4,2018,10.82,#341aff,https://cards.scryfall.io/normal/front/b/d/bd9af767-42da-46c7-a2b8-3957b2e3063f.jpg?1783933842,Creature — Faerie Wizard,Karl Kopinski
+Glen Elendra Guardian,3,2026,0.42,#341aff,https://cards.scryfall.io/normal/front/3/8/388d2e4a-0aa5-4b82-a86c-4777ca60161c.jpg?1783904491,Creature — Faerie Wizard,Yohann Schepacz
+Glen Elendra's Answer,4,2026,1.11,#341aff,https://cards.scryfall.io/normal/front/f/a/fa5bfbf9-dca2-42b7-a431-f9afedb54528.jpg?1783904490,Instant,Sam Guay
+Glint Raker,4,2022,0.17,#341aff,https://cards.scryfall.io/normal/front/7/5/7520ee10-3ed1-40eb-86a0-3e463a5fba76.jpg?1783919721,Creature — Drake,Lars Grant-West
+Glitch Interpreter,3,2024,0.26,#341aff,https://cards.scryfall.io/normal/front/d/6/d68b8dff-32b0-4e96-82f0-4d4ceb92861d.jpg?1783909661,Creature — Human Wizard,Miguel Mercado
+Glorious Purpose,2,2026,0.27,#341aff,https://cards.scryfall.io/normal/front/d/7/d78f2105-030f-4951-aa02-0d4db3d34f59.jpg?1783903293,Enchantment — Plan,Fariba Khamseh
+Glyph Keeper,5,2017,0.23,#341aff,https://cards.scryfall.io/normal/front/a/2/a2663738-1688-4306-be6d-6a1f94a2319c.jpg?1783936521,Creature — Sphinx,Chris Rahn
+God-Eternal Kefnet,4,2019,3.83,#341aff,https://cards.scryfall.io/normal/front/5/e/5e14060f-9167-4e28-a053-77689e066e30.jpg?1783933465,Legendary Creature — Zombie God,Lius Lasahido
+Gogo- Master of Mimicry,3,2025,3.51,#341aff,https://cards.scryfall.io/normal/front/c/c/cce4eb99-d960-4ab7-911a-bb4ea74d1775.jpg?1783906636,Legendary Creature — Wizard,Thea Dumitriu
+Goldberry- River-Daughter,2,2023,0.79,#341aff,https://cards.scryfall.io/normal/front/b/f/bf4f0a7c-620e-4ed8-8da3-fa6564e8a0cd.jpg?1783916317,Legendary Creature — Nymph,Marie Magny
+Goliath Sphinx,7,2010,0.28,#341aff,https://cards.scryfall.io/normal/front/8/6/864a792b-ad04-4892-92d9-0f6abe3759e8.jpg?1783942063,Creature — Sphinx,Greg Staples
+Govern the Guildless,6,2006,0.26,#341aff,https://cards.scryfall.io/normal/front/2/3/23106341-9200-4eee-93d0-d6173b0b39c4.jpg?1783943438,Sorcery,Alex Horley-Orlandelli
+Grafted Identity,4,2021,0.19,#341aff,https://cards.scryfall.io/normal/front/2/5/2559846b-03d6-4a2c-97e1-c71f107e9f24.jpg?1783925642,Enchantment — Aura,Manuel Castañón
+Grand Architect,3,2020,0.91,#341aff,https://cards.scryfall.io/normal/front/1/4/14ce909d-a53e-4711-a9fd-b110433d460f.jpg?1783930197,Creature — Vedalken Artificer,Steven Belledin
+Gran-Gran,1,2025,0.64,#341aff,https://cards.scryfall.io/normal/front/6/f/6fc7d4ed-9e30-4daa-997d-6916c916c5fd.jpg?1783905119,Legendary Creature — Human Peasant Ally,Mizutametori
+Grasping Current,5,2017,0.11,#341aff,https://cards.scryfall.io/normal/front/e/7/e7344ffb-aada-4be1-bc82-2ed96e6cb5bf.jpg?1783935685,Sorcery,Yongjae Choi
+Graven Lore,5,2021,0.29,#341aff,https://cards.scryfall.io/normal/front/e/4/e4386e5c-32b1-4096-a93f-fedd1a4801fc.jpg?1783928262,Snow Instant,Svetlin Velinov
+Graveyard Busybody,6,2017,0.29,#341aff,https://cards.scryfall.io/normal/front/b/9/b913bbbd-a4c5-4e90-98ff-74be2c907d87.jpg?1783935448,Creature — Human Spy,Bram Sels
+Gravitational Shift,5,2010,1.59,#341aff,https://cards.scryfall.io/normal/front/b/a/bad32b9f-0aa4-4036-90e6-c087cffd52e7.jpg?1783941996,Enchantment,Svetlin Velinov
+Grazilaxx- Illithid Scholar,3,2022,2.45,#341aff,https://cards.scryfall.io/normal/front/3/d/3de11222-c2fa-4544-a501-a02b31797259.jpg?1783922472,Legendary Creature — Horror,Alexander Mokhov
+Greater Morphling,8,2004,1.26,#341aff,https://cards.scryfall.io/normal/front/d/5/d5ec1ebe-805d-41f5-a131-cc4113ffab44.jpg?1783944258,Creature — Shapeshifter,Greg “Six-Pack” Staples
+Great Whale,7,1998,24.83,#341aff,https://cards.scryfall.io/normal/front/5/8/58a2acf1-dad8-4f93-a34e-891e5178a48f.jpg?1783946360,Creature — Whale,Bob Eggleton
+Grell Philosopher,3,2022,0.67,#341aff,https://cards.scryfall.io/normal/front/e/1/e18bb373-a0bb-4e3c-b7db-83f747820fcd.jpg?1783922509,Creature — Horror Wizard,David Astruga
+Grimoire Thief,2,2008,0.65,#341aff,https://cards.scryfall.io/normal/front/5/9/59c4dceb-6889-4a79-87c2-98952f3478bb.jpg?1783942799,Creature — Merfolk Rogue,Randy Gallegos
+Grozoth,9,2005,3.42,#341aff,https://cards.scryfall.io/normal/front/9/6/96d81c13-93de-4cf6-bb15-d387ed259c50.jpg?1783943685,Creature — Leviathan,Cyril Van Der Haegen
+Guardian of Tazeem,5,2015,0.27,#341aff,https://cards.scryfall.io/normal/front/5/b/5b55cf5e-4499-4e3a-9748-7b1568286b5a.jpg?1783938208,Creature — Sphinx,Zack Stella
+Guile,6,2015,0.83,#341aff,https://cards.scryfall.io/normal/front/b/9/b9021f91-0b92-44ff-9ccb-bcf1e81232c2.jpg?1783938420,Creature — Elemental Incarnation,Zoltan Boros & Gabor Szikszai
+Hakim- Loreweaver,5,1996,0.64,#341aff,https://cards.scryfall.io/normal/front/8/1/8192bca7-03e5-4ea1-ae77-8bc811c19417.jpg?1783947109,Legendary Creature — Human Wizard,Alan Rabinowitz
+Haldan- Avid Arcanist,3,2020,0.84,#341aff,https://cards.scryfall.io/normal/front/1/6/16a86a35-f7e5-434d-bf44-61ae7cb0f98b.jpg?1783931237,Legendary Creature — Human Wizard,Manuel Castañón
+Hammerhead Tyrant,6,2025,0.33,#341aff,https://cards.scryfall.io/normal/front/8/7/87d4d694-c80e-435a-ba1b-f2f1949f91fc.jpg?1783907181,Creature — Dragon,Xavier Ribeiro
+Harbinger of the Seas,3,2024,1.81,#341aff,https://cards.scryfall.io/normal/front/0/0/00212714-a410-4cbc-bf1c-f90d7d77378c.jpg?1783911289,Creature — Merfolk Wizard,Winona Nelson
+Harbinger of the Tides,2,2024,0.18,#341aff,https://cards.scryfall.io/normal/front/9/c/9ca4f70d-ec17-49a4-8968-598ecdbe8243.jpg?1783908933,Creature — Merfolk Wizard,Svetlin Velinov
+Harmonized Crescendo,6,2026,0.95,#341aff,https://cards.scryfall.io/normal/front/2/7/2715e0c0-9913-4bea-9a42-ad1164f6130a.jpg?1783904488,Instant,Tyler Walpole
+Harmonized Trio // Brainstorm,1,2026,0.86,#341aff,https://cards.scryfall.io/normal/front/6/1/617208ff-dd9b-44fd-a740-d3188081e5cc.jpg?1783903691,Creature — Merfolk Bard Wizard // Instant,Marie Magny
+Hatching Plans,2,2006,0.39,#341aff,https://cards.scryfall.io/normal/front/e/f/ef327629-9831-4a0c-bd61-7542b0713ea8.jpg?1783943522,Enchantment,Heather Hudson
+Haughty Djinn,3,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/8/c/8cabaf8a-5e19-4f26-be2b-7627b9c8e324.jpg?1783907104,Creature — Djinn,Mike Jordana
+Haunting Imitation,3,2021,0.26,#341aff,https://cards.scryfall.io/normal/front/8/4/8418fd80-2c92-40d4-87de-0c149f6815bc.jpg?1783925003,Sorcery,Liiga Smilshkalne
+Havengul Runebinder,4,2021,0.21,#341aff,https://cards.scryfall.io/normal/front/c/b/cbd27e6f-24e5-4e90-9612-27d8dcd29325.jpg?1783925344,Creature — Human Wizard,Bud Cook
+Hedron Alignment,3,2016,0.12,#341aff,https://cards.scryfall.io/normal/front/7/b/7b3ec511-1b78-46e9-8ec2-fc09abd1b434.jpg?1783937918,Enchantment,Craig J Spearing
+Hedron Crab,1,2025,21.8,#341aff,https://cards.scryfall.io/normal/front/e/a/eaa1db45-6e3a-4941-b55e-7a91a60ea1b6.jpg?1783907470,Creature — Crab,Rian Gonzales
+Heidar- Rimewind Master,5,2006,0.44,#341aff,https://cards.scryfall.io/normal/front/3/9/39916d65-60a6-4da6-8675-8a8ef9505772.jpg?1783943359,Legendary Creature — Human Wizard,Ron Spears
+Heightened Awareness,5,2000,0.27,#341aff,https://cards.scryfall.io/normal/front/2/7/2765be4f-23bf-49c1-9546-11a7916156be.jpg?1783945791,Enchantment,Pete Venters
+Helmut Zemo- Mastermind,3,2026,0.29,#341aff,https://cards.scryfall.io/normal/front/5/4/545f7f8d-f6a3-4e85-a53c-3eb9b28ebd14.jpg?1783903292,Legendary Creature — Human Noble Villain,Bartek Fedyczak
+Herald of Hoofbeats,4,2023,6.07,#341aff,https://cards.scryfall.io/normal/front/7/b/7beebc99-b027-49e2-95ad-e51ce302457f.jpg?1783917288,Creature — Human Knight,Randy Vargas
+Herald of Secret Streams,4,2023,9.29,#341aff,https://cards.scryfall.io/normal/front/e/6/e6e1f2ab-e437-444e-9edb-73278d9c7616.jpg?1783913886,Creature — Merfolk Warrior,Sara Winters
+Here Comes a New Hero!,3,2026,0.35,#341aff,https://cards.scryfall.io/normal/front/0/9/096a07e2-c213-4f8a-852f-813435bf1655.jpg?1783904174,Sorcery,Leonardo Santanna
+Hermes- Overseer of Elpis,4,2025,0.35,#341aff,https://cards.scryfall.io/normal/front/e/0/e04a05e5-7bff-46a4-aae1-6713977e6e30.jpg?1783906363,Legendary Creature — Elder Wizard,Darius Zablockis
+Hide on the Ceiling,1,2025,1.21,#341aff,https://cards.scryfall.io/normal/front/7/9/7977e448-01fa-4fa5-a275-0d6a1357b35c.jpg?1783905354,Instant,Fariba Khamseh
+High Fae Trickster,4,2024,4.39,#341aff,https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg?1783909118,Creature — Faerie Wizard,Justyna Dura
+High Tide,1,2013,15.5,#341aff,https://cards.scryfall.io/normal/front/e/4/e4bfe5d1-0914-4c0b-b851-598d0850dc01.jpg?1783939698,Instant,Eric Deschamps
+Higure- the Still Wind,5,2016,15.96,#341aff,https://cards.scryfall.io/normal/front/f/7/f7b96d12-6309-48d1-bbdc-7bc88f4e2518.jpg?1783936841,Legendary Creature — Human Ninja,Christopher Moeller
+Hinder,3,2006,3.62,#341aff,https://cards.scryfall.io/normal/front/6/7/679d6226-7ec1-44f3-ac90-30b123501aa0.jpg?1783943567,Instant,Anthony S. Waters
+Hisoka- Minamo Sensei,4,2004,0.39,#341aff,https://cards.scryfall.io/normal/front/a/8/a87aea05-5970-455e-a728-668cf23940a6.jpg?1783944327,Legendary Creature — Human Wizard,Donato Giancola
+Hive Mind,6,2009,9.89,#341aff,https://cards.scryfall.io/normal/front/8/8/88d50518-5cfc-45de-a125-acabf97b8743.jpg?1783942393,Enchantment,Steve Argyle
+Homarid Shaman,4,1994,0.79,#341aff,https://cards.scryfall.io/normal/front/c/1/c17c6416-86d6-46ea-aea1-41b98a66b250.jpg?1783947911,Creature — Homarid Shaman,Amy Weber
+Homunculus Horde,4,2024,0.79,#341aff,https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg?1783909117,Creature — Homunculus,Adrián Rodríguez Pérez
+Hordewing Skaab,5,2021,6.04,#341aff,https://cards.scryfall.io/normal/front/6/e/6e67802e-e0d9-4989-b1c2-77ef2ff69796.jpg?1783925379,Creature — Zombie Horror,Sidharth Chaturvedi
+Horned Loch-Whale // Lagoon Breach,6,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1783915120,Creature — Whale // Instant — Adventure,Simon Dominic
+Hour of Eternity,3,2021,0.3,#341aff,https://cards.scryfall.io/normal/front/c/a/ca15361f-6bf7-46e7-b83c-308c55fc393f.jpg?1783925343,Sorcery,Tyler Jacobson
+Hoverguard Sweepers,8,2014,0.28,#341aff,https://cards.scryfall.io/normal/front/0/e/0e2ec92b-dab0-4c9e-af7d-0041b22e852f.jpg?1783938850,Creature — Drone,Mark A. Nelson
+How Is This a Par Three?!,4,2022,0.13,#341aff,https://cards.scryfall.io/normal/front/c/4/c49e47aa-563d-4501-bbb3-2442b4ca037d.jpg?1783920594,Enchantment,Mike Burns
+Hraesvelgr of the First Brood,5,2025,0.26,#341aff,https://cards.scryfall.io/normal/front/a/b/abcfefe3-c66d-4512-bcc3-c9a39cfbb983.jpg?1783906362,Legendary Creature — Elder Dragon,Néstor Ossandón Leal
+Hullbreacher,3,2020,1.75,#341aff,https://cards.scryfall.io/normal/front/4/d/4df8aabc-7fcb-4b7b-980b-18f499e6c170.jpg?1783928862,Creature — Merfolk Pirate,Sidharth Chaturvedi
+Hullbreaker Horror,7,2025,6.31,#341aff,https://cards.scryfall.io/normal/front/1/3/137acb70-a1fd-4ea9-a5d9-f4b438eb5e82.jpg?1783908162,Creature — Kraken Horror,Svetlin Velinov
+Hunted by The Family,7,2023,0.3,#341aff,https://cards.scryfall.io/normal/front/0/4/04b0a2a9-ba95-4330-a8ab-9cb530eb4257.jpg?1783914670,Sorcery,Darren Tan
+Hunted Phantasm,3,2005,4.02,#341aff,https://cards.scryfall.io/normal/front/f/a/faec8ab3-80c6-4b8f-a60d-50cc683e66b4.jpg?1783943684,Creature — Spirit,Justin Sweet
+Hurkyl- Master Wizard,3,2022,0.26,#341aff,https://cards.scryfall.io/normal/front/5/f/5fcee066-425f-4341-bde5-13a5bdf06f2a.jpg?1783920111,Legendary Creature — Human Wizard Advisor,Randy Vargas
+Hurkyl's Final Meditation,7,2022,0.11,#341aff,https://cards.scryfall.io/normal/front/5/5/5577f345-9577-42f8-b244-089b9a7c2e56.jpg?1783920110,Instant,Nephelomancer
+Hurkyl's Recall,2,2015,1.75,#341aff,https://cards.scryfall.io/normal/front/7/3/73edeaaa-6a87-4cf1-b013-bab9a7bb94d9.jpg?1783938420,Instant,Ralph Horsley
+Hydro-Man- Fluid Felon,2,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/e/5/e53115a4-8959-40fa-b763-931504a1c5a2.jpg?1783905353,Legendary Creature — Elemental Villain,Borja Pindado
+Hypnotic Siren,1,2014,0.31,#341aff,https://cards.scryfall.io/normal/front/3/b/3b2f562f-00d1-41da-a6ac-bc019cce7fe7.jpg?1783939446,Enchantment Creature — Siren,James Ryman
+Icebreaker Kraken,12,2021,0.36,#341aff,https://cards.scryfall.io/normal/front/f/1/f1fdb9bb-09a2-4ff7-bcd4-35ea33c1b752.jpg?1783928261,Snow Creature — Kraken,Chris Cold
+Ice Cave,5,2001,0.8,#341aff,https://cards.scryfall.io/normal/front/f/c/fc2877c2-4426-4c07-92a2-8ba5107d5e7e.jpg?1783945353,Enchantment,Jerry Tiritilli
+Icefall Regent,5,2017,0.56,#341aff,https://cards.scryfall.io/normal/front/b/2/b2dc9693-3c27-4afe-84f3-2618a0e4ca1c.jpg?1783936160,Creature — Dragon,David Gaillet
+Ice Out,3,2023,0.62,#341aff,https://cards.scryfall.io/normal/front/4/a/4af9f237-f338-4335-843b-d352c01b73e5.jpg?1783915138,Instant,Takuma Ebisu
+Ichormoon Gauntlet,3,2023,5.1,#341aff,https://cards.scryfall.io/normal/front/2/c/2c093ce0-2561-4847-ab58-f6f1650d743e.jpg?1783918062,Artifact,Tiffany Turrill
+Icy Blast,1,2014,1.4,#341aff,https://cards.scryfall.io/normal/front/b/0/b098f029-6b5d-49e4-9a81-f497ebbdb5ce.jpg?1783939087,Instant,Eric Deschamps
+Icy Prison,2,1995,0.4,#341aff,https://cards.scryfall.io/normal/front/3/9/39a7e496-8d2e-49db-b298-475d9017537a.jpg?1783947515,Enchantment,Anson Maddocks
+Identity Thief,4,2022,0.24,#341aff,https://cards.scryfall.io/normal/front/a/3/a32e1511-2495-454a-9a04-4f3c0d9a75d0.jpg?1783923281,Creature — Shapeshifter,Magali Villeneuve
+Illithid Harvester // Plant Tadpoles,5,2022,0.34,#341aff,https://cards.scryfall.io/normal/front/d/f/df9573a3-d013-4631-98ed-78418bf0bc78.jpg?1783922787,Creature — Horror // Sorcery — Adventure,David Astruga
+Illusionary Presence,3,1995,0.66,#341aff,https://cards.scryfall.io/normal/front/a/a/aa31efed-4a11-4f59-a623-bac45d20091d.jpg?1783947514,Creature — Illusion,Kaja Foglio
+Illusionist's Gambit,4,2013,0.44,#341aff,https://cards.scryfall.io/normal/front/a/0/a00cc6ab-e97c-4eba-bc7e-49d77690433b.jpg?1783939682,Instant,Zoltan Boros
+Illusory Gains,5,2015,0.2,#341aff,https://cards.scryfall.io/normal/front/7/4/747dfb21-a00c-46ba-9da3-739f570e1246.jpg?1783938607,Enchantment — Aura,Kev Walker
+Imaginary Pet,2,2005,0.45,#341aff,https://cards.scryfall.io/normal/front/4/3/432d8827-e46d-4c0d-bde3-305594f20f19.jpg?1783944048,Creature — Illusion,Christopher Rush
+Immortus- Master of Eternity,4,2026,8.32,#341aff,https://cards.scryfall.io/normal/front/c/8/c8bd16f1-f8f2-44d2-a737-40f08a4cff3f.jpg?1783903073,Legendary Creature — Human Hero Villain,Chris Rallis
+Imperious Mindbreaker,3,2021,0.36,#341aff,https://cards.scryfall.io/normal/front/9/5/95a9e722-d7a3-4a19-afd6-6c617aaf8eda.jpg?1783924996,Creature — Human Wizard,Olivier Bernard
+Imposter Mech,2,2022,6.62,#341aff,https://cards.scryfall.io/normal/front/5/9/59b7450c-3163-4f12-9af1-2e998a6c36cf.jpg?1783923994,Artifact — Vehicle,Andrew Mar
+Impostor Syndrome,6,2025,7.2,#341aff,https://cards.scryfall.io/normal/front/0/8/08da9f92-0e25-4f39-aaa4-d8974af81a41.jpg?1783905354,Enchantment,Javier Charro
+Imprisoned in the Moon,3,2023,0.38,#341aff,https://cards.scryfall.io/normal/front/8/1/8181f54d-4515-43c6-8d08-b23a9e4199cc.jpg?1783917170,Enchantment — Aura,Ryan Alexander Lee
+Incite Insight,2,2017,0.19,#341aff,https://cards.scryfall.io/normal/front/b/a/ba905b6e-9568-4aa6-a281-248c79af87ec.jpg?1783935448,Sorcery,David Sladek
+Increasing Confusion,1,2012,0.85,#341aff,https://cards.scryfall.io/normal/front/1/3/13f5bcdc-70bb-4d67-99e1-282f166ee4bf.jpg?1783940839,Sorcery,Dan Murayama Scott
+Induced Amnesia,3,2018,0.24,#341aff,https://cards.scryfall.io/normal/front/a/4/a4ee56f1-9f08-459f-8517-0fe7bc645fa3.jpg?1783935325,Enchantment,Chris Rallis
+Inevitable Betrayal,0,2021,1.42,#341aff,https://cards.scryfall.io/normal/front/7/1/71725895-38cd-4017-bbf0-0b7dc9b5db60.jpg?1783926877,Sorcery,Franz Vohwinkel
+Inexorable Tide,5,2015,3.78,#341aff,https://cards.scryfall.io/normal/front/4/0/40441345-23ca-47e4-b349-bd13d986e41e.jpg?1783938420,Enchantment,Dave Kendall
+Infinite Reflection,6,2014,0.24,#341aff,https://cards.scryfall.io/normal/front/b/b/bb6c9287-7af5-4741-9555-c256b82c5b76.jpg?1783938850,Enchantment — Aura,Igor Kieryluk
+Ingenious Mastery,3,2021,0.25,#341aff,https://cards.scryfall.io/normal/front/2/3/2386d020-a9ae-4d54-b5e4-f2cb5a7298cc.jpg?1783927380,Sorcery,Cristi Balanescu
+Ingenious Prodigy,1,2026,0.32,#341aff,https://cards.scryfall.io/normal/front/8/d/8d242dc2-5117-4bd6-a0c9-813d36d01e11.jpg?1783903822,Creature — Human Wizard,Kim Sokol
+Inkwell Leviathan,9,2020,0.72,#341aff,https://cards.scryfall.io/normal/front/9/f/9f7a6dfb-a8f8-4899-b2db-c48d542dfd55.jpg?1783930197,Artifact Creature — Leviathan,Anthony Francisco
+Inniaz- the Gale Force,5,2020,0.26,#d78f42,https://cards.scryfall.io/normal/front/b/2/b238485f-ef67-4295-892b-a10235368f74.jpg?1783930506,Legendary Creature — Djinn,Livia Prima
+Inscription of Insight,4,2020,0.21,#341aff,https://cards.scryfall.io/normal/front/2/8/281cdb1c-21ae-4430-8e0f-c993f52ba891.jpg?1783929397,Sorcery,Zoltan Boros
+Insidious Will,4,2016,0.45,#341aff,https://cards.scryfall.io/normal/front/8/e/8eafb2bb-58bf-4c6b-ae8f-91bcea12c7d2.jpg?1783937218,Instant,Anthony Palumbo
+Insight Engine,3,2025,0.98,#341aff,https://cards.scryfall.io/normal/front/b/8/b826de8b-ed21-4e2b-b99a-e860c1cb876b.jpg?1783906067,Artifact,Gaboleps
+Inspired Idea,3,2021,0.13,#341aff,https://cards.scryfall.io/normal/front/2/f/2fe4ee8e-579d-4bfa-8c19-bfdb1c0b7177.jpg?1783924891,Sorcery,Alix Branwyn
+Inspired Sphinx,7,2021,0.3,#341aff,https://cards.scryfall.io/normal/front/7/f/7f58d798-9b99-45a9-9015-f689145018a8.jpg?1783928324,Creature — Sphinx,Jesper Ejsing
+Inspiring Refrain,6,2021,0.39,#341aff,https://cards.scryfall.io/normal/front/a/6/a66076f9-c1b0-4718-8609-3e2efe6114ab.jpg?1783927604,Sorcery,Izzy
+Intellectual Offering,5,2014,0.32,#341aff,https://cards.scryfall.io/normal/front/6/3/63de9e39-3c16-452f-9f06-4c1298752f57.jpg?1783938871,Instant,Mark Winters
+Interdisciplinary Mascot,8,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg?1783916905,Creature — Elemental Fractal,Mathias Kollros
+In Too Deep,2,2022,0.45,#341aff,https://cards.scryfall.io/normal/front/7/4/74654ccb-c81c-4677-8c3d-cc5857ef0732.jpg?1783923373,Enchantment — Aura,José Parodi
+Into the Flood Maw,1,2026,3.18,#341aff,https://cards.scryfall.io/normal/front/e/4/e412870c-62bc-4ab7-a3e3-755b6228fa0a.jpg?1783903934,Instant,Danny Schwartz
+Intrude on the Mind,5,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg?1783912908,Instant,Magali Villeneuve
+Intruder Alarm,3,2003,4.7,#341aff,https://cards.scryfall.io/normal/front/8/d/8d62468e-ed9d-4932-bbbd-103b33b98b25.jpg?1783944797,Enchantment,Luca Zontini
+Inundate,6,2008,12.35,#341aff,https://cards.scryfall.io/normal/front/d/5/d5047c92-2885-4a7b-b51f-f3e093dca5ad.jpg?1783942690,Sorcery,Mark Zug
+Invasion of Arcavios // Invocation of the Founders,5,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Enchantment,Dmitry Burmak
+Invasion of Segovia // Caetus- Sea Tyrant of Segovia,3,2023,1.01,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Legendary Creature — Serpent,Edgar Sánchez Hidalgo
+Inventive Iteration // Living Breakthrough,4,2022,0.31,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Moonfolk,Néstor Ossandón Leal
+Invoke the Winds,5,2022,0.27,#341aff,https://cards.scryfall.io/normal/front/a/d/ad7b423a-bfd1-47aa-bd2c-64a169b96924.jpg?1783923902,Sorcery,Olivier Bernard
+Irma- Part-Time Mutant,3,2026,4.01,#341aff,https://cards.scryfall.io/normal/front/c/3/c3128529-4ccd-4809-8388-03f7faa0eabe.jpg?1783904172,Legendary Creature — Human Mutant Shapeshifter,Mirko Failoni
+Ironheart- Clever Champion,5,2026,0.36,#341aff,https://cards.scryfall.io/normal/front/3/9/395e477a-861f-4661-b329-6c1ad5343ed5.jpg?1783902957,Legendary Artifact Creature — Human Hero,Julia Vasilyeva
+Iron Man- Armored Avenger,4,2026,3.83,#341aff,https://cards.scryfall.io/normal/front/9/4/94af0633-59c6-4893-ab44-232d37573dde.jpg?1783903295,Legendary Artifact Creature — Human Hero,Carlos Dattoli
+Iron Man- Bleeding Edge,5,2026,9.17,#341aff,https://cards.scryfall.io/normal/front/b/1/b14b6721-6491-41a4-afb4-93bd76f21173.jpg?1783903072,Legendary Artifact Creature — Human Hero,Ryan Pancoast
+Iron Man- Futurist Paragon,6,2026,3.29,#341aff,https://cards.scryfall.io/normal/front/2/6/266a56d7-c310-4a91-9d1f-a6d55aa17f43.jpg?1783903114,Legendary Artifact Creature — Human Hero,Thanh Tuấn
+Iron Man- Modern Marvel,4,2026,39.85,#341aff,https://cards.scryfall.io/normal/front/3/2/32df31b8-21cd-4872-a775-2144074e6a73.jpg?1783903000,Legendary Artifact Creature — Human Hero,Milivoj Ćeran
+Island Fish Jasconius,7,1995,0.33,#341aff,https://cards.scryfall.io/normal/front/8/4/84f18188-70fa-433e-a114-2f1dd49388ed.jpg?1783947858,Creature — Fish,Jesper Myrfors
+Isleback Spawn,7,2008,0.49,#341aff,https://cards.scryfall.io/normal/front/e/7/e769b1b2-c2a9-4db1-bf1f-01863aa2cd0b.jpg?1783942760,Creature — Kraken,Mark Tedin
+Isu the Abominable,5,2022,4.78,#d78f42,https://cards.scryfall.io/normal/front/1/e/1e1d50c3-3219-49cb-8f63-c1faff93215c.jpg?1783919194,Legendary Snow Creature — Yeti,Victor Adame Minguez
+Ixidor- Reality Sculptor,5,2002,2.16,#341aff,https://cards.scryfall.io/normal/front/3/1/314d5e89-55f7-42b4-af19-d4d0f499a265.jpg?1783945082,Legendary Creature — Human Wizard,Kev Walker
+Ixidron,5,2019,0.36,#341aff,https://cards.scryfall.io/normal/front/c/3/c30ec372-5cf7-471c-b3fd-411095fc249a.jpg?1783932779,Creature — Illusion,Antonio José Manzanedo
+Iymrith- Desert Doom,5,2021,1.5,#341aff,https://cards.scryfall.io/normal/front/c/3/c3e6025d-d273-4ae4-9929-5e588612f1b3.jpg?1783926511,Legendary Creature — Dragon,Wisnu Tan
+Jace- Architect of Thought,4,2023,0.39,#341aff,https://cards.scryfall.io/normal/front/7/0/7051cdfa-509e-4d84-bbae-f77556c861e4.jpg?1783915441,Legendary Planeswalker — Jace,Jaime Jones
+Jace Beleren,3,2023,1.85,#341aff,https://cards.scryfall.io/normal/front/8/0/806d4e61-004f-4e52-b2e8-ba11b922cc7d.jpg?1783915442,Legendary Planeswalker — Jace,Aleksi Briclot
+Jace- Cunning Castaway,3,2017,0.89,#341aff,https://cards.scryfall.io/normal/front/b/7/b75f56f2-88fd-44ba-ad02-56ea3391f173.jpg?1783935780,Legendary Planeswalker — Jace,Kieran Yanner
+Jace- Memory Adept,5,2013,2.92,#341aff,https://cards.scryfall.io/normal/front/2/8/2801a4ad-5d44-4414-af62-458c7f90dad6.jpg?1783939933,Legendary Planeswalker — Jace,D. Alexander Gregory
+Jace- Mirror Mage,3,2023,0.42,#341aff,https://cards.scryfall.io/normal/front/8/6/86d34cbf-e424-461a-adf3-003d556a7859.jpg?1783915440,Legendary Planeswalker — Jace,Tyler Jacobson
+Jace Reawakened,2,2024,0.7,#341aff,https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg?1783911774,Legendary Planeswalker — Jace,Cristi Balanescu
+Jace's Archivist,3,2015,9.6,#341aff,https://cards.scryfall.io/normal/front/3/c/3c21df8e-a24f-4ce1-aa8a-1467f9f9423a.jpg?1783938093,Creature — Vedalken Wizard,James Ryman
+Jace's Mindseeker,6,2014,0.39,#341aff,https://cards.scryfall.io/normal/front/a/e/aeec1661-43e9-4e64-8798-c9aebad421e6.jpg?1783939496,Creature — Fish Illusion,Greg Staples
+Jace's Ruse,5,2019,0.16,#341aff,https://cards.scryfall.io/normal/front/0/3/03e8d2c7-cd6e-48bf-9d54-73f3d6cff0aa.jpg?1783933359,Sorcery,Clint Cearley
+Jace's Sanctum,4,2019,1.24,#341aff,https://cards.scryfall.io/normal/front/8/1/8148adc6-7946-4abd-8601-b1f4cd6916c2.jpg?1783932779,Enchantment,Adam Paquette
+Jace- the Living Guildpact,4,2014,0.68,#341aff,https://cards.scryfall.io/normal/front/9/9/99713bb4-186f-42b6-aa66-e94ec8858e6a.jpg?1783939191,Legendary Planeswalker — Jace,Chase Stone
+Jace- the Mind Sculptor,4,2020,18.16,#341aff,https://cards.scryfall.io/normal/front/c/8/c8817585-0d32-4d56-9142-0d29512e86a9.jpg?1783930196,Legendary Planeswalker — Jace,Jason Chan
+Jace- the Perfected Mind,4,2023,2.06,#341aff,https://cards.scryfall.io/normal/front/6/4/64e6a8d1-ae75-45bd-af62-9a622620cb5c.jpg?1783918061,Legendary Planeswalker — Jace,Chase Stone
+Jace- Unraveler of Secrets,5,2025,1.78,#341aff,https://cards.scryfall.io/normal/front/3/d/3d9c8217-013d-4e75-bdd1-9c46c8467edb.jpg?1783908162,Legendary Planeswalker — Jace,Tyler Jacobson
+Jace- Vryn's Prodigy // Jace- Telepath Unbound,2,2015,4.46,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Wizard // Legendary Planeswalker — Jace,Jaime Jones
+Jace- Wielder of Mysteries,4,2019,9.2,#341aff,https://cards.scryfall.io/normal/front/6/a/6adb7d73-4482-4930-8497-cffd169b57e2.jpg?1783933463,Legendary Planeswalker — Jace,Anna Steinbauer
+Jacob Hauken- Inspector // Hauken's Insight,2,2021,0.46,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Advisor // Legendary Enchantment,Aurore Folny
+Jadzi- Oracle of Arcavios // Journey to the Oracle,8,2021,0.71,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Wizard // Sorcery,Chris Rahn
+Jadzi- Steward of Fate // Oracle's Gift,3,2026,0.21,#341aff,https://cards.scryfall.io/normal/front/a/9/a95b6baf-01e6-49c3-9a26-394b127d53c3.jpg?1783903689,Legendary Creature — Human Wizard // Sorcery,Martina Fačková
+Jalira- Master Polymorphist,4,2014,0.29,#341aff,https://cards.scryfall.io/normal/front/4/2/425da4aa-4374-41b0-a665-568a04f57c38.jpg?1783939191,Legendary Creature — Human Wizard,Steve Prescott
+James- Wandering Dad // Follow Him,3,2024,0.36,#341aff,https://cards.scryfall.io/normal/front/3/1/31fed516-04e1-4453-b955-dfbd32bab2f3.jpg?1783912413,Legendary Creature — Human Scientist // Instant — Adventure,Wonchun Choi
+Jarvis- Earth's Mightiest Butler,3,2026,0.27,#341aff,https://cards.scryfall.io/normal/front/6/2/62c31cd8-0c30-4cfb-89d6-2e4dac19f6ea.jpg?1783903292,Legendary Creature — Human Advisor,Gintas Galvanauskas
+Jason Bright- Glowing Prophet,3,2024,0.46,#341aff,https://cards.scryfall.io/normal/front/4/8/48313997-fd94-486a-bf30-e9143a155814.jpg?1783912413,Legendary Creature — Zombie Mutant Advisor,Tomas Duchek
+Jeskai Infiltrator,3,2018,0.16,#341aff,https://cards.scryfall.io/normal/front/4/e/4efcf6ba-e466-4947-94b2-725cc77b6e05.jpg?1783934309,Creature — Human Monk,Cynthia Sheppard
+Jetfire- Ingenious Scientist // Jetfire- Air Guardian,5,2022,0.95,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact Creature — Robot // Legendary Artifact — Vehicle,Volta Creation
+Jill- Shiva's Dominant // Shiva- Warden of Ice,3,2025,0.45,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Noble Warrior // Legendary Enchantment Creature — Saga Elemental,Arif Wijaya
+Jin-Gitaxias- Core Augur,10,2017,12.47,#341aff,https://cards.scryfall.io/normal/front/1/4/14a360b6-c7b4-4b25-8288-b3bb8d527bda.jpg?1783935545,Legendary Creature — Phyrexian Praetor,Eric Deschamps
+Jin-Gitaxias- Progress Tyrant,7,2022,9.77,#341aff,https://cards.scryfall.io/normal/front/c/5/c57b4876-5387-4f73-b8e2-8e7bdca8b0bc.jpg?1783923901,Legendary Creature — Phyrexian Praetor,Chase Stone
+Jin-Gitaxias // The Great Synthesis,5,2023,12.34,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Phyrexian Praetor // Enchantment — Saga,Ekaterina Burmak
+Johnny- Combo Player,4,2020,0.2,#341aff,https://cards.scryfall.io/normal/front/f/8/f8fc7a61-226c-426a-9b99-21d87aca2f6f.jpg?1783931343,Legendary Creature — Human Gamer,Kensuke Okabayashi
+Jokulmorder,7,2006,0.5,#341aff,https://cards.scryfall.io/normal/front/a/8/a8bd1c2f-dab8-4f22-9400-a0e45618757a.jpg?1783943358,Creature — Leviathan,Mark Zug
+Jushi Apprentice // Tomoya the Revealer,2,2004,0.35,#341aff,https://cards.scryfall.io/normal/front/3/3/33a8e5b9-6bfb-4ff2-a16d-3168a5412807.jpg?1783944325,Creature — Human Wizard // Legendary Creature — Human Wizard,Glen Angus
+Juxtapose,4,1999,0.46,#341aff,https://cards.scryfall.io/normal/front/2/b/2b1fb725-0daa-45f4-ad31-6a061fa4d20f.jpg?1783946198,Sorcery,Justin Hampton
+Jwari Shapeshifter,2,2010,3.73,#341aff,https://cards.scryfall.io/normal/front/5/8/587f91f6-b46e-4dd5-a86d-1048054dd3c0.jpg?1783942061,Creature — Shapeshifter Ally,Kev Walker
+K-9- Mark I,1,2023,3.02,#341aff,https://cards.scryfall.io/normal/front/b/2/b2e46695-7bd3-448c-a5ea-6d544943ec5f.jpg?1783914668,Legendary Artifact Creature — Robot Dog,Narendra Bintara Adi
+Kadena's Silencer,2,2019,0.33,#341aff,https://cards.scryfall.io/normal/front/c/f/cfe101fc-0c3d-461b-8c46-bb1bef97e739.jpg?1783932813,Creature — Snake Wizard,Torstein Nordstrand
+Kaho- Minamo Historian,4,2005,0.65,#341aff,https://cards.scryfall.io/normal/front/d/8/d85a5f54-9b79-4c3d-b983-021b4b01b122.jpg?1783944163,Legendary Creature — Human Wizard,Greg Staples
+Kairi- the Swirling Sky,6,2022,0.98,#341aff,https://cards.scryfall.io/normal/front/a/f/af7979d8-21f3-40ba-8a2e-7ebad210e48b.jpg?1783923901,Legendary Creature — Dragon Spirit,Tyler Jacobson
+Kaito- Cunning Infiltrator,3,2024,1.51,#341aff,https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg?1783909117,Legendary Planeswalker — Kaito,Evyn Fong
+Kami of the Crescent Moon,2,2021,8.22,#341aff,https://cards.scryfall.io/normal/front/d/d/dd420010-6eaf-4853-8b7b-11de1157416b.jpg?1783924965,Legendary Creature — Spirit,Darrell Riche
+Kang Dynasty,4,2026,0.38,#341aff,https://cards.scryfall.io/normal/front/5/e/5e4223df-c9fc-410a-913a-17bbfd054b57.jpg?1783903292,Enchantment — Saga,Serena Malyon
+Kang the Conqueror,4,2026,0.49,#341aff,https://cards.scryfall.io/normal/front/7/9/79747b45-fd7b-4023-9a9c-4d9dab2429fe.jpg?1783902956,Legendary Creature — Human Villain,Peter Scanlan
+Kappa Cannoneer,6,2025,0.44,#341aff,https://cards.scryfall.io/normal/front/9/9/99cd996f-be74-4dbb-9460-6d650cedfca6.jpg?1783906043,Artifact Creature — Turtle Warrior,Jesper Ejsing
+Karn's Temporal Sundering,6,2018,1.57,#341aff,https://cards.scryfall.io/normal/front/7/a/7a64c1a4-02ce-49d2-97f2-970b8c33672d.jpg?1783935025,Legendary Sorcery,Noah Bradley
+Karn's Touch,2,1999,0.4,#341aff,https://cards.scryfall.io/normal/front/0/7/07845861-f974-43b7-829c-79a4a41ac3e3.jpg?1783945964,Instant,Alan Pollack
+Katara's Reversal,4,2025,4.55,#341aff,https://cards.scryfall.io/normal/front/8/b/8ba06a79-d3b7-4705-9c5e-becaea1dd9e3.jpg?1783904839,Instant,Fahmi Fauzi
+Katara- Waterbending Master,2,2025,7.72,#341aff,https://cards.scryfall.io/normal/front/2/c/2c348122-37e0-443b-861d-ccf2837ce7a3.jpg?1783904828,Legendary Creature — Human Warrior Ally,Yueko
+Katsumasa- the Animator,4,2022,0.36,#341aff,https://cards.scryfall.io/normal/front/a/b/ab4b5ff5-fd6a-4948-9c54-440bf6324bd1.jpg?1783923994,Legendary Creature — Moonfolk Artificer,Heonhwa
+Kederekt Leviathan,8,2022,0.51,#341aff,https://cards.scryfall.io/normal/front/7/3/73cdb22d-90e6-49c4-9ad7-3249d9196ca9.jpg?1783921915,Creature — Leviathan,Mark Hyzer
+Keeper of Keys,5,2016,3.99,#341aff,https://cards.scryfall.io/normal/front/9/9/990b343b-70a6-46d0-abae-f5faae75816a.jpg?1783937358,Creature — Human Rogue Mutant,Bastien L. Deharme
+Keeper of the Nine Gales,3,2003,7.51,#341aff,https://cards.scryfall.io/normal/front/f/7/f75eef50-b474-44bb-8222-3e473928304a.jpg?1783944921,Creature — Bird Wizard,Jim Nelson
+Kefnet's Last Word,4,2017,0.25,#341aff,https://cards.scryfall.io/normal/front/4/d/4d7e5103-ee7d-40d7-bcd4-c5d1a48e9821.jpg?1783936051,Sorcery,Clint Cearley
+Kefnet the Mindful,3,2024,0.34,#341aff,https://cards.scryfall.io/normal/front/c/a/ca06ae1a-4080-450a-8ff0-ad6aafd8f04c.jpg?1783909627,Legendary Creature — God,Chase Stone
+Keiga- the Tide Star,6,2025,0.37,#341aff,https://cards.scryfall.io/normal/front/8/4/84d9c584-322f-49c9-9826-4838c6d2f36a.jpg?1783907103,Legendary Creature — Dragon Spirit,Ittoku
+Kenessos- Priest of Thassa,2,2022,7.59,#d78f42,https://cards.scryfall.io/normal/front/0/b/0ba97da8-0106-4e8b-b58b-8f2d63e3d618.jpg?1783919191,Legendary Creature — Merfolk Cleric,Joshua Raphael
+Kheru Spellsnatcher,4,2024,0.18,#341aff,https://cards.scryfall.io/normal/front/6/1/610f4f2b-e5ed-463b-9d9b-0f7b3f3e99c8.jpg?1783909626,Creature — Snake Wizard,Clint Cearley
+Kianne- Dean of Substance // Imbraham- Dean of Theory,3,2021,0.16,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elf Druid // Legendary Creature — Bird Wizard,Ryan Pancoast
+Kindred Discovery,5,2026,5.88,#341aff,https://cards.scryfall.io/normal/front/1/9/19bdedb2-768b-4adf-8193-917a10c8f729.jpg?1783903239,Enchantment,Stephanie Hans
+Kiora Bests the Sea God,7,2020,6.73,#341aff,https://cards.scryfall.io/normal/front/2/b/2b604451-4f6c-4cfa-8d3a-01f18d01d88f.jpg?1783931583,Enchantment — Saga,Victor Adame Minguez
+Kiora- the Rising Tide,3,2024,0.38,#341aff,https://cards.scryfall.io/normal/front/8/3/83f20a32-9f5d-4a68-8995-549e57554da2.jpg?1783909116,Legendary Creature — Merfolk Noble,Julian Kok Joon Wen
+Kira- Great Glass-Spinner,3,2020,4.93,#341aff,https://cards.scryfall.io/normal/front/4/3/437ded6e-4e53-49fa-a5ca-fd76b9165a47.jpg?1783930454,Legendary Creature — Spirit,Kev Walker
+Kitesail Larcenist,3,2023,0.53,#341aff,https://cards.scryfall.io/normal/front/0/3/03207457-70d8-4462-8c8b-ed39791d56a1.jpg?1783913794,Creature — Human Pirate,Sidharth Chaturvedi
+Kitnap,4,2024,0.26,#341aff,https://cards.scryfall.io/normal/front/0/8/085be5d1-fd85-46d1-ad39-a8aa75a06a96.jpg?1783910850,Enchantment — Aura,Irina Nordsol
+Kitsa- Otterball Elite,2,2024,3.8,#341aff,https://cards.scryfall.io/normal/front/c/8/c8ff751a-ec64-41d5-b22c-2a483ad9a9b2.jpg?1783910847,Legendary Creature — Otter Wizard,Zoltan Boros
+Kitsune- Dragon's Daughter,6,2026,0.25,#341aff,https://cards.scryfall.io/normal/front/a/8/a87a9257-4535-4286-8b59-a842ac45d05e.jpg?1783904117,Legendary Creature — Fox Warlock Avatar,Robin Har
+Kitsune's Technique,6,2026,1.49,#341aff,https://cards.scryfall.io/normal/front/9/c/9ca5327e-df90-483c-875f-73a23781f56d.jpg?1783904114,Instant,Rose Benjamin
+Knacksaw Clique,4,2008,2.69,#341aff,https://cards.scryfall.io/normal/front/2/2/22353590-f248-460e-a1a5-0b7431a4c82d.jpg?1783942760,Creature — Faerie Rogue,Steven Belledin
+Knowledge Exploitation,7,2008,7.61,#341aff,https://cards.scryfall.io/normal/front/3/d/3d283c49-2e81-4b2e-956a-69152cc4704e.jpg?1783942799,Kindred Sorcery — Rogue,Darrell Riche
+Kopala- Warden of Waves,3,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/0/b/0b018020-73e0-437c-a130-298b2f738c6f.jpg?1783913886,Legendary Creature — Merfolk Wizard,Magali Villeneuve
+Krang- Master Mind,8,2026,0.95,#341aff,https://cards.scryfall.io/normal/front/d/2/d27fa497-e842-4812-80fe-28517544e1c5.jpg?1783904114,Legendary Artifact Creature — Utrom Warrior,Narendra Bintara Adi
+Krang- the All-Powerful,5,2026,0.4,#341aff,https://cards.scryfall.io/normal/front/0/8/08a0ca58-e29e-477e-9377-f8b00e4b28a0.jpg?1783904172,Legendary Artifact Creature — Utrom Robot,Yuhong Ding
+Kukemssa Pirates,4,1996,1.88,#341aff,https://cards.scryfall.io/normal/front/d/1/d10b5ce7-16c9-48f3-a1da-8a91092d053a.jpg?1783947108,Creature — Human Pirate,Jock
+Kumena's Awakening,4,2018,0.36,#341aff,https://cards.scryfall.io/normal/front/3/a/3a86f499-a2d4-47f1-9fc1-b543e5ad5c82.jpg?1783935323,Enchantment,Zack Stella
+Laboratory Drudge,4,2020,0.23,#341aff,https://cards.scryfall.io/normal/front/b/6/b6a1d1e2-caea-4e64-8a3a-740f62b36853.jpg?1783928859,Creature — Zombie Horror,Milivoj Ćeran
+Laboratory Maniac,3,2011,2.2,#341aff,https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg?1783940974,Creature — Human Wizard,Jason Felix
+Lady Octopus- Inspired Inventor,1,2025,0.91,#341aff,https://cards.scryfall.io/normal/front/8/c/8c5f360b-f9a0-46e0-9e8b-58e5b4b0389e.jpg?1783905354,Legendary Creature — Human Scientist Villain,Fariba Khamseh
+Lady Sun,3,1999,94.43,#341aff,https://cards.scryfall.io/normal/front/0/f/0f45e837-7b98-46ef-b21b-e3508ce999e5.jpg?1783946122,Legendary Creature — Human Advisor,Miao Aili
+Last Word,4,2004,0.64,#341aff,https://cards.scryfall.io/normal/front/1/3/139d2ece-f656-4cac-8d77-b0f083f76c70.jpg?1783944450,Instant,Scott M. Fischer
+Leader- Super-Genius,4,2026,0.33,#341aff,https://cards.scryfall.io/normal/front/2/c/2c8aab8d-2dfe-49c8-9aa8-536b0587b467.jpg?1783902955,Legendary Creature — Gamma Scientist Villain,Anthony Devine
+Ledger Shredder,2,2022,8.65,#341aff,https://cards.scryfall.io/normal/front/7/e/7ea4b5bc-18a4-45db-a56a-ab3f8bd2fb0d.jpg?1783923147,Creature — Bird Advisor,Mila Pesic
+Leitmotif Composer,3,2026,0.19,#341aff,https://cards.scryfall.io/normal/front/2/5/2511b281-f822-427c-ac5f-d376b64fa6cf.jpg?1783903861,Creature — Human Bard,Nathaniel Himawan
+Leonardo da Vinci,3,2024,0.59,#341aff,https://cards.scryfall.io/normal/front/2/8/283d04a5-3639-42de-b940-ffa7e609e527.jpg?1783910982,Legendary Creature — Human Artificer,Wangjie Li
+Leviathan,9,1997,0.51,#341aff,https://cards.scryfall.io/normal/front/a/4/a4e96456-93bf-4d28-9a4b-5bc24ae07fc2.jpg?1783946946,Creature — Leviathan,Mark Tedin
+Leyline of Anticipation,4,2022,7.55,#341aff,https://cards.scryfall.io/normal/front/f/5/f57bdaa1-ce8a-4103-8598-fee751e65a53.jpg?1783922469,Enchantment,Charles Urbach
+Leyline of Singularity,4,2006,4.53,#341aff,https://cards.scryfall.io/normal/front/d/4/d40d7e5c-3b6d-4e42-b495-b3cd7ae0d808.jpg?1783943519,Enchantment,Zoltan Boros & Gabor Szikszai
+Leyline of Transformation,4,2024,0.48,#341aff,https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg?1783909492,Enchantment,Sergey Glushakov
+Library of Lat-Nam,5,1999,0.62,#341aff,https://cards.scryfall.io/normal/front/9/e/9ea40438-90ca-47ff-9805-df130d47ae48.jpg?1783946197,Sorcery,Alan Rabinowitz
+Lier- Disciple of the Drowned,5,2025,0.52,#341aff,https://cards.scryfall.io/normal/front/b/8/b8b70585-e0ea-4cb4-9360-a8ab47626696.jpg?1783907103,Legendary Creature — Human Wizard,Ekaterina Burmak
+Lighthouse Chronologist,2,2010,19.23,#341aff,https://cards.scryfall.io/normal/front/3/0/3087f7e7-9163-45b5-907d-7667c1075a74.jpg?1783941994,Creature — Human Wizard,Steven Belledin
+Linessa- Zephyr Mage,4,2007,0.45,#341aff,https://cards.scryfall.io/normal/front/7/9/799538af-e497-457b-b096-ee6f342f51b5.jpg?1783943118,Legendary Creature — Human Wizard,Jim Murray
+Living Lore,4,2015,0.18,#341aff,https://cards.scryfall.io/normal/front/8/f/8f658281-1c6c-4450-8d75-81714dbd0472.jpg?1783938606,Creature — Avatar,Jason Felix
+Llawan- Cephalid Empress,4,2002,0.89,#341aff,https://cards.scryfall.io/normal/front/a/9/a9821970-a5da-4045-93d8-f58c9e5797c1.jpg?1783945161,Legendary Creature — Octopus Noble,Mark Zug
+Loch Mare,2,2026,0.86,#341aff,https://cards.scryfall.io/normal/front/a/d/ad6c4baf-a803-45e4-81ac-708a41631a28.jpg?1783904497,Creature — Horse Serpent,Chris Rahn
+Lock and Load,3,2024,1.74,#341aff,https://cards.scryfall.io/normal/front/7/a/7a35de4b-5d98-4034-acc9-f38dc8c8f7d6.jpg?1783911968,Sorcery,Anastasia Ovchinnikova
+Loki- God of Mischief,2,2026,3.74,#341aff,https://cards.scryfall.io/normal/front/2/3/236c437f-ee9d-4145-a4db-b665908089cf.jpg?1783902955,Legendary Creature — God Sorcerer Villain,Vilhelmas Banys
+Loki- Lord of Misrule,4,2026,67.35,#341aff,https://cards.scryfall.io/normal/front/3/6/3636ecb1-8bb9-49aa-a40b-c0d0b3b71158.jpg?1783903072,Legendary Creature — God Sorcerer Villain,Toni Infante
+Lone Revenant,5,2015,0.17,#341aff,https://cards.scryfall.io/normal/front/5/c/5cb09a51-07c1-4047-81cd-67219c01e9b3.jpg?1783938092,Creature — Spirit,Jaime Jones
+Lord of Atlantis,2,2001,6.1,#341aff,https://cards.scryfall.io/normal/front/f/d/fd279366-8de2-47c5-9ac0-f41f8f81c643.jpg?1783945540,Creature — Merfolk,Greg Staples
+Lord of Change,7,2022,3.28,#341aff,https://cards.scryfall.io/normal/front/f/9/f9099d82-c13a-480d-b4bc-ecf8b810427c.jpg?1783920935,Creature — Demon,Games Workshop
+Lord of the Unreal,2,2011,0.63,#341aff,https://cards.scryfall.io/normal/front/b/0/b09140f6-fa75-4bee-9ca0-3a71cd2b5a7b.jpg?1783941091,Creature — Human Wizard,Jason Chan
+Lorthos- the Tidemaker,8,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/5/f/5f7a64cf-3c7a-4dfc-ae44-8413def80ce2.jpg?1783915695,Legendary Creature — Octopus,Kekai Kotaki
+Lost in the Maze,2,2024,0.26,#341aff,https://cards.scryfall.io/normal/front/6/3/6308dc62-d945-4761-aa4c-ef8e9271e901.jpg?1783912909,Enchantment,Julian Kok Joon Wen
+Lost Isle Calling,2,2023,0.29,#341aff,https://cards.scryfall.io/normal/front/7/b/7b744230-8127-4d4f-9d40-75e7c2aab77c.jpg?1783916313,Enchantment,Wangjie Li
+Louisoix's Sacrifice,1,2025,0.46,#341aff,https://cards.scryfall.io/normal/front/4/a/4a6976f2-0bd5-449a-8fcf-f5a732ce22c1.jpg?1783906634,Instant,Mintautas Šukys
+Ludevic's Test Subject // Ludevic's Abomination,2,2011,0.27,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Lizard Egg // Creature — Lizard Horror,Nils Hamm
+Lullmage Mentor,3,2009,6.55,#341aff,https://cards.scryfall.io/normal/front/e/3/e34de3df-3236-4281-a043-7583c76d89cc.jpg?1783942163,Creature — Merfolk Wizard,Jaime Jones
+Lulu- Stern Guardian,3,2025,0.42,#341aff,https://cards.scryfall.io/normal/front/9/c/9c0b1d5d-2b10-4dde-bb95-8cbf780cca97.jpg?1783906362,Legendary Creature — Human Wizard,Arou
+Lumengrid Augur,4,2003,0.31,#341aff,https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg?1783944554,Creature — Vedalken Wizard,rk post
+Lu Meng- Wu General,5,1999,72.95,#341aff,https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg?1783946122,Legendary Creature — Human Soldier,Gao Yan
+Lunar Insight,3,2024,0.2,#341aff,https://cards.scryfall.io/normal/front/a/9/a9a159f6-fecf-4bdd-b2f8-a9665a5cc32d.jpg?1783909117,Sorcery,Dan Murayama Scott
+Lunar Mystic,4,2020,0.22,#341aff,https://cards.scryfall.io/normal/front/c/8/c8a32b4b-4b8d-40e0-9166-06a678fd6e06.jpg?1783931187,Creature — Human Wizard,Wesley Burt
+Lu Su- Wu Advisor,5,1999,42.43,#341aff,https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg?1783946122,Legendary Creature — Human Advisor,Zhao Tan
+Lu Xun- Scholar General,4,2017,0.35,#341aff,https://cards.scryfall.io/normal/front/3/e/3e16e5b7-d130-4e52-b002-5f3d986e3e82.jpg?1783936295,Legendary Creature — Human Soldier,Xu Xiaoming
+Maddening Cacophony,2,2020,6.06,#341aff,https://cards.scryfall.io/normal/front/1/0/10a79733-702c-4611-b073-71db7f1158b2.jpg?1783929393,Sorcery,Magali Villeneuve
+Maelstrom Djinn,8,2007,0.27,#341aff,https://cards.scryfall.io/normal/front/9/c/9c102f29-6f3f-4f97-8177-4307586bd1b2.jpg?1783943122,Creature — Djinn,Hideaki Takamura
+Magical Hack,1,1997,3.97,#341aff,https://cards.scryfall.io/normal/front/c/2/c2349d53-d9f0-450f-be96-463791ee7aab.jpg?1783946945,Instant,Julie Baroh
+Magus of the Bazaar,2,2018,0.32,#341aff,https://cards.scryfall.io/normal/front/d/1/d117ed81-7b5c-4e29-b958-6126d48ac5a6.jpg?1783933842,Creature — Human Wizard,Rob Alexander
+Magus of the Future,5,2021,0.36,#341aff,https://cards.scryfall.io/normal/front/2/7/27ba1ea5-c861-4bb4-a681-fc0633268bd9.jpg?1783927842,Creature — Human Wizard,Anthony Francisco
+Magus of the Jar,5,2006,1.39,#341aff,https://cards.scryfall.io/normal/front/3/1/31961041-a9e6-4d96-bd4a-5c5f88a79e74.jpg?1783943242,Creature — Human Wizard,Zoltan Boros & Gabor Szikszai
+Magus of the Mind,6,2017,0.25,#341aff,https://cards.scryfall.io/normal/front/3/4/34a0d8a1-8564-4d4a-9390-06a06312e668.jpg?1783935947,Creature — Human Wizard,John Stanko
+Mahamoti Djinn,6,2015,0.14,#341aff,https://cards.scryfall.io/normal/front/1/0/1035c7d3-2a5b-4404-93cf-e46abd716a10.jpg?1783938299,Creature — Djinn,Greg Staples
+Malcolm- Alluring Scoundrel,2,2023,1.98,#341aff,https://cards.scryfall.io/normal/front/1/9/19d6834d-afa3-4747-a62d-0654f4d9729f.jpg?1783913793,Legendary Creature — Siren Pirate,Fesbra
+Malevolent Hermit // Benevolent Geist,2,2021,1.59,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Wizard // Creature — Spirit Wizard,Daarken
+Malleable Impostor,4,2023,8.11,#341aff,https://cards.scryfall.io/normal/front/a/d/ad0fc934-f49d-4607-a52b-aea5c1d5d342.jpg?1783914989,Creature — Faerie Shapeshifter,Alessandra Pisano
+Mana Drain,2,2022,55.89,#341aff,https://cards.scryfall.io/normal/front/3/c/3c429c40-2389-41e5-8681-4bb274e25eba.jpg?1783921913,Instant,Raymond Swanland
+Mana Leak,2,2005,10.12,#341aff,https://cards.scryfall.io/normal/front/d/e/dea41eb7-5828-4735-bca1-0dbb0fda04e3.jpg?1783944221,Instant,Christopher Rush
+Mana Maze,2,2000,4.95,#341aff,https://cards.scryfall.io/normal/front/0/d/0d62cc17-8fa3-495c-a098-ffbbec89fa53.jpg?1783945707,Enchantment,Rebecca Guay
+Mana Sculpt,3,2026,0.94,#341aff,https://cards.scryfall.io/normal/front/2/0/200c8e3d-c53b-40c7-a29a-fccc1281bfc6.jpg?1783903688,Instant,Cristi Balanescu
+Mana Severance,2,1997,4.26,#341aff,https://cards.scryfall.io/normal/front/8/5/854dc5e6-63f7-4c8b-83e5-a364f41c9a15.jpg?1783946654,Sorcery,Terese Nielsen
+Mana Short,3,2001,2.61,#341aff,https://cards.scryfall.io/normal/front/a/0/a0486784-de03-47a7-949d-550fd23492bc.jpg?1783945538,Instant,Greg Staples
+Manifold Insights,3,2018,0.73,#341aff,https://cards.scryfall.io/normal/front/e/9/e9c67dc7-dee8-4e62-bf4e-a371f1688975.jpg?1783934765,Sorcery,Tommy Arnold
+Marang River Regent // Coil and Catch,6,2025,1.7,#341aff,https://cards.scryfall.io/normal/front/f/8/f890bdc7-32e6-4492-bac7-7cabf54a8bfd.jpg?1783907393,Creature — Dragon // Instant — Omen,John Tedrick
+March from Velis Vel,3,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/3/2/32c2f269-e635-4459-a5a2-79e49c5401e5.jpg?1783911424,Sorcery,Carlos Palma Cruchaga
+March of Progress,3,2022,1.48,#341aff,https://cards.scryfall.io/normal/front/a/c/ac2da0e8-cdc5-4ffc-8a5e-893c34b7dd45.jpg?1783919722,Sorcery,Ben Wootten
+March of Swirling Mist,1,2022,3.45,#341aff,https://cards.scryfall.io/normal/front/1/0/100171d8-7436-44c8-b4cb-0101ffa05c25.jpg?1783923901,Instant,Iris Compiet
+March of the Machines,4,2010,0.56,#341aff,https://cards.scryfall.io/normal/front/3/2/3245f858-b5c3-42dd-8ec2-3f775ad9e1ec.jpg?1783941916,Enchantment,Ben Thompson
+Marina Vendrell's Grimoire,6,2024,0.3,#341aff,https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg?1783909493,Legendary Artifact — Book,Denys Tsiperko
+Marit Lage's Slumber,2,2019,0.64,#341aff,https://cards.scryfall.io/normal/front/4/f/4f5d2a6e-22cd-4493-9e58-e9c2aa3a31ab.jpg?1783933143,Legendary Snow Enchantment,Randy Vargas
+Martha Jones,3,2023,0.37,#341aff,https://cards.scryfall.io/normal/front/2/a/2a9f97c9-825b-43dc-96a5-807d1a15fdce.jpg?1783914669,Legendary Creature — Human Cleric,Daniel Correia
+Mask of the Schemer,3,2022,0.67,#341aff,https://cards.scryfall.io/normal/front/5/d/5df2a854-5807-4ce2-b2ef-cbd8aa3f86b5.jpg?1783923370,Artifact — Equipment,James Paick
+Mass Diminish,2,2019,1.38,#341aff,https://cards.scryfall.io/normal/front/7/6/762a0e40-af3c-4ef9-a9fc-0414a1758385.jpg?1783932812,Sorcery,E. M. Gist
+Mass Manipulation,4,2019,2.1,#341aff,https://cards.scryfall.io/normal/front/7/8/782760d7-59cc-4d40-a885-6a7980094fee.jpg?1783933708,Sorcery,Anthony Palumbo
+Mass Polymorph,6,2010,0.32,#341aff,https://cards.scryfall.io/normal/front/1/3/13ffe61f-e52e-4d62-854b-10ac9cfbadd3.jpg?1783941823,Sorcery,Christopher Moeller
+Masterful Replication,6,2023,0.28,#341aff,https://cards.scryfall.io/normal/front/8/6/860e81bd-769a-4e8a-97a4-b0ae653a593b.jpg?1783917168,Instant,Victor Adame Minguez
+Master of Etherium,3,2023,0.62,#341aff,https://cards.scryfall.io/normal/front/3/e/3efa70d4-d58c-4a43-bc4e-ffa9a91b0e5e.jpg?1783917169,Artifact Creature — Vedalken Wizard,Matt Cavotta
+Master of Predicaments,5,2014,0.33,#341aff,https://cards.scryfall.io/normal/front/f/0/f0b1720b-ab7a-4b52-a6d0-11c4fc573d17.jpg?1783939190,Creature — Sphinx,Matt Stewart
+Master of the Pearl Trident,2,2023,0.45,#341aff,https://cards.scryfall.io/normal/front/6/b/6b48dc56-667c-4fde-8175-952463e233cc.jpg?1783913884,Creature — Merfolk,Ryan Pancoast
+Master of Winds,4,2020,0.24,#341aff,https://cards.scryfall.io/normal/front/0/c/0caaf92a-3d9d-4c52-acff-cf960ec55e47.jpg?1783929392,Creature — Sphinx Wizard,Yigit Koroglu
+Master Transmuter,4,2020,5.76,#341aff,https://cards.scryfall.io/normal/front/4/8/480eb74f-9e62-41f7-b48a-b4249aab5752.jpg?1783930196,Artifact Creature — Human Artificer,Chippy
+Mathemagics,2,2026,2.61,#341aff,https://cards.scryfall.io/normal/front/c/d/cd3cc172-5609-4bc8-9d84-50680fed6df9.jpg?1783903688,Sorcery,Liiga Smilshkalne
+Mathise- Surge Channeler,3,2025,5.58,#341aff,https://cards.scryfall.io/normal/front/3/c/3c560e53-73d9-4b0e-9b93-c729e00e7bbe.jpg?1783906767,Legendary Creature — Human Elf Shaman Sorcerer,Michele Giorgi
+Matoya- Archon Elder,3,2025,0.64,#341aff,https://cards.scryfall.io/normal/front/1/d/1dd61cf6-2fb5-4cff-ab00-7677ac85774c.jpg?1783906634,Legendary Creature — Human Warlock,Luisa J. Preissler
+Mausoleum Wanderer,1,2025,0.34,#341aff,https://cards.scryfall.io/normal/front/f/4/f47bda42-8eb7-49c5-8f3b-e988e377a7f5.jpg?1783908159,Creature — Spirit,Kieran Yanner
+Mechanized Production,4,2024,4.18,#341aff,https://cards.scryfall.io/normal/front/e/a/eaf86997-68e8-4c37-99f1-db10ac08f54c.jpg?1783913014,Enchantment — Aura,Adam Paquette
+Meishin- the Mind Cage,7,2005,1.55,#341aff,https://cards.scryfall.io/normal/front/7/0/70efc52b-7852-44c4-9825-d5e1bd796160.jpg?1783944162,Legendary Enchantment,Thomas Gianni
+Meletis Charlatan,3,2013,0.16,#341aff,https://cards.scryfall.io/normal/front/b/f/bf22da0c-5bf5-4c81-9422-671ce17c8ffa.jpg?1783939794,Creature — Human Wizard,Jason A. Engle
+Meloku the Clouded Mirror,5,2020,0.74,#341aff,https://cards.scryfall.io/normal/front/6/0/60b9db96-a6ab-454b-99a7-910ef77560d7.jpg?1783928719,Legendary Creature — Moonfolk Wizard,Scott M. Fischer
+Memories Returning,4,2025,0.26,#341aff,https://cards.scryfall.io/normal/front/a/7/a753abfc-35d3-4faf-ab35-3b51aa778174.jpg?1783906633,Sorcery,Grace Zhu
+Memory Deluge,4,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/e/d/edcd3802-ddb3-4eb6-9b6e-a26d76557662.jpg?1783908159,Instant,Lake Hurwitz
+Memory Erosion,3,2018,9.1,#341aff,https://cards.scryfall.io/normal/front/f/2/f2fedec9-d938-419b-91e1-b4d9ad970464.jpg?1783934764,Enchantment,Howard Lyon
+Mental Misstep,1,2026,16.51,#341aff,https://cards.scryfall.io/normal/front/a/b/ab8741ca-43cb-4b4c-890d-0a363524bd13.jpg?1783904215,Instant,Kelogsloops & Scott Okumura
+Mercurial Pretender,5,2014,0.17,#341aff,https://cards.scryfall.io/normal/front/b/3/b3160d28-230d-4bce-9050-6ab5895302ee.jpg?1783939190,Creature — Shapeshifter,Izzy
+Mercurial Spelldancer,2,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/c/f/cf28c75d-1fb3-44cc-b651-5b2830e22add.jpg?1783918060,Creature — Phyrexian Rogue,Marcela Bolívar
+Merfolk Sovereign,3,2023,0.35,#341aff,https://cards.scryfall.io/normal/front/a/c/ac545978-ad30-4c6b-8add-3edd6c0eb7f3.jpg?1783913884,Creature — Merfolk Noble,Marta Nael
+Mesmerizing Benthid,5,2019,0.52,#341aff,https://cards.scryfall.io/normal/front/5/b/5bed7c69-1302-4c1a-b410-b4e6c4ef4c0c.jpg?1783933708,Creature — Octopus,Kev Walker
+Metallurgic Summonings,5,2021,2.6,#341aff,https://cards.scryfall.io/normal/front/3/a/3a769d7e-c749-4845-ba87-808f0386df80.jpg?1783927564,Enchantment,Kieran Yanner
+Metamorphic Alteration,2,2018,0.33,#341aff,https://cards.scryfall.io/normal/front/e/f/eff03d37-d90a-4dcc-bacd-64fd71301354.jpg?1783934585,Enchantment — Aura,Livia Prima
+Metathran Aerostat,4,2000,0.26,#341aff,https://cards.scryfall.io/normal/front/5/9/59f34850-fb6f-4ac5-8309-4d53d770e28c.jpg?1783945707,Creature — Metathran,Greg Staples
+Midnight Clock,3,2024,0.69,#341aff,https://cards.scryfall.io/normal/front/0/b/0b3c33b7-5b15-4b61-bfd6-1ffa823eb28a.jpg?1783911941,Artifact,Alexander Forssberg
+Mimeofacture,4,2006,0.21,#341aff,https://cards.scryfall.io/normal/front/f/4/f4ada33a-5b7c-426a-8416-4ce01bccaa5c.jpg?1783943518,Sorcery,Dan Murayama Scott
+Minas Tirith Garrison,4,2023,0.49,#341aff,https://cards.scryfall.io/normal/front/9/0/9023a7eb-fe74-4e3d-9279-e69519b41fbd.jpg?1783913966,Creature — Human Soldier,Irina Nordsol
+Mind Bend,1,2007,1.85,#341aff,https://cards.scryfall.io/normal/front/6/9/692a5bfa-9a50-4610-acd7-19fc0a53f798.jpg?1783943054,Instant,Mike Dringenberg
+Mind Bomb,1,1994,4.92,#341aff,https://cards.scryfall.io/normal/front/0/e/0ee810a5-f0f9-4b73-8194-3d1344784050.jpg?1783947942,Sorcery,Mark Tedin
+Mindbreak Trap,4,2009,15.46,#341aff,https://cards.scryfall.io/normal/front/4/f/4f51140b-6254-431a-8810-94307bfdfbbe.jpg?1783942162,Instant — Trap,Christopher Moeller
+Mind Flayer,5,2022,0.38,#341aff,https://cards.scryfall.io/normal/front/a/6/a6cb10f5-ee9f-49e6-826a-a2a2395daa92.jpg?1783922468,Creature — Horror,Daarken
+Mindlink Mech,3,2022,0.24,#341aff,https://cards.scryfall.io/normal/front/2/8/28273a5b-57b3-4b7a-b017-5886c171c9c9.jpg?1783923900,Artifact — Vehicle,Robbie Trevino
+Mindlock Orb,4,2008,0.65,#341aff,https://cards.scryfall.io/normal/front/5/5/55c84e9f-ccbb-4fbc-98e1-4072968a1f8a.jpg?1783942572,Artifact,rk post
+Mind Over Matter,6,1998,42.63,#341aff,https://cards.scryfall.io/normal/front/6/e/6e091dd6-149f-46ea-bae0-224e79e3aacb.jpg?1783946523,Enchantment,Keith Parkinson
+Mindreaver,2,2014,0.15,#341aff,https://cards.scryfall.io/normal/front/8/7/87912ae7-3edc-4ea2-9b4b-caf2bc149ad1.jpg?1783939567,Creature — Human Wizard,Wesley Burt
+Minds Aglow,1,2023,1.48,#341aff,https://cards.scryfall.io/normal/front/c/c/ccacc197-7c22-444d-8e6e-950dca63eb2c.jpg?1783915694,Sorcery,Yeong-Hao Han
+Mind's Desire,6,2021,1.21,#341aff,https://cards.scryfall.io/normal/front/1/7/17ef3058-46b8-4ec4-950f-c721919c4ac1.jpg?1783927563,Sorcery,Anthony Francisco
+Mind's Dilation,7,2024,4.95,#341aff,https://cards.scryfall.io/normal/front/4/f/4f2980ba-2468-4a36-afdb-87e6567797a9.jpg?1783911942,Enchantment,Iain McCaig
+Mindshrieker,2,2011,0.58,#341aff,https://cards.scryfall.io/normal/front/a/b/ab1e52af-6746-4ec6-afbf-008594c874f8.jpg?1783940971,Creature — Spirit Bird,Dave Kendall
+Mindsplice Apparatus,4,2023,1.09,#341aff,https://cards.scryfall.io/normal/front/7/f/7f4ad1cb-4bbb-4485-b322-0b003f06d034.jpg?1783918059,Artifact,Ovidio Cartagena
+Mind Spring,2,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/e/7/e7e7d174-eb7c-41ad-a241-cfbfdc71e3a7.jpg?1783910741,Sorcery,Mark Zug
+Mindspring Merfolk,1,2025,0.65,#341aff,https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg?1783907907,Creature — Merfolk Wizard,Andreia Ugrai
+Mind Unbound,6,2011,0.46,#341aff,https://cards.scryfall.io/normal/front/f/d/fd90cf36-9841-4adf-b5cb-0a7bf103eb93.jpg?1783941089,Enchantment,Jason Felix
+Minn- Wily Illusionist,3,2021,7.75,#341aff,https://cards.scryfall.io/normal/front/4/e/4eec1d87-1007-44a1-a45d-0623816de681.jpg?1783926254,Legendary Creature — Gnome Wizard,Dmitry Burmak
+Mirage Mockery,3,2023,0.35,#341aff,https://cards.scryfall.io/normal/front/6/7/67cead78-26fa-4cae-ba0e-925e28c26d53.jpg?1783918156,Sorcery,Anna Pavleeva
+Mirelurk Queen,5,2024,0.95,#341aff,https://cards.scryfall.io/normal/front/6/e/6e6d1843-9e05-4cdd-ad4e-15d7913d87f7.jpg?1783912412,Creature — Crab Mutant,Nicholas Gregory
+Mirrodin Besieged,3,2019,4.98,#341aff,https://cards.scryfall.io/normal/front/d/8/d8423d8d-744a-4bbe-a853-8ad756451bdb.jpg?1783933143,Enchantment,Bram Sels
+Mirrorform,6,2026,1.86,#341aff,https://cards.scryfall.io/normal/front/5/5/55d30256-f5d8-4f61-a3f5-878970ced6d1.jpg?1783904485,Instant,Wayne Reynolds
+Mirrorhall Mimic // Ghastly Mimicry,4,2021,1.3,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Spirit // Enchantment — Aura,Justine Cruz
+Mirrormade,3,2024,2.42,#341aff,https://cards.scryfall.io/normal/front/a/2/a26cbfbe-fbb8-4804-b065-ab2c42ddad9b.jpg?1783909627,Enchantment,Volkan Baǵa
+Mirror-Mad Phantasm,5,2011,0.72,#341aff,https://cards.scryfall.io/normal/front/b/2/b20eea41-9daf-4ac1-8bad-bb4aa211bb53.jpg?1783940970,Creature — Spirit,Howard Lyon
+Mirror Mockery,2,2015,0.49,#341aff,https://cards.scryfall.io/normal/front/f/8/f837b050-70a6-46f0-963d-4badb37a42a1.jpg?1783938607,Enchantment — Aura,Ryan Alexander Lee
+Mirror Room // Fractured Realm,10,2024,2.35,#341aff,https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1783909490,Enchantment — Room // Enchantment — Room,Helge C. Balzer
+Miscast,1,2025,7.19,#341aff,https://cards.scryfall.io/normal/front/7/5/7585b181-bf9a-4cc2-a874-b8404b06bebd.jpg?1783905159,Instant,Justyna Dura
+Mischievous Quanar,5,2003,1.1,#341aff,https://cards.scryfall.io/normal/front/d/c/dc48c2db-f5b4-4c24-a5fa-00750b7ff56f.jpg?1783944885,Creature — Beast,Lars Grant-West
+Misdirection,5,2017,11.75,#341aff,https://cards.scryfall.io/normal/front/c/9/c96763d6-0cea-40ed-afb2-886bfebe50a0.jpg?1783935613,Instant,Mathias Kollros
+Misleading Signpost,3,2023,13.73,#341aff,https://cards.scryfall.io/normal/front/c/1/c15dfe35-c570-4aaf-b82d-270c15464fe2.jpg?1783914988,Artifact,Julian Kok Joon Wen
+Mission Briefing,2,2024,0.33,#341aff,https://cards.scryfall.io/normal/front/5/e/5ed398e7-9d2b-4bd2-9a4b-2885e4749003.jpg?1783913014,Instant,Matt Stewart
+Mistbind Clique,4,2007,10.58,#341aff,https://cards.scryfall.io/normal/front/c/f/cfc421e2-0dd4-4bdf-b5f5-a60c4b0df63b.jpg?1783942900,Creature — Faerie Wizard,Ben Thompson
+Mistcaller,1,2018,0.47,#341aff,https://cards.scryfall.io/normal/front/a/3/a35c1bd0-3d1a-4e46-b74d-11db6867e0d7.jpg?1783934583,Creature — Merfolk Wizard,Ryan Yee
+Mist Dancer,5,2023,0.25,#341aff,https://cards.scryfall.io/normal/front/9/7/97d8fcf4-4606-4560-87da-a3c1a9d8da7e.jpg?1783913912,Creature — Merfolk Wizard,Christina Kraus
+Mist Dragon,6,1996,3.63,#341aff,https://cards.scryfall.io/normal/front/3/b/3b9b4be4-74c8-4fe5-a5e4-de57c11e8ec1.jpg?1783947105,Creature — Dragon,Al Davidson
+Mister Fantastic,3,2026,2.08,#d78f42,https://cards.scryfall.io/normal/front/f/1/f1d80509-ece1-4b6d-bfe5-c6d003f581cf.jpg?1783903304,Legendary Creature — Human Scientist Hero,Gintas Galvanauskas
+Mistform Skyreaver,7,2002,0.25,#341aff,https://cards.scryfall.io/normal/front/e/3/e394e096-ea70-4813-9039-e4bd065d0a17.jpg?1783945081,Creature — Illusion,Anthony S. Waters
+Mistform Ultimus,4,2003,0.41,#341aff,https://cards.scryfall.io/normal/front/e/3/e3be21c3-9b83-430b-be0a-792de9a680e3.jpg?1783944919,Legendary Creature — Illusion,Anthony S. Waters
+Misthollow Griffin,4,2012,3.06,#341aff,https://cards.scryfall.io/normal/front/2/d/2db4fe28-e580-479b-910f-b719d69468b1.jpg?1783940715,Creature — Griffin,Jaime Jones
+Mist of Stagnation,5,2002,0.49,#341aff,https://cards.scryfall.io/normal/front/7/6/76d03121-9515-4101-9d60-e01225533f44.jpg?1783945127,Enchantment,Mike Ploog
+Mists of Lórien,3,2023,1.15,#341aff,https://cards.scryfall.io/normal/front/e/b/eb23c5fc-3172-44c3-9d3a-ec619c6c4824.jpg?1783914199,Sorcery,Alexander Mokhov
+Mist-Syndicate Naga,3,2019,3.06,#341aff,https://cards.scryfall.io/normal/front/6/5/65c8f074-e260-4f8e-85d1-1904ca928b51.jpg?1783933143,Creature — Snake Ninja,Randy Vargas
+Mitotic Manipulation,3,2011,0.36,#341aff,https://cards.scryfall.io/normal/front/2/a/2abd4521-62c8-4b2f-a406-a8ddfa8f475a.jpg?1783941388,Sorcery,Dan Murayama Scott
+Mizzium Meddler,3,2015,0.14,#341aff,https://cards.scryfall.io/normal/front/7/6/762d568d-a2d6-449b-85c2-a92755efe4c3.jpg?1783938350,Creature — Vedalken Wizard,Johann Bodin
+Mm'menon- the Right Hand,5,2025,0.36,#341aff,https://cards.scryfall.io/normal/front/8/2/82add0a0-e402-4b31-b101-81c0bf332015.jpg?1783905978,Legendary Creature — Jellyfish Advisor,Joshua Raphael
+Mnemonic Deluge,9,2020,6.46,#341aff,https://cards.scryfall.io/normal/front/2/d/2d0e725b-2250-4189-9682-73461b5cfed2.jpg?1783928856,Sorcery,Chris Rallis
+Mobile Clone,4,2022,0.18,#341aff,https://cards.scryfall.io/normal/front/f/0/f080ab50-c78c-4a27-a7e5-abfbd93f4e41.jpg?1783920593,Sorcery,Setor Fiadzigbey
+Mockingbird,1,2024,3.56,#341aff,https://cards.scryfall.io/normal/front/a/d/ade32396-8841-4ba4-8852-d11146607f21.jpg?1783910846,Creature — Bird Bard,Aurore Folny
+Mocking Doppelganger,4,2022,4.01,#341aff,https://cards.scryfall.io/normal/front/6/c/6c5f81d8-b189-4f6e-872f-a237bb872aa9.jpg?1783922508,Creature — Shapeshifter,Igor Grechanyi
+Monastery Siege,3,2017,0.62,#341aff,https://cards.scryfall.io/normal/front/3/2/32d2a1ad-210c-444d-9cb7-b78b493db7ea.jpg?1783935917,Enchantment,Mark Winters
+Mondo Gecko,3,2026,0.57,#341aff,https://cards.scryfall.io/normal/front/6/6/665e44f9-bc0d-40aa-83a4-f7fe64f2506d.jpg?1783904113,Legendary Creature — Lizard Mutant,Maël Ollivier-Henry
+Monstrosity of the Lake,5,2023,0.37,#341aff,https://cards.scryfall.io/normal/front/d/7/d72aa8fc-6808-4865-879e-417a300c40de.jpg?1783916033,Legendary Creature — Kraken,Ben Wootten
+Moonlace,1,2006,0.61,#341aff,https://cards.scryfall.io/normal/front/c/7/c781cc80-5f57-4677-a9da-3523191cc7c6.jpg?1783943242,Instant,Mike Dringenberg
+Moonlit Meditation,3,2025,0.4,#341aff,https://cards.scryfall.io/normal/front/f/2/f2a56007-5bca-4edf-9cc4-5f77a273636c.jpg?1783905978,Enchantment — Aura,Liiga Smilshkalne
+Mordenkainen,6,2021,1.42,#341aff,https://cards.scryfall.io/normal/front/2/f/2fa5e4c7-12fa-4ec4-bd4b-752e367306c7.jpg?1783926511,Legendary Planeswalker — Mordenkainen,Ryan Pancoast
+Ms. Marvel- Kamala Khan,3,2026,0.29,#341aff,https://cards.scryfall.io/normal/front/9/d/9dd2d627-10fc-4045-8545-03bcf75e60ca.jpg?1783902954,Legendary Creature — Mutant Inhuman Hero,Smirtouille
+Muddle the Mixture,2,2023,5.37,#341aff,https://cards.scryfall.io/normal/front/b/3/b3c28fcb-09e8-4b58-bda2-339afb68fc9a.jpg?1783916636,Instant,Rebecca Guay
+Mulldrifter,5,2026,1.73,#341aff,https://cards.scryfall.io/normal/front/f/f/ff990293-3e73-4c01-9b79-707339c8b28b.jpg?1783903472,Creature — Elemental,Virginia Elwood
+Multiple Choice,1,2021,0.32,#341aff,https://cards.scryfall.io/normal/front/0/8/08c9890f-7081-42f6-89eb-35c83911b443.jpg?1783927376,Sorcery,Campbell White
+Multiversal Incursion,7,2026,1.58,#341aff,https://cards.scryfall.io/normal/front/8/a/8a505f6f-933c-4644-838f-897f5e4133b0.jpg?1783902956,Sorcery,Lordigan
+Murktide Regent,7,2021,5.86,#341aff,https://cards.scryfall.io/normal/front/2/0/20c4aae1-7665-4df7-bd51-a1d95bf8a17d.jpg?1783926875,Creature — Dragon,Lucas Graciano
+Murmuring Mystic,4,2026,2.17,#341aff,https://cards.scryfall.io/normal/front/5/d/5dc95208-2b3a-44cd-9782-b303379b8174.jpg?1783903579,Creature — Human Wizard,Marta Nael
+Muse Vortex,2,2021,0.29,#341aff,https://cards.scryfall.io/normal/front/c/1/c11b6560-51e8-42d2-a51d-fca70a5807b5.jpg?1783927603,Sorcery,Kieran Yanner
+Mu Yanling- Sky Dancer,3,2019,0.67,#341aff,https://cards.scryfall.io/normal/front/0/2/0240f9eb-e1b2-4b41-94b0-b00ad2850825.jpg?1783933006,Legendary Planeswalker — Yanling,G-host Lee
+Mu Yanling- Wind Rider,4,2025,0.44,#341aff,https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg?1783907905,Legendary Creature — Human Wizard Pilot,Justyna Dura
+Myojin of Cryptic Dreams,8,2022,0.35,#341aff,https://cards.scryfall.io/normal/front/3/1/31142a36-3676-4ce4-9f5b-d9252fc30739.jpg?1783923986,Legendary Creature — Spirit,Yigit Koroglu
+Myojin of Seeing Winds,10,2004,6.31,#341aff,https://cards.scryfall.io/normal/front/8/f/8f5f8d3a-95e7-4dd9-8510-43517eb02693.jpg?1783944324,Legendary Creature — Spirit,Kev Walker
+Mysterio- Master of Illusion,4,2025,0.35,#341aff,https://cards.scryfall.io/normal/front/f/a/facbd96f-c088-4377-b740-5e0fe99102bb.jpg?1783905353,Legendary Creature — Human Villain,Alexander Gering
+Mysterio's Mirage,3,2026,0.96,#341aff,https://cards.scryfall.io/normal/front/d/5/d5628e8b-7df6-4c9e-9ddc-57f124b38470.jpg?1783903070,Enchantment,Rimas Valeikis
+Mystical Dispute,3,2023,3.48,#341aff,https://cards.scryfall.io/normal/front/b/6/b6175fea-1de4-4d82-b86c-3c3140a3c286.jpg?1783918519,Instant,Brigitte Roka
+Mystical Tutor,1,2023,16.52,#341aff,https://cards.scryfall.io/normal/front/3/6/36fa9a0b-b0c9-43ea-ba11-99d7982f974e.jpg?1783918491,Instant,Lindsey Look
+Mystic Archaeologist,2,2024,0.19,#341aff,https://cards.scryfall.io/normal/front/c/0/c069ff32-6759-48a2-8674-4f729c91dcd0.jpg?1783908963,Creature — Human Wizard,Eric Deschamps
+Mystic Confluence,5,2023,1.06,#341aff,https://cards.scryfall.io/normal/front/6/2/62e5d409-c0b6-4123-802d-eb32f223bd1a.jpg?1783915695,Instant,Kieran Yanner
+Mystic Decree,4,1995,1.03,#341aff,https://cards.scryfall.io/normal/front/8/b/8b069e6a-2c0e-4fc9-8e19-08bf1245a6c0.jpg?1783947295,World Enchantment,Liz Danforth
+Mystic Might,1,1995,0.52,#341aff,https://cards.scryfall.io/normal/front/e/3/e35d7f08-0687-41bd-8c53-31a49adabb11.jpg?1783947511,Enchantment — Aura,Nicola Leonard
+Mystic Reflection,2,2021,1.26,#341aff,https://cards.scryfall.io/normal/front/f/7/f7b877e2-60eb-46cd-acd7-8555b9e7e993.jpg?1783928260,Instant,YW Tang
+Mystic Remora,1,2023,12.75,#341aff,https://cards.scryfall.io/normal/front/4/0/40140991-cffa-4b52-9a25-37e9a8aa9ddd.jpg?1783918491,Enchantment,Jesper Ejsing
+Mythos of Illuna,4,2020,0.24,#d78f42,https://cards.scryfall.io/normal/front/f/1/f1b07082-c5a5-4283-a2f5-5b1e0120d752.jpg?1783931072,Sorcery,Seb McKinnon
+Naban- Dean of Iteration,2,2018,0.55,#341aff,https://cards.scryfall.io/normal/front/8/8/88f41175-880f-491e-96c3-bf52f3c0db5d.jpg?1783935023,Legendary Creature — Human Wizard,Ryan Alexander Lee
+Nadir Kraken,3,2024,0.39,#341aff,https://cards.scryfall.io/normal/front/3/b/3bd63804-d538-471f-b57f-e1023f7e14a8.jpg?1783913013,Creature — Kraken,Dan Murayama Scott
+Naga Fleshcrafter,4,2025,0.35,#341aff,https://cards.scryfall.io/normal/front/5/d/5df17423-9fdd-4432-8660-1d267c685595.jpg?1783907393,Creature — Snake Shapeshifter,Valera Lutfullina
+Namor- Scourge of the Seas,5,2026,3.41,#341aff,https://cards.scryfall.io/normal/front/e/c/ecbba25e-40fd-43f5-90c8-786ce9c27075.jpg?1783903070,Legendary Creature — Mutant Merfolk Villain,Grace Zhu
+Namor the Sub-Mariner,3,2026,10.21,#341aff,https://cards.scryfall.io/normal/front/7/a/7aaefcf9-fbe1-4767-92a5-09825761d116.jpg?1783902956,Legendary Creature — Mutant Merfolk Villain,Chris Rallis
+Nanogene Conversion,4,2023,9.25,#341aff,https://cards.scryfall.io/normal/front/8/1/81aa8dbd-ae18-4d62-a721-94afcb12bf27.jpg?1783914668,Sorcery,Miklós Ligeti
+Narcomoeba,2,2018,0.34,#341aff,https://cards.scryfall.io/normal/front/a/3/a3e23275-2261-4d6d-88d8-124342334391.jpg?1783934186,Creature — Illusion,Howard Lyon
+Nardole- Resourceful Cyborg,2,2023,0.21,#341aff,https://cards.scryfall.io/normal/front/0/3/03a5c463-6b5c-49c9-84c9-666aa8c19fbf.jpg?1783914662,Legendary Artifact Creature — Scientist,Yuliya Litvinova
+Narset's Reversal,2,2025,2.29,#341aff,https://cards.scryfall.io/normal/front/4/e/4ede8d68-6870-445c-b140-da98adbc246a.jpg?1783907140,Instant,Nathaniel Himawan
+Naru Meha- Master Wizard,4,2021,0.89,#341aff,https://cards.scryfall.io/normal/front/c/f/cf44910a-4e24-4e36-a58e-ae7f463db368.jpg?1783927563,Legendary Creature — Human Wizard,Matt Stewart
+Narwhal,4,1995,1.29,#341aff,https://cards.scryfall.io/normal/front/2/0/202d3ed5-f493-43b6-bf36-81ad289e6fb0.jpg?1783947295,Creature — Whale,David A. Cherry
+Nascent Metamorph,2,2020,0.28,#341aff,https://cards.scryfall.io/normal/front/6/1/61e7984b-8c20-4867-8045-4fb52cd6e2d4.jpg?1783931220,Creature — Shapeshifter,Brian Valeza
+Necroduality,4,2025,6.52,#341aff,https://cards.scryfall.io/normal/front/6/3/6385509a-6814-4039-83fb-1fa5a7439696.jpg?1783908156,Enchantment,Billy Christian
+Neerdiv- Devious Diver,3,2024,1.69,#341aff,https://cards.scryfall.io/normal/front/0/7/070e0081-b0fe-4417-b943-d0496e3b8cd7.jpg?1783908859,Legendary Creature — Merfolk Rogue,Yuchi Yuki
+Negate,2,2020,9.37,#341aff,https://cards.scryfall.io/normal/front/b/1/b12d13b4-a210-4d8d-bd04-42a00f68ae7b.jpg?1783929690,Instant,Ralph Horsley
+Nephalia Moondrakes,7,2016,0.14,#341aff,https://cards.scryfall.io/normal/front/f/7/f714d6c4-b1e1-40dd-806f-a3d87020292e.jpg?1783937793,Creature — Drake,Tianhua X
+Netherese Puzzle-Ward,4,2021,1.04,#341aff,https://cards.scryfall.io/normal/front/2/6/26bd3a70-3154-44a4-8705-1eac01cde8fd.jpg?1783926253,Enchantment,Ralph Horsley
+New Perspectives,6,2020,0.23,#341aff,https://cards.scryfall.io/normal/front/2/8/286be1fb-8ed2-4228-9df8-0ea413714778.jpg?1783931186,Enchantment,Darek Zabrocki
+Nexus Mentality,4,2026,0.31,#341aff,https://cards.scryfall.io/normal/front/d/9/d9ed2ef7-9433-4f2f-957b-b58d2ec391fe.jpg?1783903861,Instant,Lie Setiawan
+Nexus of Fate,7,2024,6.02,#341aff,https://cards.scryfall.io/normal/front/f/0/f0aacf61-be23-400e-8e3c-5584b44df449.jpg?1783909936,Instant,Mike Bierek
+Nezahal- Primal Tide,7,2020,7.68,#341aff,https://cards.scryfall.io/normal/front/a/9/a959b40d-dd8c-49d8-8003-744d0c877b04.jpg?1783928719,Legendary Creature — Elder Dinosaur,Sam Burley
+Niblis of Frost,4,2020,0.31,#341aff,https://cards.scryfall.io/normal/front/f/4/f4a3d06c-8059-4f73-8f7e-29aa004cd3d5.jpg?1783931186,Creature — Spirit,Josu Hernaiz
+Nick Valentine- Private Eye,3,2024,0.26,#341aff,https://cards.scryfall.io/normal/front/0/a/0a7c9553-d4a8-4d51-8e8a-8a0ffbdf1715.jpg?1783912413,Legendary Artifact Creature — Synth Detective,Viko Menezes
+Nightmares and Daydreams,3,2025,0.17,#341aff,https://cards.scryfall.io/normal/front/1/c/1c2e1d6d-e7c3-4dd4-b8e1-cd89c28afa3a.jpg?1783904828,Enchantment — Saga,AKAGI
+Nimble Obstructionist,3,2020,0.44,#341aff,https://cards.scryfall.io/normal/front/8/3/832426d7-be22-4092-b614-7fa417af03bd.jpg?1783931185,Creature — Bird Wizard,Shreya Shetty
+Nimble Trapfinder,2,2020,0.24,#341aff,https://cards.scryfall.io/normal/front/1/e/1ee1a550-b7e7-48e0-bd96-a41986dbd879.jpg?1783929391,Creature — Human Rogue,Caio Monteiro
+Ninja of the Deep Hours,4,2025,19.48,#341aff,https://cards.scryfall.io/normal/front/5/2/522beeb1-3218-4bb9-95d2-1c25d4a53019.jpg?1783907928,Creature — Human Ninja,Tsubonari
+Nix,1,2007,1.09,#341aff,https://cards.scryfall.io/normal/front/3/d/3dab4f64-2a91-409a-b83b-45b22afd22ff.jpg?1783943116,Instant,Brian Despain
+Norman Osborn // Green Goblin,2,2025,19.11,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Scientist Villain // Legendary Creature — Goblin Human Villain,Scott M. Fischer
+Notorious Throng,4,2020,3.42,#341aff,https://cards.scryfall.io/normal/front/c/8/c8be7edf-807a-4a7b-ab48-78f309997210.jpg?1783929482,Kindred Sorcery — Rogue,Thomas Denmark
+Novijen Sages,6,2006,0.31,#341aff,https://cards.scryfall.io/normal/front/0/4/04ec467e-5d4a-4941-ac30-801ed681da54.jpg?1783943438,Creature — Human Advisor Mutant,Luca Zontini
+Now I Know My ABC's,3,2004,2.64,#341aff,https://cards.scryfall.io/normal/front/9/5/95c790e6-340f-42c2-af88-e458b7b9690c.jpg?1783944256,Enchantment,Tony Szczudlo
+Nyssa of Traken,4,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/b/e/bed41499-759d-4a3b-aabb-c462d5831956.jpg?1783914665,Legendary Creature — Human Scientist,Irina Nordsol
+O'aka- Traveling Merchant,2,2025,0.33,#341aff,https://cards.scryfall.io/normal/front/9/d/9d860089-fb88-4736-b7f4-b605551bedc8.jpg?1783906362,Legendary Creature — Human Citizen,Fang Xinyu
+Oath of Jace,3,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/d/a/da62e9a8-d1aa-4fea-abb7-50c10d40fa6a.jpg?1783915439,Legendary Enchantment,Wesley Burt
+Oath of Scholars,4,1998,0.39,#341aff,https://cards.scryfall.io/normal/front/d/6/d61376ad-21c8-4d34-b37d-ed60877f5d4a.jpg?1783946523,Enchantment,Michael Sutfin
+Observed Stasis,4,2025,0.21,#341aff,https://cards.scryfall.io/normal/front/6/3/6301c10c-8c27-4595-a0a7-30c621332b2c.jpg?1783906361,Enchantment — Aura,Toni Infante
+Occult Epiphany,1,2021,1.15,#341aff,https://cards.scryfall.io/normal/front/6/9/6920c895-bc98-4871-a53f-219fa27a74e5.jpg?1783925004,Instant,Jason Rainville
+Octavia- Living Thesis,10,2024,1.04,#341aff,https://cards.scryfall.io/normal/front/e/9/e9591647-bad3-4015-90d1-1646a9eb4d14.jpg?1783911940,Legendary Creature — Elemental Octopus,Simon Dominic
+Octopus Umbra,5,2018,2.43,#341aff,https://cards.scryfall.io/normal/front/9/e/9efcf24c-ad57-4320-9b85-c838f5ed659b.jpg?1783934341,Enchantment — Aura,Howard Lyon
+Ojer Pakpatiq- Deepest Epoch // Temple of Cyclical Time,4,2023,3.59,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Land,Chris Rahn
+Oko- Lorwyn Liege // Oko- Shadowmoor Scion,3,2026,0.8,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Planeswalker — Oko // Legendary Planeswalker — Oko,Kai Carpenter
+Omniscience,10,2024,6.53,#341aff,https://cards.scryfall.io/normal/front/d/3/d33d91d0-1506-45e4-9def-975bf901815e.jpg?1783909079,Enchantment,Jason Chan
+Omnispell Adept,5,2018,0.25,#341aff,https://cards.scryfall.io/normal/front/e/1/e17664df-e8ba-464d-b338-3e671d2d7f0e.jpg?1783934185,Creature — Human Wizard,Jason Rainville
+One with the Machine,4,2018,0.26,#341aff,https://cards.scryfall.io/normal/front/1/7/17f2aaf5-6c1f-4663-865f-6cdd5640485a.jpg?1783934583,Sorcery,Chase Stone
+One with the Multiverse,8,2024,2.31,#341aff,https://cards.scryfall.io/normal/front/1/c/1c85ae22-ccd0-4649-a736-1915043daae7.jpg?1783909627,Enchantment,Liiga Smilshkalne
+Opposition,4,2023,0.99,#341aff,https://cards.scryfall.io/normal/front/a/e/ae14acde-8a5c-4f0e-8e68-b799a363b9f7.jpg?1783918488,Enchantment,Todd Lockwood
+Opt,1,2025,6.89,#341aff,https://cards.scryfall.io/normal/front/f/1/f1de6f4a-ec3f-4bdb-902f-2e04f36ad7f4.jpg?1783906078,Instant,BLUMOO
+Order of Succession,4,2013,0.47,#341aff,https://cards.scryfall.io/normal/front/1/1/11f68867-a46c-447f-9061-2bc4dbdde206.jpg?1783939681,Sorcery,Magali Villeneuve
+Ormos- Archive Keeper,6,2020,0.31,#341aff,https://cards.scryfall.io/normal/front/7/1/711412f1-9ab3-48b6-91a4-77232b416a32.jpg?1783930506,Legendary Creature — Sphinx,G-host Lee
+Orvar- the All-Form,4,2021,3.35,#341aff,https://cards.scryfall.io/normal/front/7/f/7f36775e-9e48-49cc-a771-d58481712edc.jpg?1783928258,Legendary Creature — Shapeshifter,Chase Stone
+Osgood- Operation Double,4,2023,0.24,#341aff,https://cards.scryfall.io/normal/front/d/1/d180a882-84d9-4e38-8aed-1fc6ecd1df72.jpg?1783914609,Legendary Creature — Human Alien Shapeshifter,Justyna Dura
+Otherworldly Gaze,1,2025,6.59,#341aff,https://cards.scryfall.io/normal/front/d/c/dc5f5440-3867-4b0a-b233-2d3b8b8b443a.jpg?1783906078,Instant,Molly Mendoza
+Overburden,2,2000,15.46,#341aff,https://cards.scryfall.io/normal/front/7/e/7e6cf6b6-b4c1-4742-9be4-b3b15fbb0202.jpg?1783945791,Enchantment,John Matson
+Overcharged Amalgam,4,2025,0.69,#341aff,https://cards.scryfall.io/normal/front/2/f/2fae9b40-a1ee-425d-bbf6-fa4b0861cdc4.jpg?1783908158,Creature — Zombie Horror,Mike Jordana
+Overflowing Insight,7,2017,0.44,#341aff,https://cards.scryfall.io/normal/front/f/6/f6b3dd8f-902e-45b8-a422-370705621294.jpg?1783935777,Sorcery,Lucas Graciano
+Overlord of the Floodpits,5,2024,1.96,#341aff,https://cards.scryfall.io/normal/front/5/f/5fca5de8-9cda-4370-9f72-4462f8cfd696.jpg?1783909491,Enchantment Creature — Avatar Horror,Abz J Harding
+Overtaker,2,1999,0.74,#341aff,https://cards.scryfall.io/normal/front/1/4/145903cb-9eaa-4f3c-a376-88dcd474ffda.jpg?1783945964,Creature — Merfolk Spellshaper,Clyde Caldwell
+Overwhelming Denial,4,2016,0.16,#341aff,https://cards.scryfall.io/normal/front/3/3/33ff1000-1a4e-43f6-aa02-1dbe9fac6901.jpg?1783937918,Instant,Jama Jurabaev
+Owlin Spiralmancer,4,2026,0.28,#341aff,https://cards.scryfall.io/normal/front/8/e/8e6266b5-9a02-4b06-b80c-048926a4eda7.jpg?1783903859,Creature — Bird Wizard,Matheus Graef
+Pact of Negation,0,2021,17.13,#341aff,https://cards.scryfall.io/normal/front/1/e/1ed4c0bb-b710-44a1-b8bc-6bd11c27b8b8.jpg?1783927843,Instant,Jason Chan
+Padeem- Consul of Innovation,4,2016,2.07,#341aff,https://cards.scryfall.io/normal/front/e/3/e31b30a7-13e8-408e-a758-60e6e9290808.jpg?1783937217,Legendary Creature — Vedalken Artificer,Matt Stewart
+Pale Moon,2,2000,0.42,#341aff,https://cards.scryfall.io/normal/front/a/e/aeb282bb-d0b8-4822-8197-ff0523549309.jpg?1783945834,Instant,Pete Venters
+Paradigm Shift,2,1997,5.46,#341aff,https://cards.scryfall.io/normal/front/e/6/e64a17a8-091d-4029-908e-31d6a050b479.jpg?1783946743,Sorcery,Cliff Nielsen
+Paradox Haze,3,2025,4.02,#341aff,https://cards.scryfall.io/normal/front/3/f/3f92e3ed-32f7-40e0-952d-08ca524579c3.jpg?1783905794,Enchantment — Aura,Stephen Andrade
+Paradoxical Outcome,4,2016,0.47,#341aff,https://cards.scryfall.io/normal/front/1/7/17e50157-bf49-4c5f-9b8a-bf73484e63a5.jpg?1783937215,Instant,Nils Hamm
+Parallax Tide,4,2000,19.16,#341aff,https://cards.scryfall.io/normal/front/7/f/7fe593eb-df3c-43e5-97a6-418f91e87cb3.jpg?1783945836,Enchantment,Carl Critchlow
+Parallel Thoughts,5,2003,1.59,#341aff,https://cards.scryfall.io/normal/front/d/9/d913c541-a8fb-4383-bbab-988be3e0f5d5.jpg?1783944885,Enchantment,Ben Thompson
+Part the Veil,4,2004,0.26,#341aff,https://cards.scryfall.io/normal/front/d/8/d870e607-1607-46f3-bc9f-925d0164bcf9.jpg?1783944324,Instant — Arcane,Arnie Swekel
+Part the Waterveil,6,2015,1.29,#341aff,https://cards.scryfall.io/normal/front/8/3/83fe992f-0441-42be-89f9-2387b4bc24ce.jpg?1783938208,Sorcery,Titus Lunter
+Patchwork Crawler,2,2021,0.22,#341aff,https://cards.scryfall.io/normal/front/6/b/6bb86ebf-f145-43c1-8f05-f4b55ded59b6.jpg?1783924886,Creature — Zombie Horror,Fesbra
+Path of the Enigma,5,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/0/8/0873cc1c-1285-4c39-936b-78fd8f93f3ad.jpg?1783917288,Sorcery,Jeremy Wilson
+Patient Rebuilding,5,2018,0.48,#341aff,https://cards.scryfall.io/normal/front/2/2/2256e07f-a35a-4393-9744-045564d5770b.jpg?1783934584,Enchantment,Magali Villeneuve
+Patrician Geist,3,2021,0.36,#341aff,https://cards.scryfall.io/normal/front/d/e/de2b0c63-c929-42ec-aada-dddb2a26550c.jpg?1783925634,Creature — Spirit Knight,Marta Nael
+Patron of the Moon,7,2005,3.58,#341aff,https://cards.scryfall.io/normal/front/5/e/5e5fcd6f-1653-44bf-a796-4c9ff9adf390.jpg?1783944204,Legendary Creature — Spirit,Scott M. Fischer
+Patron Wizard,3,2001,5.42,#341aff,https://cards.scryfall.io/normal/front/1/0/10b863b8-7780-4bbe-a7f8-46bfdcb34a2b.jpg?1783945259,Creature — Human Wizard,Donato Giancola
+Pearl Lake Ancient,7,2014,0.43,#341aff,https://cards.scryfall.io/normal/front/f/b/fbee4d2f-6b41-4717-a1c6-831034452bec.jpg?1783939087,Creature — Leviathan,Richard Wright
+Pedantic Learning,2,2001,0.5,#341aff,https://cards.scryfall.io/normal/front/6/7/67445332-0b56-4fec-8dcd-bb9a87194db5.jpg?1783945259,Enchantment,Heather Hudson
+Peer Pressure,4,2002,1.61,#341aff,https://cards.scryfall.io/normal/front/b/e/be0110ba-49e4-4729-8a84-4d408b20df53.jpg?1783945080,Sorcery,Edward P. Beard, Jr.
+Pendrell Mists,4,1997,12.7,#341aff,https://cards.scryfall.io/normal/front/b/9/b902b972-3a93-4e4e-aa77-02ada81e6b95.jpg?1783946741,Enchantment,Andrew Robinson
+Pensive Professor,3,2026,0.44,#341aff,https://cards.scryfall.io/normal/front/6/6/66d47940-84f9-4479-8562-45e5148435d4.jpg?1783903688,Creature — Human Wizard,Billy Christian
+Peregrine Drake,5,2024,16.77,#341aff,https://cards.scryfall.io/normal/front/d/0/d0915174-102d-4d86-b386-8647aa231f95.jpg?1783913096,Creature — Drake,Rowynn Ellis
+Perplexing Chimera,5,2014,3.09,#341aff,https://cards.scryfall.io/normal/front/f/9/f9cff40b-9cae-47d0-8df4-c287a17a33e4.jpg?1783939566,Enchantment Creature — Chimera,Tyler Jacobson
+Perplexing Test,5,2026,0.29,#341aff,https://cards.scryfall.io/normal/front/c/f/cf5fe687-91e0-4a2b-b973-3190c268a8e2.jpg?1783903793,Instant,Fariba Khamseh
+Personal Tutor,1,2023,6.0,#341aff,https://cards.scryfall.io/normal/front/2/8/2887fc25-22cd-48c9-ad2b-6539c8139e27.jpg?1783915692,Sorcery,Julie Dillon
+Persuasion,5,2001,0.45,#341aff,https://cards.scryfall.io/normal/front/7/d/7db5d930-23b4-4726-8f5c-3c690b36f4a4.jpg?1783945257,Enchantment — Aura,Adam Rex
+Phantasmal Image,2,2021,4.8,#341aff,https://cards.scryfall.io/normal/front/c/1/c1c080cf-a5e8-4d9d-af49-f78588971e87.jpg?1783926223,Creature — Illusion,Nils Hamm
+Phantasmal Sphere,2,1996,0.53,#341aff,https://cards.scryfall.io/normal/front/a/8/a84617c7-c70a-497c-b834-3d98346180cf.jpg?1783947194,Creature — Illusion,Mark Tedin
+Phantom Steed,4,2021,0.44,#341aff,https://cards.scryfall.io/normal/front/6/4/64513f0a-067d-4b70-bb23-9ebe606bda1a.jpg?1783926252,Creature — Horse Illusion,Brian Valeza
+Phantom Warrior,3,1999,1.25,#341aff,https://cards.scryfall.io/normal/front/7/f/7ff1dfcd-fa5b-4f7c-8369-b502711b382f.jpg?1783946042,Creature — Illusion Warrior,John Matson
+Phone a Friend,5,2022,0.25,#341aff,https://cards.scryfall.io/normal/front/d/a/da66e33a-3a11-494f-9c23-8e410f7cdae4.jpg?1783920594,Sorcery,Ben Wootten
+Phyrexian Ingester,7,2014,0.24,#341aff,https://cards.scryfall.io/normal/front/c/6/c633c12c-0f47-4212-bf87-4e444da0bf52.jpg?1783938848,Creature — Phyrexian Beast,Chris Rahn
+Phyrexian Metamorph,4,2025,2.28,#341aff,https://cards.scryfall.io/normal/front/a/5/a564c2e8-f49f-4ed7-850f-7c8bc92e4926.jpg?1783906041,Artifact Creature — Phyrexian Shapeshifter,Jana Schirmer & Johannes Voss
+Piper Wright- Publick Reporter,2,2024,0.33,#341aff,https://cards.scryfall.io/normal/front/9/1/916bf331-455a-4694-93d3-15dcf6971072.jpg?1783912412,Legendary Creature — Human Detective,Rafater
+Piracy,2,1999,64.44,#341aff,https://cards.scryfall.io/normal/front/3/2/323e3084-8d84-474f-b208-a4637b1ccb51.jpg?1783946043,Sorcery,Bradley Williams
+Pirated Copy,5,2026,7.51,#341aff,https://cards.scryfall.io/normal/front/e/9/e9c3a74f-6b39-42f6-a144-592f83846d9b.jpg?1783904218,Creature — Shapeshifter Pirate,Jim Lawson
+Pirate Ship,5,1997,1.0,#341aff,https://cards.scryfall.io/normal/front/b/7/b7ad5912-6d1e-4ad3-9911-0c768417d6d4.jpg?1783946944,Creature — Human Pirate,Tom Wänerstrand
+Plagiarize,4,2007,0.48,#341aff,https://cards.scryfall.io/normal/front/d/5/d59ae2f8-1e19-495a-86a9-8391e1e14ac5.jpg?1783943053,Instant,Jeremy Jarvis
+Plagon- Lord of the Beach,3,2024,1.09,#d78f42,https://cards.scryfall.io/normal/front/7/f/7f8a6bfe-6033-4f6b-ab45-6b553f8b51a1.jpg?1783908858,Legendary Creature — Starfish Wizard,GOSSAN
+Planar Overlay,3,2001,0.49,#341aff,https://cards.scryfall.io/normal/front/1/3/1315fef0-234e-44f5-a7a3-bf3db78943c3.jpg?1783945624,Sorcery,Ron Walotsky
+Planeswalker's Mischief,3,2001,0.41,#341aff,https://cards.scryfall.io/normal/front/7/9/79aa232c-3f16-4c68-99dc-09a7aeef477b.jpg?1783945625,Enchantment,Pete Venters
+Plate Spinning,5,2022,0.18,#341aff,https://cards.scryfall.io/normal/front/b/a/ba43188f-ac49-4c6a-b53c-9170fe047aa5.jpg?1783920592,Enchantment,Raluca Marinescu
+Political Trickery,3,1996,5.25,#341aff,https://cards.scryfall.io/normal/front/3/e/3e56e720-5e8b-4685-969c-e073de78b9a1.jpg?1783947106,Sorcery,Scott Kirschner
+Pol Jamaar- Illusionist,6,2024,0.78,#341aff,https://cards.scryfall.io/normal/front/6/3/63e806ee-3c32-48bf-97a1-160a74765e76.jpg?1783908859,Legendary Creature — Human Illusion Wizard,Kuregure
+Pollywog Prodigy,2,2024,6.07,#341aff,https://cards.scryfall.io/normal/front/9/4/94a020df-714b-4465-bfa2-ac15f27d8412.jpg?1783910733,Creature — Frog Wizard,Caroline Gariba
+Polymorph,4,2009,1.63,#341aff,https://cards.scryfall.io/normal/front/8/3/83d274f4-452b-4ff2-b026-83667e9ba98f.jpg?1783942389,Sorcery,Robert Bliss
+Polymorphist's Jest,3,2017,5.48,#341aff,https://cards.scryfall.io/normal/front/f/5/f5f935cb-4ec2-4131-878b-f8e557d848b9.jpg?1783935916,Instant,Craig J Spearing
+Polymorphous Rush,3,2014,0.17,#341aff,https://cards.scryfall.io/normal/front/2/f/2ff5f703-339f-430c-b342-77bcc2c63222.jpg?1783939445,Instant,Ryan Barger
+Ponder,1,2026,5.63,#341aff,https://cards.scryfall.io/normal/front/2/0/20edb8fa-6e26-46f7-a5a8-b4c4c3e75dfa.jpg?1783903401,Sorcery,Caleb Meurer
+Pongify,1,2026,3.18,#341aff,https://cards.scryfall.io/normal/front/5/7/5780936e-629d-4737-9005-651234f5426d.jpg?1783903929,Instant,Dominik Mayer
+Poppet Stitcher // Poppet Factory,3,2021,3.07,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Wizard // Artifact,Simon Dominic
+Portal Mage,3,2020,0.29,#341aff,https://cards.scryfall.io/normal/front/e/9/e9f6cb64-07e3-44ca-986c-fd10ab74cc8a.jpg?1783931184,Creature — Human Wizard,Yongjae Choi
+Portent of Calamity,1,2024,0.26,#341aff,https://cards.scryfall.io/normal/front/8/5/8599e2dd-9164-4da3-814f-adccef3b9497.jpg?1783910845,Sorcery,Sam Guay
+Possessed Aven,4,2002,0.39,#d78f42,https://cards.scryfall.io/normal/front/9/9/997c56c7-c625-4209-b4b6-d274dee2db48.jpg?1783945161,Creature — Bird Soldier Horror,Scott M. Fischer
+Possession Engine,5,2025,0.33,#341aff,https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg?1783907906,Artifact — Vehicle,Leroy Steinmann
+Precognition,5,1997,0.37,#341aff,https://cards.scryfall.io/normal/front/7/6/76a0e317-5a76-4eac-a903-b0e3f0a45873.jpg?1783946653,Enchantment,Jeff Miracola
+Precognition Field,4,2018,0.23,#341aff,https://cards.scryfall.io/normal/front/c/f/cf2a92ee-2b20-4299-84b2-b4963f4a42a1.jpg?1783935024,Enchantment,Adam Paquette
+Precognitive Perception,5,2019,0.32,#341aff,https://cards.scryfall.io/normal/front/7/2/724fd1ea-05ad-497c-9989-825ada48e684.jpg?1783933707,Instant,Chris Rallis
+Press the Enemy,4,2023,0.6,#341aff,https://cards.scryfall.io/normal/front/d/f/dfa5380a-480c-4c61-ac52-5debc49c5df9.jpg?1783916313,Instant,Valera Lutfullina
+Primordial Mist,5,2024,0.3,#341aff,https://cards.scryfall.io/normal/front/1/f/1f814aa9-f5e7-409c-82b5-45205d2b5f29.jpg?1783909624,Enchantment,Titus Lunter
+Prism Array,5,2015,0.1,#d78f42,https://cards.scryfall.io/normal/front/6/e/6e18c46d-dd6b-4feb-9eb3-3d52985ce6e1.jpg?1783938208,Enchantment,Philip Straub
+Prismatic Lace,1,1996,3.6,#341aff,https://cards.scryfall.io/normal/front/d/1/d1129585-6d59-4217-9404-747a100f1e8c.jpg?1783947104,Instant,David O'Connor
+Prodigal Sorcerer,3,2024,7.57,#341aff,https://cards.scryfall.io/normal/front/6/b/6bce5aeb-0087-4ac6-96d2-6b3df55e4266.jpg?1783910871,Creature — Human Wizard Sorcerer,Andreas Zafiratos
+Profaner of the Dead,4,2015,0.35,#341aff,https://cards.scryfall.io/normal/front/8/7/87630910-47cc-4347-b126-fd779e7dadc0.jpg?1783938605,Creature — Snake Wizard,Vincent Proce
+Professor Hulk,6,2026,2.84,#341aff,https://cards.scryfall.io/normal/front/1/b/1b03fa4e-b3a1-4c23-8341-e9ce89aa872f.jpg?1783903291,Legendary Creature — Gamma Scientist Hero,Leroy Steinmann
+Proft's Eidetic Memory,2,2024,2.03,#341aff,https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg?1783912906,Legendary Enchantment,Julie Dillon
+Prognostic Sphinx,5,2024,0.3,#341aff,https://cards.scryfall.io/normal/front/d/9/d9d36763-2975-4b5c-aeda-2d0159cb5191.jpg?1783909624,Creature — Sphinx,Jesper Ejsing
+Propaganda,3,2024,12.97,#341aff,https://cards.scryfall.io/normal/front/1/b/1b8aa419-dc96-4cd7-9e6a-c2d071df98d1.jpg?1783912021,Enchantment,Desmuncubic
+Prophet of the Scarab,5,2025,0.29,#341aff,https://cards.scryfall.io/normal/front/0/2/0208b947-78d9-45bd-855f-846d9a7c547d.jpg?1783907751,Creature — Zombie Wizard,Cristi Balanescu
+Prosperity,1,1997,8.57,#341aff,https://cards.scryfall.io/normal/front/2/6/269bb4fc-9d8f-42cc-8f71-6a658e41533c.jpg?1783946836,Sorcery,Phil Foglio
+Protean Thaumaturge,2,2020,0.41,#341aff,https://cards.scryfall.io/normal/front/7/4/749bfd81-c61b-4901-8efb-72611fd08244.jpg?1783931580,Creature — Human Wizard,Izzy
+Psionic Entity,5,1995,0.36,#341aff,https://cards.scryfall.io/normal/front/6/6/6641a587-c066-4f0a-a951-b91d3f749eb2.jpg?1783947854,Creature — Illusion,Justin Hampton
+Psionic Ritual,6,2022,0.39,#341aff,https://cards.scryfall.io/normal/front/9/e/9eb36d21-0136-4fee-a348-92a99b7c5305.jpg?1783922506,Sorcery,Aaron J. Riley
+Psionic Sliver,5,2006,1.99,#341aff,https://cards.scryfall.io/normal/front/2/5/2559ca03-4442-47c5-bd6e-84e71cfa6ca5.jpg?1783943242,Creature — Sliver,Wayne England
+Psychic Allergy,5,1994,3.37,#341aff,https://cards.scryfall.io/normal/front/f/e/fec3275e-4491-43a8-9f23-d7b48177c103.jpg?1783947941,Enchantment,Mark Tedin
+Psychic Battle,5,2000,1.06,#341aff,https://cards.scryfall.io/normal/front/8/7/8758ca24-e613-43bf-be58-4cf557f82d0c.jpg?1783945706,Enchantment,Ray Lago
+Psychic Corrosion,3,2024,22.3,#341aff,https://cards.scryfall.io/normal/front/7/a/7ac21208-eeab-49db-bd55-d2f2fad40c2a.jpg?1783909220,Enchantment,Peach Momoko
+Psychic Network,1,1998,1.11,#341aff,https://cards.scryfall.io/normal/front/6/0/60dfba09-9e75-4fb9-a163-40e3149f7785.jpg?1783946432,Enchantment,Claymore J. Flapdoodle
+Psychic Possession,4,2006,17.76,#341aff,https://cards.scryfall.io/normal/front/e/8/e8364ce0-4c11-4af0-9f4b-e4c20d640dfc.jpg?1783943437,Enchantment — Aura,Mark Tedin
+Psychic Surgery,2,2011,0.49,#341aff,https://cards.scryfall.io/normal/front/5/1/51ea9a6d-d6ca-48cb-adac-958ad0e7440c.jpg?1783941319,Enchantment,Anthony Francisco
+Psychic Theft,2,2000,0.26,#341aff,https://cards.scryfall.io/normal/front/f/6/f6f86c92-c19e-4f2c-96d3-d3b05623cb00.jpg?1783945791,Sorcery,Don Hazeltine
+Psychic Trance,4,2002,0.36,#341aff,https://cards.scryfall.io/normal/front/d/5/d5e55695-16cc-4373-8078-959f1ded4c6d.jpg?1783945079,Instant,Rebecca Guay
+Psychic Transfer,5,1999,0.19,#341aff,https://cards.scryfall.io/normal/front/a/c/ac6d7d5a-697b-4251-bc18-4dcfe0aa5cc6.jpg?1783946042,Sorcery,Dom!
+Psychic Vortex,4,1997,3.87,#341aff,https://cards.scryfall.io/normal/front/3/b/3bc2a419-7122-4eeb-bb64-738a647cfd82.jpg?1783946738,Enchantment,Steve Luke
+Puca's Mischief,4,2008,2.64,#341aff,https://cards.scryfall.io/normal/front/8/3/8380bd90-35f2-4936-995b-af6427f61752.jpg?1783942759,Enchantment,Scott Altmann
+Pull from Tomorrow,2,2026,0.27,#341aff,https://cards.scryfall.io/normal/front/7/4/74d8d661-a43f-4cee-87d5-1f74433a283e.jpg?1783903821,Instant,Ioannis Fiore
+Pulse of the Grid,3,2004,0.38,#341aff,https://cards.scryfall.io/normal/front/b/6/b6805341-fa4f-4d89-8003-b27280fadfbd.jpg?1783944447,Instant,Wayne England
+Pursued Whale,7,2022,0.21,#341aff,https://cards.scryfall.io/normal/front/f/1/f1ba925b-9216-4e37-814d-b061950b3998.jpg?1783922464,Creature — Whale,Jonathan Kuo
+Quantum Misalignment,5,2026,4.98,#341aff,https://cards.scryfall.io/normal/front/5/6/561caecd-e065-48f6-8fde-85b938794ed3.jpg?1783903239,Sorcery,Alexander Skripnikov
+Quantum Riddler,5,2025,32.63,#341aff,https://cards.scryfall.io/normal/front/1/2/120be808-ff3b-4fca-96a1-4db6b9825856.jpg?1783905977,Creature — Sphinx,Izzy
+Quasiduplicate,3,2024,0.73,#341aff,https://cards.scryfall.io/normal/front/f/0/f0b75745-08a8-432c-9175-d39a92406b3d.jpg?1783913334,Sorcery,Dmitry Burmak
+Quest for Ula's Temple,1,2010,4.81,#341aff,https://cards.scryfall.io/normal/front/7/7/77983bbf-6761-4126-82b4-bdcdd6b8e1dc.jpg?1783942061,Enchantment,Rob Alexander
+Quicken,1,2017,0.28,#341aff,https://cards.scryfall.io/normal/front/e/6/e6209bbf-5861-4755-abb6-0f04def9527e.jpg?1783936578,Instant,Aleksi Briclot
+Quicksilver Dragon,6,2014,0.41,#341aff,https://cards.scryfall.io/normal/front/a/8/a8943e2c-8a85-4ca4-a7b1-87b89e697877.jpg?1783938745,Creature — Dragon,Ron Spencer
+Quicksilver Elemental,5,2003,23.79,#341aff,https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg?1783944552,Creature — Elemental,Tony Szczudlo
+Quicksilver Gargantuan,7,2010,0.58,#341aff,https://cards.scryfall.io/normal/front/b/8/b83f5aea-80f2-4f3d-8508-9619413e0087.jpg?1783941738,Creature — Shapeshifter,Steven Belledin
+Quicksmith Spy,4,2017,0.22,#341aff,https://cards.scryfall.io/normal/front/0/f/0f922e87-1744-4966-9e3a-54917f7f3d9e.jpg?1783936769,Creature — Human Artificer,Ryan Alexander Lee
+Radstorm,4,2024,5.37,#341aff,https://cards.scryfall.io/normal/front/d/7/d778cdec-8fc7-4174-bae1-4c8e8ccdfab3.jpg?1783912412,Instant,Salvatorre Zee Yazzie
+Rainbow Efreet,4,1997,0.91,#341aff,https://cards.scryfall.io/normal/front/1/d/1d6f03a6-3665-40e4-ae68-640913972770.jpg?1783946998,Creature — Efreet,Nathalie Hertz
+Raise the Palisade,5,2023,10.08,#341aff,https://cards.scryfall.io/normal/front/7/9/7966eb7a-0ef7-470f-9769-0d5f45f0395b.jpg?1783916033,Sorcery,Jason Kang
+Ral's Dispersal,5,2018,0.18,#341aff,https://cards.scryfall.io/normal/front/a/2/a2660fae-6459-446d-85dc-3c9126c81cb3.jpg?1783934094,Instant,Lake Hurwitz
+Rangers of Ithilien,4,2023,0.23,#341aff,https://cards.scryfall.io/normal/front/8/1/819b4208-7a29-41fa-947f-614bf669b300.jpg?1783916313,Creature — Human Ranger,Torgeir Fjereide
+Ransack,4,1999,0.37,#341aff,https://cards.scryfall.io/normal/front/9/7/97b8db82-4632-40fd-b1e2-7172ddf8d6de.jpg?1783946042,Sorcery,Ron Spencer
+Rapid Hybridization,1,2022,17.02,#341aff,https://cards.scryfall.io/normal/front/4/2/423ed9cd-94d9-49a1-a167-69899b630f95.jpg?1783918771,Instant,kozyndan
+Rattlechains,2,2021,0.36,#341aff,https://cards.scryfall.io/normal/front/7/0/709f6376-9a33-4900-a7ae-00767fb9f9bf.jpg?1783924962,Creature — Spirit,Lius Lasahido
+Raven Guild Master,3,2003,1.03,#341aff,https://cards.scryfall.io/normal/front/9/8/9843f847-6a8f-4042-86b6-f7fe5a47cc57.jpg?1783944885,Creature — Human Wizard Mutant,Kev Walker
+Ray Fillet- Wave Warrior,3,2026,0.35,#341aff,https://cards.scryfall.io/normal/front/7/9/796c1b1c-c701-4c7e-922b-0964f04e03a6.jpg?1783904171,Legendary Creature — Fish Mutant,Brian Valeza
+Rayne- Academy Chancellor,3,1999,1.63,#341aff,https://cards.scryfall.io/normal/front/8/e/8ee6480c-7697-47e2-893b-ca88c0ab3376.jpg?1783946077,Legendary Creature — Human Wizard,Matthew D. Wilson
+Read the Runes,1,2020,0.67,#341aff,https://cards.scryfall.io/normal/front/2/c/2c65088f-bbbd-4e8d-b482-58181069bef2.jpg?1783930450,Instant,Alan Pollack
+Reality Shift,2,2024,4.9,#341aff,https://cards.scryfall.io/normal/front/4/9/49c2488c-c252-42a6-b487-c358c16b7ae1.jpg?1783909715,Instant,Jeff Easley
+Reality Twist,3,1995,2.63,#d78f42,https://cards.scryfall.io/normal/front/1/b/1b7e955c-3de2-430c-93b9-0b39ccea5420.jpg?1783947510,Enchantment,James Ernest
+Realmwright,1,2013,0.28,#341aff,https://cards.scryfall.io/normal/front/9/8/989c76b2-d130-443d-8534-6525fef404c2.jpg?1783940135,Creature — Vedalken Wizard,Slawomir Maniak
+Recall,1,1999,0.92,#341aff,https://cards.scryfall.io/normal/front/7/9/791af96f-1de9-46f2-a1e5-93921c4905c7.jpg?1783946195,Sorcery,Brian Snõddy
+Recantation,5,1998,0.46,#341aff,https://cards.scryfall.io/normal/front/9/5/95479839-779e-4dbe-8989-ccf26cc488fe.jpg?1783946357,Enchantment,Greg Simanson
+Reconnaissance Mission,4,2026,1.06,#341aff,https://cards.scryfall.io/normal/front/8/7/875dfbf5-9313-439b-b021-8b92d898baa4.jpg?1783903317,Enchantment,Kaare Andrews
+Redirect,2,2012,0.31,#341aff,https://cards.scryfall.io/normal/front/0/e/0eef8431-f63c-44e0-940c-e1a38c338214.jpg?1783940504,Instant,Izzy
+Reduce to Dreams,5,2005,0.55,#341aff,https://cards.scryfall.io/normal/front/1/0/10962b1b-4039-4d8a-88e0-fc67537920a9.jpg?1783944204,Sorcery,Daren Bader
+Reed Richards- Smartest Man,6,2026,1.47,#341aff,https://cards.scryfall.io/normal/front/0/4/040dfd14-57e1-4f28-a42b-6d8874b44fea.jpg?1783903069,Legendary Creature — Human Scientist Hero,David Palumbo
+Reef Worm,4,2021,0.33,#341aff,https://cards.scryfall.io/normal/front/e/7/e715bb21-db06-475a-b71e-4f2313817b8d.jpg?1783927562,Creature — Worm,Dan Murayama Scott
+Reenact the Crime,4,2024,0.28,#341aff,https://cards.scryfall.io/normal/front/d/9/d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg?1783912905,Instant,Daarken
+Reflections of Littjara,5,2025,2.39,#341aff,https://cards.scryfall.io/normal/front/5/7/578a1846-8c1a-4013-b669-1d3f4ddbbaa3.jpg?1783907098,Enchantment,Aaron Miller
+Reins of Power,4,2022,3.08,#341aff,https://cards.scryfall.io/normal/front/9/b/9b5730aa-c74a-4c74-bb1b-a133a3c353ec.jpg?1783922462,Instant,John Severin Brassell
+Release to the Wind,3,2018,0.74,#341aff,https://cards.scryfall.io/normal/front/4/b/4b4f72ef-3939-467c-8fe4-fd1c215f2b1e.jpg?1783935323,Instant,Joseph Meehan
+Relic Bind,3,1995,0.4,#341aff,https://cards.scryfall.io/normal/front/0/5/05eee3dd-e17f-4154-8f8d-29c5421cd89d.jpg?1783947854,Enchantment — Aura,Christopher Rush
+Remove Soul,2,2009,1.53,#341aff,https://cards.scryfall.io/normal/front/6/7/675440ff-9701-4310-a4ad-8502b9cb73ae.jpg?1783942498,Instant,Mike Dringenberg
+Renegade Doppelganger,2,2010,0.5,#341aff,https://cards.scryfall.io/normal/front/f/6/f6453040-38a3-4d3a-8e4b-51b72aa80186.jpg?1783941992,Creature — Shapeshifter,James Ryman
+Renet- Temporal Apprentice,5,2026,0.25,#341aff,https://cards.scryfall.io/normal/front/2/a/2ae30766-c858-4f4e-a042-14af55698cb2.jpg?1783904111,Legendary Creature — Human Wizard,Yuhong Ding
+Replication Technique,5,2026,0.27,#341aff,https://cards.scryfall.io/normal/front/b/3/b3149976-2811-4bbd-af1e-d59016bb0754.jpg?1783903791,Sorcery,Viko Menezes
+Repulsor Bots,6,2026,1.04,#341aff,https://cards.scryfall.io/normal/front/a/9/a9982511-0486-4d23-9932-78dc52f846f3.jpg?1783903103,Artifact Creature — Robot Hero,Milivoj Ćeran
+Repurposing Bay,3,2025,0.67,#341aff,https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg?1783907906,Artifact,William Tempest
+Resculpt,2,2025,2.34,#341aff,https://cards.scryfall.io/normal/front/5/9/5981ff16-9d0f-4b4f-ae90-6b54db1f60f9.jpg?1783906663,Instant,Imiri Sakabashira
+Research Thief,5,2022,1.64,#341aff,https://cards.scryfall.io/normal/front/d/0/d0ef159d-657a-4566-b9e0-f545df230025.jpg?1783923994,Artifact Creature — Moonfolk Wizard,Cristi Balanescu
+Reservoir Kraken,4,2022,0.37,#341aff,https://cards.scryfall.io/normal/front/5/3/53cf9152-da16-4289-9a2d-331e7b9cb839.jpg?1783923140,Creature — Kraken,Nicholas Gregory
+Reshape,2,2020,4.54,#341aff,https://cards.scryfall.io/normal/front/8/f/8f8a8f14-bced-4388-b263-5e70431b191f.jpg?1783930192,Sorcery,Jon Foster
+Retraced Image,1,2002,8.65,#341aff,https://cards.scryfall.io/normal/front/c/6/c62fa778-ce44-4a3e-958a-91dfe5398944.jpg?1783945161,Sorcery,Greg Staples
+Retract,1,2004,5.61,#341aff,https://cards.scryfall.io/normal/front/4/e/4e09a443-0a00-458a-b351-8cb188e9218c.jpg?1783944447,Instant,Matt Cavotta
+Retreat to Coralhelm,3,2022,5.68,#341aff,https://cards.scryfall.io/normal/front/3/d/3d268b09-acc7-474d-86be-537d6449755c.jpg?1783922249,Enchantment,Kelogsloops
+Reveka- Wizard Savant,4,1995,0.79,#341aff,https://cards.scryfall.io/normal/front/a/9/a952236e-3085-4e6e-8639-355976b7c8f5.jpg?1783947294,Legendary Creature — Dwarf Wizard,Susan Van Camp
+Reverberation,4,1994,25.85,#341aff,https://cards.scryfall.io/normal/front/a/3/a3d1f470-058d-41b7-acaf-4f68431de9ed.jpg?1783948072,Instant,Justin Hampton
+Reverse the Polarity,3,2023,0.45,#341aff,https://cards.scryfall.io/normal/front/7/6/76f3ea66-555c-490d-b34f-12c267bc4e9b.jpg?1783914663,Instant,Randy Gallegos
+Reweave,6,2004,0.57,#341aff,https://cards.scryfall.io/normal/front/4/f/4ff68016-80b4-4801-b796-5c5fdbc8faa1.jpg?1783944322,Instant — Arcane,Alex Horley-Orlandelli
+Rewind,4,2023,9.04,#341aff,https://cards.scryfall.io/normal/front/0/3/0374cd0e-d06a-4976-9483-202015c845ff.jpg?1783914801,Instant,Julie Dillon & Scott Okumura
+Rhet-Tomb Mystic,2,2025,0.32,#341aff,https://cards.scryfall.io/normal/front/1/3/131a68e6-09ee-4afd-a0e1-d63bbc0775e8.jpg?1783907752,Creature — Zombie Bird Wizard,Irina Nordsol
+Rhystic Study,3,2022,69.85,#341aff,https://cards.scryfall.io/normal/front/9/f/9f37c5b6-a59c-45cd-9a99-e9357fe9ea1b.jpg?1783919146,Enchantment,Tatiana Kirgetova
+Rhythmic Water Vortex,5,2018,0.21,#341aff,https://cards.scryfall.io/normal/front/b/e/be82ea29-66d4-471d-bef7-c6524207b96d.jpg?1783934631,Sorcery,Xin-Yu Liu
+Richard Garfield- Ph.D.,5,2020,0.32,#341aff,https://cards.scryfall.io/normal/front/6/1/616a3755-f08c-4b8f-954b-7e3f3a8fa71f.jpg?1783931341,Legendary Creature — Human Designer,Dave Dorman
+Riddlekeeper,3,2018,12.37,#341aff,https://cards.scryfall.io/normal/front/5/7/57ad1d92-0c91-4a43-a4d3-c2250b9fe23e.jpg?1783934764,Creature — Homunculus,Steve Prescott
+Riddlemaster Sphinx,6,2019,0.18,#341aff,https://cards.scryfall.io/normal/front/7/9/7980e24c-bcb4-479c-8012-f19f4e87f0bf.jpg?1783932908,Creature — Sphinx,Ryan Yee
+Rimefeather Owl,7,2006,1.81,#341aff,https://cards.scryfall.io/normal/front/7/e/7e8e3552-a251-4a80-b0bb-a96a9f8a4c56.jpg?1783943357,Snow Creature — Bird,Kensuke Okabayashi
+Rimefire Torque,2,2026,0.26,#341aff,https://cards.scryfall.io/normal/front/4/f/4f8931b2-ff3f-4167-8a40-f33460c2d27e.jpg?1783904482,Artifact,Jorge Jacinto
+Ripples of Potential,2,2025,3.34,#341aff,https://cards.scryfall.io/normal/front/8/e/8e724c6d-3922-406f-b9e6-e478e1039416.jpg?1783906041,Instant,Sam Hogg
+Riptide Director,4,2003,0.67,#341aff,https://cards.scryfall.io/normal/front/2/8/28d07de3-b176-4ac7-aaa7-497c06c08b55.jpg?1783944919,Creature — Human Wizard,Scott M. Fischer
+Riptide Entrancer,3,2002,1.38,#341aff,https://cards.scryfall.io/normal/front/2/c/2cd9abc9-f289-4294-bc0f-4addc8b92a4e.jpg?1783945078,Creature — Human Wizard,Scott Hampton
+Riptide Mangler,2,2003,0.37,#341aff,https://cards.scryfall.io/normal/front/5/3/5314a802-85d6-4d7b-ae9a-ca64eec652cf.jpg?1783944919,Creature — Beast,Arnie Swekel
+Rise and Shine,2,2023,0.37,#341aff,https://cards.scryfall.io/normal/front/8/1/816716d6-4234-4570-9a64-cb3bef388095.jpg?1783917166,Sorcery,Franz Vohwinkel
+Rishadan Brigand,5,1999,0.81,#341aff,https://cards.scryfall.io/normal/front/a/6/a6efb653-97d8-4bc7-af8f-0b09fda655ff.jpg?1783945963,Creature — Human Pirate,Scott Hampton
+Rishadan Dockhand,1,2021,0.2,#341aff,https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg?1783926871,Creature — Merfolk,Manuel Castañón
+Rising Waters,4,2000,2.06,#341aff,https://cards.scryfall.io/normal/front/e/c/ec9c84db-cf45-43e1-b38f-8bbf53cf088b.jpg?1783945834,Enchantment,Scott M. Fischer
+Rite of Replication,4,2026,0.29,#341aff,https://cards.scryfall.io/normal/front/5/0/5032d71d-d9f8-498c-97d1-271c2e9c1c47.jpg?1783903790,Sorcery,Matt Cavotta
+Riverchurn Monument,2,2025,1.98,#341aff,https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg?1783907906,Artifact,Anthony Devine
+River Kelpie,5,2025,0.29,#341aff,https://cards.scryfall.io/normal/front/7/2/7203136a-2556-4489-ae1e-1ff13a488f39.jpg?1783907097,Creature — Beast,Jeff Easley
+River Merfolk,2,1994,1.07,#341aff,https://cards.scryfall.io/normal/front/2/7/27d7fa54-4b89-4a9a-b088-4b89c525c1ea.jpg?1783947910,Creature — Merfolk,Douglas Shuler
+River's Rebuke,6,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg?1783908932,Sorcery,Raymond Swanland
+Robe of the Archmagi,3,2022,0.49,#341aff,https://cards.scryfall.io/normal/front/7/4/74feb29b-5169-44d7-bded-c2c94718e61f.jpg?1783922779,Artifact — Equipment,Dallas Williams
+Rod of Absorption,3,2021,0.49,#341aff,https://cards.scryfall.io/normal/front/5/9/59e9e244-bb8e-4346-b06b-4af987473442.jpg?1783926252,Artifact,Svetlin Velinov
+Roil Elemental,6,2009,14.83,#341aff,https://cards.scryfall.io/normal/front/6/6/66139c73-8e14-433d-bcb6-ae3e518bcdfb.jpg?1783942161,Creature — Elemental,Raymond Swanland
+Rona- Herald of Invasion // Rona- Tolarian Obliterator,2,2023,1.68,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Wizard // Legendary Creature — Phyrexian Wizard,Victor Adame Minguez
+Rooftop Storm,6,2025,2.5,#341aff,https://cards.scryfall.io/normal/front/3/1/31146f03-cb5e-4f33-aad7-ce970b914d90.jpg?1783908155,Enchantment,John Stanko
+Rootwater Matriarch,4,2007,0.55,#341aff,https://cards.scryfall.io/normal/front/0/9/09179261-aa02-4144-9028-3b8d6420a860.jpg?1783943051,Creature — Merfolk,Daren Bader
+Rootwater Shaman,3,1997,0.68,#341aff,https://cards.scryfall.io/normal/front/c/a/caa1b84b-efda-4324-9106-0d1d00385cdc.jpg?1783946651,Creature — Merfolk Shaman,Paolo Parente
+Rootwater Thief,2,2000,2.4,#341aff,https://cards.scryfall.io/normal/front/3/8/38addef3-1dd7-41a1-9706-3be5c86a58c9.jpg?1783945833,Creature — Merfolk Rogue,Ron Spears
+Rose Noble,4,2023,8.98,#341aff,https://cards.scryfall.io/normal/front/3/9/39edd98a-2ee9-4799-9194-5b5a3efb6255.jpg?1783913388,Legendary Creature — Human,Justyna Dura
+Rowan- Scholar of Sparks // Will- Scholar of Frost,3,2021,1.97,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Planeswalker — Rowan // Legendary Planeswalker — Will,Magali Villeneuve
+Ruin Crab,1,2026,3.5,#341aff,https://cards.scryfall.io/normal/front/f/7/f754499b-8b56-4be7-aecd-fdebde81fb41.jpg?1784458000,Creature — Crab,Nicholas Gregory
+Sage-Eye Avengers,6,2017,0.09,#341aff,https://cards.scryfall.io/normal/front/0/2/026e33ed-2f2d-4345-8a89-58c9f2f6c727.jpg?1783936579,Creature — Djinn Monk,Dan Murayama Scott
+Sage of Hours,2,2014,12.62,#341aff,https://cards.scryfall.io/normal/front/8/c/8cb55caf-fc95-40dc-80af-5144f94333ee.jpg?1783939443,Creature — Human Wizard,Matt Stewart
+Sage of Lat-Nam,2,2003,0.18,#341aff,https://cards.scryfall.io/normal/front/2/8/28ac8823-9bc0-4d15-a7ab-0d106167a0e5.jpg?1783944789,Creature — Human Artificer,Alan Pollack
+Sage of the Beyond,7,2024,1.09,#341aff,https://cards.scryfall.io/normal/front/2/2/226a4c5d-bf49-40d8-a7a4-341c18029634.jpg?1783911936,Creature — Spirit Giant,Cristi Balanescu
+Saheeli's Artistry,6,2023,0.35,#341aff,https://cards.scryfall.io/normal/front/4/c/4cdfb468-e475-47e6-80f5-190c9b206e70.jpg?1783917167,Sorcery,Kieran Yanner
+Sai- Master Thopterist,3,2023,0.64,#341aff,https://cards.scryfall.io/normal/front/a/d/ad0b5c09-5075-408e-84c5-1095354ac53e.jpg?1783915691,Legendary Creature — Human Artificer,Adam Paquette
+Sakashima of a Thousand Faces,4,2020,33.95,#341aff,https://cards.scryfall.io/normal/front/7/1/714c3a1f-7b30-4ed8-8f38-6176758741fb.jpg?1783928853,Legendary Creature — Human Rogue,Jason A. Engle
+Sakashima's Protege,6,2020,0.47,#341aff,https://cards.scryfall.io/normal/front/c/c/cce06cd4-099b-445f-af95-76564ee24668.jpg?1783928853,Creature — Shapeshifter,Tyler Walpole
+Sakashima's Student,4,2016,24.29,#341aff,https://cards.scryfall.io/normal/front/9/1/91b0a6cb-1c2e-4122-8874-a48e69e1c464.jpg?1783936839,Creature — Human Ninja,Brian Snõddy
+Sakashima's Will,4,2020,0.4,#341aff,https://cards.scryfall.io/normal/front/c/a/ca9fd318-ffb2-40d0-b1e0-e951d7735f78.jpg?1783928852,Sorcery,Volkan Baǵa
+Sakashima the Impostor,4,2005,17.98,#341aff,https://cards.scryfall.io/normal/front/6/1/61dc2f54-3637-4caa-9741-36ff14dc5527.jpg?1783944160,Legendary Creature — Human Rogue,rk post
+Sand Squid,4,1999,0.61,#341aff,https://cards.scryfall.io/normal/front/4/e/4efd7ce9-b920-409d-a4d2-a07fff280712.jpg?1783945962,Creature — Squid Beast,Kev Walker
+Sanity Grinding,3,2008,1.34,#341aff,https://cards.scryfall.io/normal/front/7/d/7d3e377f-6bb7-4fa1-b58b-7e2af06ca4b7.jpg?1783942689,Sorcery,Lars Grant-West
+Sapphire Leech,2,2000,0.31,#341aff,https://cards.scryfall.io/normal/front/e/6/e6763ffd-9d89-4f26-871a-be24fbdef38d.jpg?1783945704,Creature — Leech,Ron Spencer
+Saprazzan Bailiff,5,1999,0.46,#341aff,https://cards.scryfall.io/normal/front/a/9/a9f50964-1b57-426a-ac46-c90c045c7e40.jpg?1783945962,Creature — Merfolk,Ron Spencer
+Saprazzan Heir,2,1999,1.95,#341aff,https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg?1783945961,Creature — Merfolk,Terese Nielsen
+Savor the Moment,3,2008,9.07,#341aff,https://cards.scryfall.io/normal/front/9/3/93a0d9ad-31bf-4561-a5b2-f44a12a2c2c2.jpg?1783942758,Sorcery,Warren Mahy
+Scalpelexis,5,2007,0.28,#341aff,https://cards.scryfall.io/normal/front/a/d/ad3ca697-bdf4-41df-973d-22a0ce89ad35.jpg?1783943050,Creature — Beast,Mark Tedin
+Scatter to the Winds,3,2015,0.16,#341aff,https://cards.scryfall.io/normal/front/d/7/d73ad49f-fe15-4fe5-9731-fd71d31c1e7f.jpg?1783938207,Instant,Raymond Swanland
+Scepter of Insight,3,2009,0.17,#341aff,https://cards.scryfall.io/normal/front/8/a/8ac51021-e66c-4cd1-b54f-031b69d9699f.jpg?1783942486,Artifact,Steven Belledin
+Schema Thief,4,2023,0.36,#341aff,https://cards.scryfall.io/normal/front/9/6/963fa041-5388-4fe5-97f6-2cd0e61808ce.jpg?1783917286,Creature — Vedalken Rogue Artificer,Artur Treffner
+Scholar of the Lost Trove,7,2020,0.26,#341aff,https://cards.scryfall.io/normal/front/a/a/aa254a86-3c30-408d-9c14-befd472f9740.jpg?1783930505,Creature — Sphinx,Volkan Baǵa
+Scion of Oona,3,2013,13.72,#341aff,https://cards.scryfall.io/normal/front/a/2/a29f95fe-2efa-4788-84d8-2bd88d8650b4.jpg?1783939995,Creature — Faerie Soldier,Eric Fortune
+Scourge of Fleets,7,2020,2.5,#341aff,https://cards.scryfall.io/normal/front/a/7/a79471f9-5cc0-48f5-9fa4-1f1374993825.jpg?1783928720,Creature — Kraken,Steven Belledin
+Scroll of Isildur,3,2023,1.13,#341aff,https://cards.scryfall.io/normal/front/1/9/195821f4-ba3d-4412-930f-f3656b319dfd.jpg?1783916311,Enchantment — Saga,Audrey Benjaminsen
+Sea-Dasher Octopus,3,2020,1.37,#341aff,https://cards.scryfall.io/normal/front/a/6/a6f59d9e-6c1b-437a-934c-7c776c8dd1d5.jpg?1783931070,Creature — Octopus,Chris Seaman
+Seafloor Oracle,4,2023,0.29,#341aff,https://cards.scryfall.io/normal/front/a/7/a746c2ff-60f3-41c4-853d-e5159d005bea.jpg?1783913883,Creature — Merfolk Wizard,Simon Dominic
+Sea Gate Loremaster,5,2009,6.69,#341aff,https://cards.scryfall.io/normal/front/5/c/5cd723c8-4b3d-4fbb-a825-79934279382d.jpg?1783942160,Creature — Merfolk Wizard Ally,Dave Kendall
+Sea Gate Restoration // Sea Gate- Reborn,7,2020,39.95,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Land,Adam Paquette
+Sea Gate Stormcaller,2,2020,0.32,#341aff,https://cards.scryfall.io/normal/front/1/e/1e14e677-9bfa-4bcc-9772-8e7758d7538a.jpg?1783929387,Creature — Human Wizard,Anna Steinbauer
+Seahunter,4,2000,3.66,#341aff,https://cards.scryfall.io/normal/front/c/3/c375f65a-6d88-4d3c-a7a7-8c7a5cc5807f.jpg?1783945833,Creature — Human Mercenary,Heather Hudson
+Search for Azcanta // Azcanta- the Sunken Ruin,2,2017,1.8,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Enchantment // Legendary Land,Magali Villeneuve
+Search the City,5,2012,0.13,#341aff,https://cards.scryfall.io/normal/front/9/c/9cd77575-fedc-45b1-a53b-dfed0f34c875.jpg?1783940366,Enchantment,Jack Wang
+Season of Weaving,6,2024,4.57,#341aff,https://cards.scryfall.io/normal/front/f/5/f5713bb4-bdd9-4253-b6b9-e590532ed773.jpg?1783910844,Sorcery,Wylie Beckert
+Second Chance,3,1999,6.3,#341aff,https://cards.scryfall.io/normal/front/6/2/62d1a0da-40b9-4e79-bace-b93f98ae4695.jpg?1783946245,Enchantment,Mark Tedin
+Secret Invasion,3,2026,0.26,#341aff,https://cards.scryfall.io/normal/front/e/3/e361b2f4-cd2f-44e9-a56d-c1d6b5ae742d.jpg?1783902953,Enchantment — Aura,Nino Is
+Secret of Bloodbending,4,2025,1.15,#341aff,https://cards.scryfall.io/normal/front/9/b/9bb928ae-f636-4aee-9146-a7885e6a8976.jpg?1783904982,Sorcery — Lesson,Olena Richards
+Secrets of the Dead,3,2026,3.69,#341aff,https://cards.scryfall.io/normal/front/0/b/0b0a7009-bf57-4367-b59e-314348876f8c.jpg?1783904225,Enchantment,Alix Branwyn
+See Double,4,2023,0.86,#341aff,https://cards.scryfall.io/normal/front/4/1/41634103-7b58-4feb-84b7-90a07a7b474f.jpg?1783917024,Instant,Marc Simonetti
+See the Truth,2,2020,0.52,#341aff,https://cards.scryfall.io/normal/front/9/1/91af15cc-fdd5-4d72-a53a-314fa5353527.jpg?1783930719,Sorcery,Ekaterina Burmak
+Selective Memory,4,2010,0.38,#341aff,https://cards.scryfall.io/normal/front/5/5/555063cc-99ad-4014-b17b-c4c6b40d2e81.jpg?1783942061,Sorcery,Chippy
+Senator Peacock,5,2024,0.38,#341aff,https://cards.scryfall.io/normal/front/8/7/8778b33c-efab-4b65-b6e3-f0e3d1d8f937.jpg?1783912585,Legendary Creature — Human Advisor,Aurore Folny
+Serendib Efreet,3,2020,0.14,#341aff,https://cards.scryfall.io/normal/front/3/0/30032a0b-dece-42a4-9309-fa9e9e277603.jpg?1783930446,Creature — Efreet,Matt Stewart
+Serendib Sorcerer,3,2017,0.27,#341aff,https://cards.scryfall.io/normal/front/5/2/5270c9cb-f322-4a21-b985-be8670c317cb.jpg?1783935914,Creature — Human Wizard Sorcerer,Dan Murayama Scott
+Serpent of Yawning Depths,6,2020,7.48,#341aff,https://cards.scryfall.io/normal/front/a/4/a4ac18ae-0d1e-43f5-9cc9-722fa6e36fe5.jpg?1783931490,Enchantment Creature — Serpent,Tomasz Jedruszek
+Serra Sphinx,5,2007,0.32,#341aff,https://cards.scryfall.io/normal/front/f/9/f9a4d7ac-082b-4f66-9b7f-4d1d0fda78c7.jpg?1783943157,Creature — Sphinx,Daren Bader
+Serum Sovereign,5,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/7/0/70d562aa-8b49-40a3-a5c1-3af8afa98edc.jpg?1783917920,Creature — Phyrexian Sphinx,Chris Rallis
+Serum Visions,1,2025,5.04,#341aff,https://cards.scryfall.io/normal/front/9/e/9ec1b99c-82c0-4845-b46b-a2127d64ed5a.jpg?1783905156,Sorcery,Justin Gerard
+Shacklegeist,2,2021,0.21,#341aff,https://cards.scryfall.io/normal/front/d/6/d69b40d5-25e7-4c59-b00a-aa7d7367504e.jpg?1783924961,Creature — Spirit,Igor Kieryluk
+Shadow Kin,4,2021,0.86,#341aff,https://cards.scryfall.io/normal/front/0/0/00ca621f-c409-4255-828b-c9957e82c06f.jpg?1783925380,Creature — Shapeshifter,Irvin Rodriguez
+Shadow of the Second Sun,6,2024,0.86,#341aff,https://cards.scryfall.io/normal/front/0/d/0da72736-574d-4d99-98ba-3a91c374cd10.jpg?1783911288,Enchantment — Aura,Danny Schwartz
+Shadow Puppeteers,7,2023,3.38,#341aff,https://cards.scryfall.io/normal/front/2/a/2ad71a49-8a93-462f-a2c3-9362b33481fa.jpg?1783914989,Creature — Faerie Wizard,Cristi Balanescu
+Shameless Charlatan,2,2022,0.26,#341aff,https://cards.scryfall.io/normal/front/e/6/e65ad0e2-8f78-4e60-a97e-1cd20901680f.jpg?1783922778,Legendary Enchantment — Background,Inka Schulz
+Shape Anew,4,2010,0.71,#341aff,https://cards.scryfall.io/normal/front/b/3/b3d5462e-f60c-4550-b29e-4d9f9cd72385.jpg?1783941737,Sorcery,Zoltan Boros & Gabor Szikszai
+Shapesharer,2,2007,6.17,#341aff,https://cards.scryfall.io/normal/front/e/1/e148481d-a969-40d9-9335-d0e06ad8245b.jpg?1783942897,Creature — Shapeshifter,Alan Pollack
+Shapeshifter's Marrow,4,2007,0.37,#341aff,https://cards.scryfall.io/normal/front/4/8/48cb3fa8-555f-4df6-994e-cf01896f7470.jpg?1783943116,Enchantment,Chippy
+Sharding Sphinx,6,2023,0.36,#341aff,https://cards.scryfall.io/normal/front/1/d/1d93d905-cc36-4a78-b07c-07f8bbf39a47.jpg?1783917166,Artifact Creature — Sphinx,Michael Bruinsma
+Shared Fate,5,2003,0.65,#341aff,https://cards.scryfall.io/normal/front/a/d/ad0d5b02-ef38-4dab-8ac6-78814ef27b55.jpg?1783944552,Enchantment,Matt Cavotta
+Shark Typhoon,6,2024,1.53,#341aff,https://cards.scryfall.io/normal/front/2/b/2b2accb1-d77b-4633-9d0c-b972d9c014bb.jpg?1783909622,Enchantment,Caio Monteiro
+Shield Broker,5,2022,0.24,#341aff,https://cards.scryfall.io/normal/front/a/3/a319afae-019c-408d-a57b-b7bf0b1598bd.jpg?1783923369,Creature — Octopus Advisor,Daniel Ljunggren
+S.H.I.E.L.D. Flying Car,3,2026,0.18,#341aff,https://cards.scryfall.io/normal/front/8/e/8e651410-b829-4468-b866-a9dd15f909ad.jpg?1783902952,Artifact — Vehicle,Paulius Daščioras
+Shifting Sky,3,2003,0.39,#341aff,https://cards.scryfall.io/normal/front/f/e/fed441d0-b8c8-4d63-80ff-cc4fb47d0b26.jpg?1783944787,Enchantment,Jerry Tiritilli
+Shifty Doppelganger,3,2001,0.5,#341aff,https://cards.scryfall.io/normal/front/5/3/538ffe1e-c312-4797-99dd-9bf5f896bdc3.jpg?1783945256,Creature — Shapeshifter,Greg Staples
+Shimmer,4,1996,2.71,#341aff,https://cards.scryfall.io/normal/front/5/c/5c892daa-57fe-4712-b64a-6099d531bb26.jpg?1783947102,Enchantment,David A. Cherry
+Shimmer Dragon,6,2024,0.37,#341aff,https://cards.scryfall.io/normal/front/3/9/3983a11e-8a8a-4d9d-868b-13e0c3719abb.jpg?1783913013,Creature — Dragon,Lie Setiawan
+Shipbreaker Kraken,6,2020,0.36,#341aff,https://cards.scryfall.io/normal/front/2/e/2e558f0a-f921-4ecf-b1c9-2c93aa2d3fd9.jpg?1783928718,Creature — Kraken,Jack Wang
+Shorecrasher Elemental,3,2015,0.29,#341aff,https://cards.scryfall.io/normal/front/e/8/e8890fc6-45e9-443d-ae86-f1acb1ebd0aa.jpg?1783938604,Creature — Elemental,Igor Kieryluk
+Show and Tell,3,2016,19.63,#341aff,https://cards.scryfall.io/normal/front/f/a/fa7b7897-36e0-415a-8bb7-602886164852.jpg?1783937320,Sorcery,Zack Stella
+Shrouded Serpent,7,2000,0.3,#341aff,https://cards.scryfall.io/normal/front/d/3/d3d9035b-b6ec-479f-b697-3e5c3110ef10.jpg?1783945788,Creature — Serpent,Dana Knutson
+Shu Yun- the Silent Tempest,3,2015,0.33,#d78f42,https://cards.scryfall.io/normal/front/b/d/bd79e83a-a34b-472c-9317-12af4ed2ca28.jpg?1783938703,Legendary Creature — Human Monk,David Gaillet
+Shyft,5,1995,0.38,#341aff,https://cards.scryfall.io/normal/front/9/9/99a60c33-b641-42c4-870d-95d07bc975dc.jpg?1783947510,Creature — Shapeshifter,Richard Thomas
+Sigil Tracer,3,2008,8.14,#341aff,https://cards.scryfall.io/normal/front/7/c/7c9341e6-b899-418d-916f-550775af419f.jpg?1783942796,Creature — Merfolk Wizard,Dan Murayama Scott
+Silent Hallcreeper,2,2024,1.82,#341aff,https://cards.scryfall.io/normal/front/a/a/aac4f0cc-63be-4f08-956e-39839c9735ba.jpg?1783909489,Enchantment Creature — Horror,Joshua Raphael
+Silent Submersible,2,2019,0.24,#341aff,https://cards.scryfall.io/normal/front/a/e/ae2f3dee-1768-4562-9333-a50b9ee7570f.jpg?1783933458,Artifact — Vehicle,Daniel Ljunggren
+Silver Scrutiny,2,2022,0.32,#341aff,https://cards.scryfall.io/normal/front/8/b/8b650ab6-9c22-424f-99e5-8ef5235a18a3.jpg?1783921345,Sorcery,Donato Giancola
+Silver Surfer- Cosmic Voyager,6,2026,2.84,#341aff,https://cards.scryfall.io/normal/front/4/f/4f200c66-2356-4aec-978b-6bb509a3d885.jpg?1783903067,Legendary Creature — Alien Hero,Scott M. Fischer
+Simic Manipulator,3,2013,0.35,#341aff,https://cards.scryfall.io/normal/front/e/3/e3dff9e6-5e0c-4e5b-8184-f0ae9cf347b3.jpg?1783940134,Creature — Mutant Wizard,Maciej Kuciara
+Simulacrum Synthesizer,3,2024,28.38,#341aff,https://cards.scryfall.io/normal/front/a/a/aaa05ad1-5cda-4edd-b6bf-562ae3e5011a.jpg?1783912002,Artifact,Anton Solovianchyk
+Sinister Concierge,2,2022,1.06,#341aff,https://cards.scryfall.io/normal/front/4/3/434a43a4-cd03-4ddf-8e36-edff02be33b2.jpg?1783923368,Creature — Human Wizard,Tomas Duchek
+Sister of Silence,5,2022,0.43,#341aff,https://cards.scryfall.io/normal/front/1/5/15d56042-db45-40dc-a197-e2b7a3e6ab06.jpg?1783920931,Creature — Human Knight,Games Workshop
+Skaab Ruinator,3,2024,0.24,#341aff,https://cards.scryfall.io/normal/front/6/6/668d4e90-61d3-4064-b867-6ac7a49a7d59.jpg?1783909622,Creature — Zombie Horror,Chris Rahn
+Skill Borrower,3,2008,0.34,#341aff,https://cards.scryfall.io/normal/front/a/c/ac7ac7c8-8e01-4f80-a3fa-d533cb594d7c.jpg?1783942571,Artifact Creature — Human Wizard,Shelly Wan
+Skycoach Conductor // All Aboard,3,2026,0.33,#341aff,https://cards.scryfall.io/normal/front/4/e/4ecbca71-9a1d-44c5-b709-d6f565941d5e.jpg?1783903688,Creature — Bird Pilot // Instant,Christina Kraus
+Skystrike Officer,3,2022,0.27,#341aff,https://cards.scryfall.io/normal/front/9/2/925fa343-d9c3-4ed9-bd1f-aaa31c0badd7.jpg?1783920106,Creature — Human Soldier,Diego Gisbert
+Sky Swallower,5,2006,0.4,#341aff,https://cards.scryfall.io/normal/front/0/5/05189964-5ad0-48b7-a3af-67c7f46fe89e.jpg?1783943518,Creature — Leviathan,rk post
+Skyway Robber,4,2022,0.31,#341aff,https://cards.scryfall.io/normal/front/7/d/7df5aaae-4fa6-4945-bdd4-577ff3235a7d.jpg?1783923367,Creature — Bird Rogue,Denys Tsiperko
+Sleep-Cursed Faerie,1,2023,0.34,#341aff,https://cards.scryfall.io/normal/front/3/1/31051436-68f2-457e-8293-2b10ccf7684e.jpg?1783915116,Creature — Faerie Wizard,Heonhwa
+Sleight of Hand,1,2024,0.71,#341aff,https://cards.scryfall.io/normal/front/4/1/41cb4b43-2688-4693-86fd-9429efb57068.jpg?1783909746,Sorcery,Helvetica Blanc
+Sleight of Mind,1,1997,0.33,#341aff,https://cards.scryfall.io/normal/front/3/c/3cdb4f1c-6754-4269-8fac-d4edc02c8e00.jpg?1783946940,Instant,Mark Poole
+Sliptide Serpent,6,2000,0.35,#341aff,https://cards.scryfall.io/normal/front/f/8/f8647649-5669-46c4-8840-9ff967fabd99.jpg?1783945834,Creature — Serpent,Daren Bader
+Slithermuse,4,2026,0.24,#341aff,https://cards.scryfall.io/normal/front/5/8/58b1e5df-de53-4452-90a9-9ff13c4a0bd6.jpg?1783904564,Creature — Elemental,Steven Belledin
+Sludge Monster,5,2022,0.63,#341aff,https://cards.scryfall.io/normal/front/a/3/a32be366-d86e-48aa-8257-ca8afb87ba18.jpg?1783922462,Creature — Horror,Svetlin Velinov
+Sly Instigator,4,2022,0.33,#341aff,https://cards.scryfall.io/normal/front/c/9/c9ed183a-a78a-4934-9317-9f16b29e69a2.jpg?1783922460,Creature — Human Wizard,Justine Cruz
+Smirking Spelljacker,5,2024,2.72,#341aff,https://cards.scryfall.io/normal/front/0/1/01d1e394-1b0c-4b40-ba85-f55973703d41.jpg?1783911967,Creature — Djinn Wizard Rogue,Borja Pindado
+Snapcaster Mage,2,2025,19.12,#341aff,https://cards.scryfall.io/normal/front/2/2/22b36ad5-bf4d-436a-9c3c-fa4acd0052fe.jpg?1783907976,Creature — Human Wizard,Volkan Baǵa
+Solve the Equation,3,2024,5.56,#341aff,https://cards.scryfall.io/normal/front/4/c/4c547c39-9ef8-4e8c-a6fd-6d9b6a8345a5.jpg?1783909203,Sorcery,Mike Burns
+Somnophore,4,1998,0.48,#341aff,https://cards.scryfall.io/normal/front/c/3/c35aa7a8-5579-46b7-83ef-f5ecc2b31847.jpg?1783946355,Creature — Illusion,Andrew Robinson
+Soramaro- First to Dream,6,2005,0.42,#341aff,https://cards.scryfall.io/normal/front/e/5/e56de23d-7281-42f9-afce-7a81438dae5d.jpg?1783944159,Legendary Creature — Spirit,Brian Despain
+Sorcerous Squall,9,2023,0.98,#341aff,https://cards.scryfall.io/normal/front/c/0/c06274ff-892e-418b-8ba5-4d3b3231e327.jpg?1783914197,Sorcery,Matt Stewart
+Soulblade Djinn,5,2018,0.25,#341aff,https://cards.scryfall.io/normal/front/7/b/7b891276-1645-4e96-b774-647b82bf0e60.jpg?1783933984,Creature — Djinn,Viktor Titov
+Soul of Ravnica,6,2014,0.44,#341aff,https://cards.scryfall.io/normal/front/a/7/a7332471-c052-4a24-abf1-a5805d685658.jpg?1783939188,Creature — Avatar,Stephan Martiniere
+Souvenir Snatcher,5,2020,0.76,#341aff,https://cards.scryfall.io/normal/front/f/7/f7845c68-ab08-4fb3-a1af-167ba6c8b82a.jpg?1783931219,Creature — Bird,Kev Walker
+Sower of Temptation,4,2018,2.04,#341aff,https://cards.scryfall.io/normal/front/0/d/0d4a3eb3-8b28-49f7-a06c-eae26da6026b.jpg?1783934830,Creature — Faerie Wizard,Christopher Moeller
+Spark Double,4,2024,14.08,#341aff,https://cards.scryfall.io/normal/front/c/4/c41b9ba2-0006-4d8e-b600-efe81ff5e0cc.jpg?1783913330,Creature — Illusion,Eric Deschamps
+Sparkshaper Visionary,3,2023,0.24,#341aff,https://cards.scryfall.io/normal/front/5/e/5e941849-033b-499b-b691-6ad9250d9ecd.jpg?1783915484,Creature — Human Wizard,Svetlin Velinov
+Spawnbroker,3,2005,0.39,#341aff,https://cards.scryfall.io/normal/front/c/e/ce1e4aa6-b06d-4b87-9912-a4c403e8d7c6.jpg?1783943680,Creature — Human Wizard,Wayne England
+Spawning Kraken,6,2021,14.0,#341aff,https://cards.scryfall.io/normal/front/4/4/44917638-3c84-4c21-b139-5084e6e1efc6.jpg?1783927601,Creature — Kraken,Kev Walker
+Spectral Adversary,2,2021,0.48,#341aff,https://cards.scryfall.io/normal/front/7/c/7c67fe04-814f-4051-bd13-7c8ee40a6c08.jpg?1783925630,Creature — Spirit,Uriah Voth
+Spectral Arcanist,4,2021,0.27,#341aff,https://cards.scryfall.io/normal/front/f/6/f65bb20b-e207-49da-9d15-a8718b53783e.jpg?1783925003,Creature — Spirit Wizard,Johan Grenier
+Spectral Deluge,6,2021,4.81,#341aff,https://cards.scryfall.io/normal/front/7/2/7238c46e-6338-4aca-96f2-934c44c8cc36.jpg?1783928340,Sorcery,Kieran Yanner
+Spectral Shift,2,2004,0.45,#341aff,https://cards.scryfall.io/normal/front/b/1/b1a3f75d-9a79-4c16-8f50-43a18add4579.jpg?1783944402,Instant,John Avon
+Spelljack,6,2002,1.6,#341aff,https://cards.scryfall.io/normal/front/3/e/3eda8c7b-ce35-482a-bece-52a30cc78a9a.jpg?1783945126,Instant,Pete Venters
+Spell Pierce,1,2026,18.74,#341aff,https://cards.scryfall.io/normal/front/7/f/7f1c50e3-641a-4100-b6ab-9ed037d6a7ed.jpg?1783903510,Instant,Shie Nanahara
+Spellseeker,3,2023,17.52,#341aff,https://cards.scryfall.io/normal/front/a/7/a749c591-2fbe-41d8-ac5b-56ebce82d33e.jpg?1783915690,Creature — Human Wizard,Igor Kieryluk
+Spellshift,4,2007,0.33,#341aff,https://cards.scryfall.io/normal/front/f/5/f5c897a6-5835-42ac-8cc7-e8d9fc1e7c77.jpg?1783943160,Instant,Stephen Tappin
+Spell Swindle,5,2023,2.21,#341aff,https://cards.scryfall.io/normal/front/0/1/01feef77-ff30-4f77-892f-6bdae3f0d35c.jpg?1783917165,Instant,Victor Adame Minguez
+Spelltwine,6,2017,0.33,#341aff,https://cards.scryfall.io/normal/front/a/b/ab3332a9-cbed-4ebd-8aac-eb87325221fa.jpg?1783935914,Sorcery,Noah Bradley
+Spellweaver Volute,5,2007,1.14,#341aff,https://cards.scryfall.io/normal/front/7/9/79cc73ea-3f07-4d11-9961-dc31ac598b73.jpg?1783943116,Enchantment — Aura,Bud Cook
+Sphinx Ambassador,7,2009,15.25,#341aff,https://cards.scryfall.io/normal/front/b/0/b0937274-d5cb-4790-8c10-804f537c5581.jpg?1783942388,Creature — Sphinx,Jim Murray
+Sphinx Mindbreaker,7,2020,1.66,#341aff,https://cards.scryfall.io/normal/front/d/7/d70c50ce-48f0-49a6-9653-42b8ccb9a647.jpg?1783931493,Creature — Sphinx,PINDURSKI
+Sphinx of Clear Skies,5,2022,0.29,#341aff,https://cards.scryfall.io/normal/front/9/7/974c9e0c-07b2-4535-a3d0-bb827b651075.jpg?1783921342,Creature — Sphinx,Valera Lutfullina
+Sphinx of Foresight,4,2019,0.36,#341aff,https://cards.scryfall.io/normal/front/c/f/cf2386fd-edc0-4731-8f4e-7a7c45548bf3.jpg?1783933703,Creature — Sphinx,Titus Lunter
+Sphinx of Forgotten Lore,4,2024,0.43,#341aff,https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg?1783909114,Creature — Sphinx,Dmitry Burmak
+Sphinx of Jwar Isle,6,2018,0.16,#341aff,https://cards.scryfall.io/normal/front/a/3/a38387c9-cee0-4ec1-800a-877d6a7edc2d.jpg?1783934305,Creature — Sphinx,Justin Sweet
+Sphinx of Lost Truths,5,2009,0.34,#341aff,https://cards.scryfall.io/normal/front/d/9/d97b61b6-bf80-4326-a646-a1985e0b50d7.jpg?1783942160,Creature — Sphinx,Shelly Wan
+Sphinx of Magosi,6,2017,0.18,#341aff,https://cards.scryfall.io/normal/front/a/2/a2b4f70d-e922-4ecb-9d5a-6253f7a7716c.jpg?1783936548,Creature — Sphinx,James Ryman
+Sphinx of the Chimes,6,2012,0.24,#341aff,https://cards.scryfall.io/normal/front/3/1/31a0cae5-925f-4d00-a4da-1db8bae5511b.jpg?1783940365,Creature — Sphinx,Greg Staples
+Sphinx of the Final Word,7,2026,0.25,#341aff,https://cards.scryfall.io/normal/front/6/0/6071239e-0b85-4c54-bef8-d9456eb8d8fc.jpg?1783903951,Creature — Sphinx,Lius Lasahido
+Sphinx of the Second Sun,8,2024,2.56,#341aff,https://cards.scryfall.io/normal/front/b/e/be2d74cd-76fb-4bca-99b5-07749aef4d06.jpg?1783913012,Creature — Sphinx,Antonio José Manzanedo
+Sphinx of Uthuun,7,2020,0.23,#341aff,https://cards.scryfall.io/normal/front/5/b/5bd5cd33-20e2-4063-b422-2bde13021888.jpg?1783928716,Creature — Sphinx,Kekai Kotaki
+Sphinx's Tutelage,3,2024,4.5,#341aff,https://cards.scryfall.io/normal/front/9/4/94a3673b-6003-4612-a8f6-02829aa9de7d.jpg?1783908596,Enchantment,Jason A. Engle
+Spider-Man 2099- Miguel O'Hara,5,2025,7.78,#341aff,https://cards.scryfall.io/normal/front/e/c/eca05fe2-f203-4e7c-ae90-41f1f2ae94cb.jpg?1783905373,Legendary Creature — Spider Human Hero,Thanh Tuấn
+Spider-Sense,2,2025,1.76,#341aff,https://cards.scryfall.io/normal/front/4/4/4499a25b-f4a5-4f2c-9ebd-bc68c7840b39.jpg?1783905348,Instant,Borja Pindado
+Spirit Away,7,2012,0.13,#341aff,https://cards.scryfall.io/normal/front/d/8/d8823bdc-0467-47f1-9bef-a281b4a7071d.jpg?1783940710,Enchantment — Aura,Greg Staples
+Spirit Water Revival,3,2025,0.67,#341aff,https://cards.scryfall.io/normal/front/0/c/0c019e76-c88e-4d1b-a546-0f4e462ef44a.jpg?1783904980,Sorcery,Enishi
+Sprite Noble,3,2006,0.6,#341aff,https://cards.scryfall.io/normal/front/0/d/0de52e53-8a45-4c0a-bb7d-6dc0d659a7c0.jpg?1783943240,Creature — Faerie Noble,Randy Gallegos
+Squeeze,4,1999,0.47,#341aff,https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg?1783945960,Enchantment,DiTerlizzi
+Standardize,2,2002,1.18,#341aff,https://cards.scryfall.io/normal/front/f/2/f2c79e64-91bf-4e87-a4fd-3136ea67c5bb.jpg?1783945076,Instant,Justin Sweet
+Standstill,2,2025,2.32,#341aff,https://cards.scryfall.io/normal/front/d/4/d4296046-23bc-456c-b478-4da73836b843.jpg?1783904856,Enchantment,Viacom
+Starfield Vocalist,4,2025,1.35,#341aff,https://cards.scryfall.io/normal/front/d/e/deca0b2a-e7f3-444a-883d-7c41dd62c9cc.jpg?1783905975,Creature — Human Bard,Nathaniel Himawan
+Stark's Ingenuity,3,2026,2.82,#341aff,https://cards.scryfall.io/normal/front/9/c/9c090e1b-bfeb-4dd5-9da8-f25b3473d806.jpg?1783903102,Enchantment — Aura,Milivoj Ćeran
+Startled Awake // Persistent Nightmare,4,2016,0.76,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Creature — Nightmare,Sean Sevestre
+Starwinder,7,2025,0.82,#341aff,https://cards.scryfall.io/normal/front/2/7/27d1a010-5790-4b35-9fdc-0e366eed021d.jpg?1783905975,Creature — Leviathan,Devin Elle Kurtz
+Statecraft,4,1999,3.65,#341aff,https://cards.scryfall.io/normal/front/7/6/76dcd19e-8daf-4d53-946b-c07d5eca3cc9.jpg?1783945960,Enchantment,Mike Ploog
+Steamcore Scholar,3,2024,0.28,#341aff,https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg?1783912907,Creature — Weird Detective,David Astruga
+Step Between Worlds,5,2024,0.28,#341aff,https://cards.scryfall.io/normal/front/7/0/70ea2054-3d22-42ce-ab50-501ef09c2128.jpg?1783911839,Sorcery,Chris Ostrowski
+Stifle,1,2014,13.72,#341aff,https://cards.scryfall.io/normal/front/6/1/616d1b20-61c1-4d39-a9b5-ad9fd61699e4.jpg?1783939358,Instant,Eric Fortune
+Stillness in Motion,2,2025,0.21,#341aff,https://cards.scryfall.io/normal/front/a/6/a6289251-17e4-4987-96b9-2fb1a8f90e2a.jpg?1783907388,Enchantment,Kai Carpenter
+Stitcher Geralf,5,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/a/4/a4ce6c30-a301-4a8a-ac3a-abacaf358a56.jpg?1783915689,Legendary Creature — Human Wizard,Karla Ortiz
+Stoic Sphinx,4,2024,0.17,#341aff,https://cards.scryfall.io/normal/front/f/9/f93f5055-30d8-4fc4-afa5-29212e8c7536.jpg?1783911839,Creature — Sphinx,Andreas Zafiratos
+Stolen by the Fae,2,2019,0.28,#341aff,https://cards.scryfall.io/normal/front/a/9/a98a7698-57fb-41f6-86d4-251c7d444c6a.jpg?1783932648,Sorcery,Ryan Alexander Lee
+Stolen Goods,4,2024,0.35,#341aff,https://cards.scryfall.io/normal/front/4/9/495c8498-a446-4617-ae5e-f09ef63c7cb7.jpg?1783911937,Sorcery,Anthony Francisco
+Stolen Identity,6,2022,0.38,#341aff,https://cards.scryfall.io/normal/front/2/8/2831fe77-ea98-4334-a78e-01580fb002c0.jpg?1783923275,Sorcery,Clint Cearley
+Stormchaser's Talent,1,2024,3.77,#341aff,https://cards.scryfall.io/normal/front/a/3/a36e682d-b43d-4e08-bf5b-70d7e924dbe5.jpg?1783910842,Enchantment — Class,Christina Kraus
+Storm Fleet Negotiator,3,2023,0.25,#341aff,https://cards.scryfall.io/normal/front/7/a/7ac4efff-eb66-48dd-9d6b-14eaf1684034.jpg?1783913913,Creature — Siren Pirate,Nino Vecia
+Storm of Forms,4,2022,0.24,#341aff,https://cards.scryfall.io/normal/front/5/f/5fab4f0d-006d-4a94-80ba-924f19b42f63.jpg?1783923367,Instant,Campbell White
+Storm of Saruman,6,2023,3.33,#341aff,https://cards.scryfall.io/normal/front/5/2/52884e67-c742-4799-9afd-55bc70b2cf40.jpg?1783916312,Enchantment,Lorenzo Lanfranconi
+Stormscape Master,4,2000,0.48,#d78f42,https://cards.scryfall.io/normal/front/9/b/9b704165-4587-48f1-8830-c5a07ec666cc.jpg?1783945703,Creature — Human Wizard,Hannibal King
+Stormsurge Kraken,5,2023,0.56,#341aff,https://cards.scryfall.io/normal/front/5/2/525d742f-dadb-4a59-b70d-3b328bf99cca.jpg?1783915688,Creature — Kraken,Svetlin Velinov
+Stormtide Leviathan,8,2020,2.08,#341aff,https://cards.scryfall.io/normal/front/9/9/996bb4c0-dc72-4233-9f44-2e25aef71ad7.jpg?1783928715,Creature — Leviathan,Karl Kopinski
+Stormwing Entity,5,2020,0.27,#341aff,https://cards.scryfall.io/normal/front/0/5/0540ee72-6370-4f70-9526-6f441b3cac1e.jpg?1783930718,Creature — Elemental,Caroline Gariba
+Stratus Dancer,2,2019,0.28,#341aff,https://cards.scryfall.io/normal/front/8/2/82fb8b0c-b86e-4915-b72d-9a6b5c1368c7.jpg?1783932776,Creature — Djinn Monk,Anastasia Ovchinnikova
+Strix Serenade,1,2024,2.12,#341aff,https://cards.scryfall.io/normal/front/4/2/42ac5ac7-b2f9-4e6f-af41-7e42ac816374.jpg?1783911288,Instant,Filipe Pagliuso
+Stroke of Genius,3,2026,0.31,#341aff,https://cards.scryfall.io/normal/front/b/e/beeb5419-828e-4a84-b4f3-87bc6f4cc594.jpg?1783903788,Instant,Rovina Cai
+Struggle for Project Purity,4,2024,4.79,#341aff,https://cards.scryfall.io/normal/front/0/4/04c60155-9337-4ea2-b9a2-5b72d96743ff.jpg?1783912410,Enchantment,Billy Christian
+Stunt Double,4,2024,4.57,#341aff,https://cards.scryfall.io/normal/front/7/a/7afaaea9-300a-46c8-b9ec-a2579f8a4b7f.jpg?1783912551,Creature — Shapeshifter,Joseph Meehan
+Sturmgeist,5,2011,0.36,#341aff,https://cards.scryfall.io/normal/front/c/4/c409d1d0-fc45-40bf-adac-83b680209a38.jpg?1783940963,Creature — Spirit,Terese Nielsen
+Subjugate the Hobbits,7,2023,0.32,#341aff,https://cards.scryfall.io/normal/front/6/2/6206d9f1-6a57-46a2-942f-6f20e33e5d6a.jpg?1783916032,Sorcery,Chris Cold
+Sublime Epiphany,6,2025,0.34,#341aff,https://cards.scryfall.io/normal/front/0/f/0f7d3839-0bc3-402b-b9ea-c903f82d39da.jpg?1783907098,Instant,Lindsey Look
+Subterfuge,5,2026,0.32,#341aff,https://cards.scryfall.io/normal/front/f/d/fdbf0034-c28a-44ed-b817-519b2a3df3c4.jpg?1783904607,Creature — Elemental Incarnation,Ilse Gort
+Subterranean Schooner,2,2023,0.3,#341aff,https://cards.scryfall.io/normal/front/9/4/94b6881a-b00e-4e90-92e6-602ed8e0e090.jpg?1783913787,Artifact — Vehicle,Svetlin Velinov
+Subtlety,4,2021,15.87,#341aff,https://cards.scryfall.io/normal/front/7/0/701256d5-1389-48b7-9581-d6037209bd06.jpg?1783926869,Creature — Elemental Incarnation,Anastasia Ovchinnikova
+Sudden Substitution,4,2019,5.4,#341aff,https://cards.scryfall.io/normal/front/9/f/9f7983bf-2a3b-4428-8c01-35285f589da8.jpg?1783932812,Instant,Noah Bradley
+Summary Dismissal,4,2016,0.28,#341aff,https://cards.scryfall.io/normal/front/0/b/0b75794d-3334-4b4d-9446-0a251dd3bd15.jpg?1783937493,Instant,Igor Kieryluk
+Summon: Leviathan,6,2025,1.23,#341aff,https://cards.scryfall.io/normal/front/e/a/ea7f26a9-b203-4ee7-88f1-3d9c77a25bcb.jpg?1783906627,Enchantment Creature — Saga Leviathan,OTUMAMI
+Summon: Valefor,5,2025,0.28,#341aff,https://cards.scryfall.io/normal/front/e/0/e0474d99-48e5-4e60-8cd6-537a10bcfea5.jpg?1783906359,Enchantment Creature — Saga Drake,SENNSU
+Sun Ce- Young Conquerer,5,1999,109.99,#341aff,https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg?1783946121,Legendary Creature — Human Soldier,Yang Guangmai
+Sunder,5,1998,5.0,#341aff,https://cards.scryfall.io/normal/front/c/d/cd9dd7c6-36b6-4fe2-b3d3-f62a6e10a428.jpg?1783946354,Instant,Stephen Daniele
+Sunderflock,9,2026,1.68,#341aff,https://cards.scryfall.io/normal/front/e/5/e5b6221e-cb22-45e4-bb98-2b960afc614c.jpg?1783904481,Creature — Elemental,Caio Monteiro
+Sunken Hope,5,2016,0.23,#341aff,https://cards.scryfall.io/normal/front/7/3/73fe736d-9ffa-4e8b-a353-d591da749ec3.jpg?1783936842,Enchantment,Volkan Baǵa
+Sun Quan- Lord of Wu,6,2023,8.15,#341aff,https://cards.scryfall.io/normal/front/7/8/78c71971-fa26-4ae6-aa6f-a401e5285b76.jpg?1783915688,Legendary Creature — Human Soldier,Xu Xiaoming
+Supplant Form,6,2015,1.29,#341aff,https://cards.scryfall.io/normal/front/3/d/3df927c0-9aa9-450b-ab2a-ae12c5489d57.jpg?1783938701,Instant,Adam Paquette
+Supreme Exemplar,7,2008,0.43,#341aff,https://cards.scryfall.io/normal/front/2/b/2bea92ba-d6e3-4fba-be81-86b10852a9d1.jpg?1783942795,Creature — Elemental,Mark Tedin
+Supreme Inquisitor,5,2002,0.59,#341aff,https://cards.scryfall.io/normal/front/8/6/867de3d2-2178-4931-823e-ff439e1a45ea.jpg?1783945076,Creature — Human Wizard,rk post
+Supreme Phantom,2,2021,0.33,#341aff,https://cards.scryfall.io/normal/front/c/b/cbf4ca25-73cc-45ba-bed5-dbaa517e8bb8.jpg?1783924962,Creature — Spirit,Robbie Trevino
+Surgespanner,4,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/3/3/3303c5cb-0064-47c0-bc91-228acd82348e.jpg?1783913881,Creature — Merfolk Wizard,Warren Mahy
+Surrakar Spellblade,3,2015,0.32,#341aff,https://cards.scryfall.io/normal/front/a/0/a0c26b28-b542-41d4-bfe0-222400653ae9.jpg?1783938417,Creature — Surrakar,Dave Kendall
+Surtland Elementalist,7,2021,0.2,#341aff,https://cards.scryfall.io/normal/front/1/c/1c9e7fdc-676f-4901-83ff-bfea3a96d937.jpg?1783928123,Creature — Giant Wizard,Nicholas Gregory
+Suspend,1,2021,0.52,#341aff,https://cards.scryfall.io/normal/front/4/0/40af215c-d3f7-42f0-85cd-77a3fcd919ba.jpg?1783926868,Instant,Lake Hurwitz
+Suspicious Stowaway // Seafaring Werewolf,2,2021,0.15,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Rogue Werewolf // Creature — Werewolf,Jake Murray
+Svyelun of Sea and Sky,3,2023,0.43,#341aff,https://cards.scryfall.io/normal/front/0/1/01f5ab00-5305-4ac4-915d-feeb591f9389.jpg?1783913880,Legendary Creature — Merfolk God,Seb McKinnon
+Swan Song,1,2025,8.43,#341aff,https://cards.scryfall.io/normal/front/8/3/83d0b761-d694-4232-9f40-5bd8c82a05f1.jpg?1783906053,Instant,Lorenzo Mastroianni
+Swarm Intelligence,7,2021,0.39,#341aff,https://cards.scryfall.io/normal/front/2/c/2c573d12-4c69-4a54-b1b9-236c003ba98a.jpg?1783927560,Enchantment,Daniel Ljunggren
+Sway of the Stars,10,2005,5.58,#341aff,https://cards.scryfall.io/normal/front/5/e/5eb58d9e-d181-4167-8b80-64b238183bdb.jpg?1783944203,Sorcery,Randy Gallegos
+Swindler's Scheme,3,2022,0.17,#341aff,https://cards.scryfall.io/normal/front/d/c/dc7436c6-cd33-4324-bd1b-026a5d5c0007.jpg?1783923343,Enchantment,Anato Finnstark
+Swirl the Mists,4,2004,0.41,#341aff,https://cards.scryfall.io/normal/front/2/e/2ea50e09-4ab3-439e-83d7-d584f8af8f16.jpg?1783944319,Enchantment,Arnie Swekel
+Sygg- Wanderwine Wisdom // Sygg- Wanderbrine Shield,2,2026,0.27,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Merfolk Wizard // Legendary Creature — Merfolk Rogue,Justin Gerard
+Synapse Sliver,5,2023,4.13,#341aff,https://cards.scryfall.io/normal/front/7/c/7c458a0f-0e63-417f-b51e-8491822835b0.jpg?1783915438,Creature — Sliver,Thomas M. Baxa
+Synod Artificer,3,2004,0.37,#341aff,https://cards.scryfall.io/normal/front/d/c/dc895eea-505d-4a12-936b-dcf9895d01a1.jpg?1783944446,Creature — Vedalken Artificer,Mark Zug
+Synthesis Pod,4,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/e/0/e06d72d0-909d-4e38-85e6-52c658836c18.jpg?1783918155,Artifact,Campbell White
+Synthesizer Labship,1,2025,0.29,#341aff,https://cards.scryfall.io/normal/front/f/b/fba6332c-acba-43f9-877c-ca6c5328aae9.jpg?1783905973,Artifact — Spacecraft,Adrián Rodríguez Pérez
+Synthetic Destiny,6,2021,0.24,#341aff,https://cards.scryfall.io/normal/front/d/c/dc19002c-e87d-45a1-84f2-f953587ddfd1.jpg?1783928324,Instant,Dave Kendall
+Synth Infiltrator,5,2024,0.25,#341aff,https://cards.scryfall.io/normal/front/3/f/3fe16bc4-8457-4c5f-902a-0746112e80a4.jpg?1783912409,Artifact Creature — Synth,Leonardo Borazio
+Taeko- the Patient Avalanche,4,2024,4.89,#d78f42,https://cards.scryfall.io/normal/front/6/5/65b815a1-98d8-47b9-8d6b-b30e0a5f087c.jpg?1783908859,Legendary Creature — Turtle Ninja,GOSSAN
+Taigam- Master Opportunist,2,2025,1.15,#341aff,https://cards.scryfall.io/normal/front/8/6/8693d631-05f6-414d-9e49-6385746e8960.jpg?1783907388,Legendary Creature — Human Monk,Joshua Raphael
+Take Possession,7,2007,0.3,#341aff,https://cards.scryfall.io/normal/front/7/8/78366049-4613-4cd1-aab0-308996926563.jpg?1783943119,Enchantment — Aura,Michael Phillippi
+Talas Researcher,5,1998,1.42,#341aff,https://cards.scryfall.io/normal/front/1/c/1c51008b-7031-4dbc-b4d6-7433c05bf6dc.jpg?1783946482,Creature — Human Pirate Wizard,Kaja Foglio
+Talas Warrior,3,1998,5.63,#341aff,https://cards.scryfall.io/normal/front/d/e/de3d8cc5-5889-4e52-a32c-d15556fd2166.jpg?1783946480,Creature — Human Pirate Warrior,Douglas Shuler
+Talent of the Telepath,4,2015,0.69,#341aff,https://cards.scryfall.io/normal/front/c/5/c5da13a1-8be2-4312-a660-f3e102c552b6.jpg?1783938346,Sorcery,Peter Mohrbacher
+Tale's End,2,2019,2.03,#341aff,https://cards.scryfall.io/normal/front/1/4/1421115b-9a98-4ab2-bcb2-7d8899ce12db.jpg?1783933002,Instant,Randy Vargas
+Tales of the Ancestors,4,2021,0.32,#341aff,https://cards.scryfall.io/normal/front/c/2/c286a74c-3714-4190-8322-84b161debe39.jpg?1783928338,Sorcery,Colin Boyer
+Talion's Messenger,3,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg?1783915114,Creature — Faerie Noble,Marta Nael
+Talrand- Sky Summoner,4,2024,1.06,#341aff,https://cards.scryfall.io/normal/front/1/b/1be3ed47-072e-481a-b3d9-dc232ac4b24f.jpg?1783911937,Legendary Creature — Merfolk Wizard,Svetlin Velinov
+Tameshi- Reality Architect,3,2022,0.35,#d78f42,https://cards.scryfall.io/normal/front/2/6/26594b52-3e9c-4cde-88df-1f4e9e16676e.jpg?1783923894,Legendary Creature — Moonfolk Wizard,Scott M. Fischer
+Tamiyo- Inquisitive Student // Tamiyo- Seasoned Scholar,1,2024,17.5,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Moonfolk Wizard // Legendary Planeswalker — Tamiyo,Magali Villeneuve
+Tamiyo- the Moon Sage,5,2012,4.99,#341aff,https://cards.scryfall.io/normal/front/b/9/b9398926-13b9-47b8-b66b-1ab9d06bb704.jpg?1783940708,Legendary Planeswalker — Tamiyo,Eric Deschamps
+Tangletrove Kelp,7,2024,0.35,#341aff,https://cards.scryfall.io/normal/front/7/5/7582d7c0-6cb6-47d1-8026-3d661b5a809f.jpg?1783913046,Artifact Creature — Clue Plant,Erikas Perl
+Taniwha,5,1996,5.64,#341aff,https://cards.scryfall.io/normal/front/7/2/72d12315-4220-470d-9628-b9a3ea904ca7.jpg?1783947101,Legendary Creature — Serpent,Ian Miller
+Tasha's Hideous Laughter,3,2021,3.64,#341aff,https://cards.scryfall.io/normal/front/c/4/c4932113-904f-427a-9566-509cc008f3ef.jpg?1783926505,Sorcery,Ilse Gort
+Taunt,1,1997,2.11,#341aff,https://cards.scryfall.io/normal/front/f/4/f4d87322-aba4-4187-9655-1da1f18615f8.jpg?1783946834,Sorcery,Phil Foglio
+Taunting Sliver,4,2023,2.67,#341aff,https://cards.scryfall.io/normal/front/3/d/3db8a900-b15a-42eb-a240-35764d57c155.jpg?1783915485,Creature — Sliver,Maxime Minard
+Tawnos- Solemn Survivor,2,2022,0.41,#d78f42,https://cards.scryfall.io/normal/front/b/d/bdf67de0-f468-4f04-99ab-a442347bb16b.jpg?1783919724,Legendary Creature — Human Artificer,Matt Stewart
+Teachings of the Archaics,3,2021,0.37,#341aff,https://cards.scryfall.io/normal/front/9/6/967148b1-2bb6-4bc0-95e6-c45fcf99afd2.jpg?1783927373,Sorcery — Lesson,Lius Lasahido
+Teferi- Mage of Zhalfir,5,2021,3.23,#341aff,https://cards.scryfall.io/normal/front/8/f/8fc5e4a8-ea7b-4803-a7ed-3b915708661f.jpg?1783927835,Legendary Creature — Human Wizard,D. Alexander Gregory & Jeremy Jarvis
+Teferi- Master of Time,4,2020,7.95,#341aff,https://cards.scryfall.io/normal/front/9/c/9c0c61e3-9f3d-4e7f-9046-0ea336dd8a2d.jpg?1783930718,Legendary Planeswalker — Teferi,Yongjae Choi
+Teferi's Ageless Insight,4,2024,5.13,#341aff,https://cards.scryfall.io/normal/front/b/1/b1a32b7c-9f26-4504-9f8d-379164d69346.jpg?1783913011,Legendary Enchantment,Kieran Yanner
+Teferi's Imp,3,1996,0.91,#341aff,https://cards.scryfall.io/normal/front/0/4/048f2368-0e2f-4197-b977-353d38b38ccc.jpg?1783947101,Creature — Imp,Una Fricker
+Teferi's Realm,3,1997,2.1,#341aff,https://cards.scryfall.io/normal/front/a/b/aba3e4ea-2241-4f1e-a46b-70f512fe729e.jpg?1783946997,World Enchantment,Alan Rabinowitz
+Teferi's Response,2,2000,10.43,#341aff,https://cards.scryfall.io/normal/front/f/3/f3bb2df8-c559-4a34-83b0-d48fbc694cc8.jpg?1783945703,Instant,Scott Bailey
+Teferi's Talent,5,2023,0.55,#341aff,https://cards.scryfall.io/normal/front/5/6/56f642ae-68f3-4eeb-8b3f-a9fe1596231d.jpg?1783917250,Enchantment — Aura,Dominik Mayer
+Teferi's Wavecaster,5,2020,0.17,#341aff,https://cards.scryfall.io/normal/front/d/6/d67e4c42-a44f-456b-87e7-21ca56dc4630.jpg?1783930621,Creature — Merfolk Wizard,Miranda Meeks
+Teferi- Temporal Archmage,6,2023,0.87,#341aff,https://cards.scryfall.io/normal/front/3/6/368c6e60-804c-447c-bc2b-ac9dc4cab5e7.jpg?1783915687,Legendary Planeswalker — Teferi,Tyler Jacobson
+Teferi- Temporal Pilgrim,5,2022,4.74,#341aff,https://cards.scryfall.io/normal/front/2/3/23a4f1ec-eadf-4f1e-8821-f22293ad2580.jpg?1783920103,Legendary Planeswalker — Teferi,Magali Villeneuve
+Tekuthal- Inquiry Dominus,4,2025,1.29,#341aff,https://cards.scryfall.io/normal/front/2/d/2d389264-e2d2-4589-9636-faa11fe46710.jpg?1783906040,Legendary Creature — Phyrexian Horror,Martin de Diego Sádaba
+Telekinesis,2,1994,33.17,#341aff,https://cards.scryfall.io/normal/front/d/5/d5aa920e-b93f-41c2-b505-a9350353be8b.jpg?1783948071,Instant,Daniel Gelon
+Telekinetic Bonds,5,2002,0.33,#341aff,https://cards.scryfall.io/normal/front/d/6/d68fad1d-a517-433a-b939-d0635e8f5535.jpg?1783945126,Enchantment,Jim Nelson
+Telemin Performance,5,2009,0.71,#341aff,https://cards.scryfall.io/normal/front/3/a/3ac0f1fb-0ada-4b3c-b9bd-654ffc0a167d.jpg?1783942486,Sorcery,Izzy
+Teleport,3,1995,0.39,#341aff,https://cards.scryfall.io/normal/front/3/9/39c65d23-4bc5-4f79-a0e5-0cd4b2660f96.jpg?1783947371,Instant,Douglas Shuler
+Tempest Djinn,3,2026,0.28,#341aff,https://cards.scryfall.io/normal/front/3/d/3de55b97-059c-4d7b-afd0-44fd8380df4c.jpg?1783903951,Creature — Djinn,Zezhou Chen
+Temporal Adept,3,2005,0.4,#341aff,https://cards.scryfall.io/normal/front/0/f/0ff2dfe6-dbc0-46c3-9d5c-9f0ba6f511ec.jpg?1783944026,Creature — Human Wizard,Mark Tedin
+Temporal Cascade,7,2003,0.58,#341aff,https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg?1783944551,Sorcery,Puddnhead
+Temporal Distortion,5,2000,0.41,#341aff,https://cards.scryfall.io/normal/front/7/4/74bd0d14-8d26-403f-9405-d0dcdecd1a49.jpg?1783945702,Enchantment,Stephanie Law
+Temporal Manipulation,5,2018,12.61,#341aff,https://cards.scryfall.io/normal/front/6/2/6270b93e-8cd2-4668-982a-f4c4628da9d9.jpg?1783933834,Sorcery,Franz Vohwinkel
+Temporal Mastery,7,2025,4.92,#341aff,https://cards.scryfall.io/normal/front/0/f/0f46a800-b443-461d-87e0-5587249a42d8.jpg?1783908154,Sorcery,Franz Vohwinkel
+Temporal Trespass,11,2015,3.38,#341aff,https://cards.scryfall.io/normal/front/a/0/a08b7a1e-b404-41ea-875f-b3468501cb4b.jpg?1783938701,Sorcery,Clint Cearley
+Tempted by the Oriq,4,2021,0.3,#341aff,https://cards.scryfall.io/normal/front/c/2/c23e64f9-531e-4735-9960-b0a76b32c340.jpg?1783927374,Sorcery,Billy Christian
+Tempt with Reflections,4,2013,2.06,#341aff,https://cards.scryfall.io/normal/front/e/b/ebb0070f-8686-4127-91c3-4f1488e2d995.jpg?1783939680,Sorcery,Mike Bierek
+Tetsuko Umezawa- Fugitive,2,2025,3.63,#341aff,https://cards.scryfall.io/normal/front/d/3/d32f3fb7-df52-4cef-8686-c11f7360cfd9.jpg?1783905121,Legendary Creature — Human Rogue,Mitch Mohrhauser
+Tezzeret- Artifice Master,5,2018,5.13,#341aff,https://cards.scryfall.io/normal/front/e/5/e5e12371-f05c-41cf-92ca-7cb17c2f7f1a.jpg?1783934576,Legendary Planeswalker — Tezzeret,Josh Hass
+Tezzeret- Betrayer of Flesh,4,2024,0.42,#341aff,https://cards.scryfall.io/normal/front/3/5/35f30004-13e0-42c1-9842-eea52793fcfc.jpg?1783913011,Legendary Planeswalker — Tezzeret,Bryan Sola
+Tezzeret's Gambit,4,2024,0.41,#341aff,https://cards.scryfall.io/normal/front/1/5/15b2188f-06c8-4771-bba6-e6fc531ebc9a.jpg?1783911937,Sorcery,Karl Kopinski
+Tezzeret the Seeker,5,2015,24.43,#341aff,https://cards.scryfall.io/normal/front/c/f/cf339735-eb1a-46f0-8c3e-eae06f278eca.jpg?1783938417,Legendary Planeswalker — Tezzeret,Anthony Francisco
+Thada Adel- Acquisitor,3,2010,17.44,#341aff,https://cards.scryfall.io/normal/front/3/b/3bfcbeab-7a1e-4dcf-99bf-98f42c2b6a6f.jpg?1783942061,Legendary Creature — Merfolk Rogue,Andrew Robinson
+Thalakos Deceiver,4,1998,3.08,#341aff,https://cards.scryfall.io/normal/front/a/e/ae4cc2f5-3a50-40c8-87ea-6b92f081f55c.jpg?1783946566,Creature — Thalakos Wizard,Andrew Robinson
+Thalakos Drifters,4,1998,0.52,#341aff,https://cards.scryfall.io/normal/front/4/6/468e13d2-6bd7-403c-8e2e-e00917b39597.jpg?1783946521,Creature — Thalakos,Andrew Robinson
+Thassa- Deep-Dwelling,4,2020,28.96,#341aff,https://cards.scryfall.io/normal/front/c/8/c83ed3e0-82d0-4410-a6ca-b0f923eadf83.jpg?1783931576,Legendary Enchantment Creature — God,Zack Stella
+Thassa- God of the Sea,3,2023,3.6,#341aff,https://cards.scryfall.io/normal/front/9/f/9f9db424-e668-48b4-b275-7b35be4e1bf8.jpg?1783913880,Legendary Enchantment Creature — God,Jason Chan
+Thassa's Intervention,2,2020,0.4,#341aff,https://cards.scryfall.io/normal/front/2/c/2c1241d0-20d4-4eab-970d-74e476f023b4.jpg?1783931577,Instant,Zack Stella
+Thassa's Oracle,2,2020,24.86,#341aff,https://cards.scryfall.io/normal/front/7/2/726e8b29-13e9-4138-b6a9-d2a0d8188d1c.jpg?1783931575,Creature — Merfolk Wizard,Jesper Ejsing
+The Antiquities War,4,2018,0.29,#341aff,https://cards.scryfall.io/normal/front/b/b/bbda670a-00a7-419c-b4b5-bfdb323f006d.jpg?1783935033,Enchantment — Saga,Mark Tedin
+The Blackstaff of Waterdeep,1,2021,0.21,#341aff,https://cards.scryfall.io/normal/front/3/3/3317cbf3-13a1-4471-a23c-de429941e8a4.jpg?1783926518,Legendary Artifact,Anna Steinbauer
+The Blue Spirit,4,2025,0.91,#341aff,https://cards.scryfall.io/normal/front/d/0/d0d1f5b0-f842-40d5-ae51-015eefe68fa1.jpg?1783904832,Legendary Creature — Human Rogue Ally,Claudiu-Antoniu Magherusan
+The Clone Saga,4,2026,0.31,#341aff,https://cards.scryfall.io/normal/front/d/3/d356ed6b-062f-47c5-a54e-a74dbc0300f4.jpg?1784182977,Enchantment — Saga,Bill Sienkiewicz
+The Destined Thief,3,2025,3.65,#341aff,https://cards.scryfall.io/normal/front/d/e/de95250d-294d-4a0e-8049-e0a877078e2e.jpg?1783904655,Legendary Creature — Human Rogue,David Rapoza
+The Eleventh Hour,4,2023,0.28,#341aff,https://cards.scryfall.io/normal/front/a/c/ac5c90a9-697a-4bff-a738-0cebfb238bff.jpg?1783914670,Enchantment — Saga,Matt Stewart
+The Enigma Jewel // Locus of Enlightenment,1,2023,1.33,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact // Legendary Artifact,Martin de Diego Sádaba
+The Everflowing Well // The Myriad Pools,3,2023,0.31,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact // Legendary Artifact Land,David Álvarez
+The Flood of Mars,4,2023,0.37,#341aff,https://cards.scryfall.io/normal/front/8/c/8c3474c4-9466-46fc-8327-50950d75e79f.jpg?1783914667,Creature — Alien Zombie Horror,Andrey Kuzinskiy
+The Indomitable,4,2023,0.79,#341aff,https://cards.scryfall.io/normal/front/e/6/e6456329-b521-474b-bfb5-bfcd7e52b5f8.jpg?1783913913,Legendary Artifact — Vehicle,Samuel Perin
+The Key to the Vault,2,2024,0.46,#341aff,https://cards.scryfall.io/normal/front/1/6/166814af-a444-4a62-937e-7491673d9387.jpg?1783911844,Legendary Artifact — Equipment,Leon Tukker
+The Legend of Kuruk // Avatar Kuruk,4,2025,2.37,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Legendary Creature — Avatar,Takayama Toshiaki
+The Lunar Whale,4,2025,0.34,#341aff,https://cards.scryfall.io/normal/front/a/e/ae875471-346c-4a76-b26f-b7205dad5b80.jpg?1783906634,Legendary Artifact — Vehicle,Fiona Hsieh
+The Magic Mirror,9,2019,3.76,#341aff,https://cards.scryfall.io/normal/front/0/8/08b89af1-7b22-4153-b42d-a2ea4e0f320c.jpg?1783932655,Legendary Artifact,Anastasia Ovchinnikova
+The Mechanist- Aerial Artisan,3,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/b/9/b910851e-9332-4c83-a790-d379667cabfc.jpg?1783904984,Legendary Creature — Human Artificer Ally,Le Vuong
+The Mindskinner,3,2024,3.37,#341aff,https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg?1783909491,Legendary Enchantment Creature — Nightmare,Abz J Harding
+The Mirari Conjecture,5,2018,0.3,#341aff,https://cards.scryfall.io/normal/front/1/c/1c68954c-4bab-4973-9819-ecd084438303.jpg?1783935024,Enchantment — Saga,James Arnold
+Theoretical Duplication,3,2021,0.6,#341aff,https://cards.scryfall.io/normal/front/1/5/1575a14e-fa70-44f0-8384-95cb90031337.jpg?1783927601,Instant,Anna Christenson
+The Phasing of Zhalfir,4,2022,0.29,#341aff,https://cards.scryfall.io/normal/front/0/7/0770eb6a-4f01-4677-a401-14c1b30692c9.jpg?1783921347,Enchantment — Saga,L.A. Draws
+The Reality Chip,2,2022,4.35,#341aff,https://cards.scryfall.io/normal/front/d/8/d859de3a-0be1-4e66-b438-1c3d4ee756cd.jpg?1783923896,Legendary Artifact Creature — Equipment Jellyfish,Campbell White
+The Tale of Tamiyo,3,2024,0.28,#341aff,https://cards.scryfall.io/normal/front/a/a/aaeba193-05d3-4c2d-a304-bbe7114c2eef.jpg?1783909489,Legendary Enchantment — Saga,Anna Pavleeva
+The Temporal Anchor,6,2022,0.3,#341aff,https://cards.scryfall.io/normal/front/1/a/1a212d59-b72e-4939-a757-c131ca4323ce.jpg?1783920095,Legendary Artifact,Kekai Kotaki
+The Terror of Serpent's Pass,7,2025,0.21,#341aff,https://cards.scryfall.io/normal/front/f/7/f7569861-5b68-4265-bb45-3d54992bfe66.jpg?1783904783,Legendary Creature — Serpent,Douzen
+The Theorist- Jace Beleren,4,2026,49.95,#341aff,https://cards.scryfall.io/normal/front/2/0/20bb8c55-4b0b-425f-8201-b54fa2fdde86.jpg?1784338223,Legendary Planeswalker — Jace,Ekaterina Burmak
+The Unagi of Kyoshi Island,5,2025,1.25,#341aff,https://cards.scryfall.io/normal/front/0/e/0ecd8b38-9ee5-41a5-9b93-21c33fc1a6ff.jpg?1783904980,Legendary Creature — Serpent,Miho Midorikawa
+The Unspeakable,9,2017,0.3,#341aff,https://cards.scryfall.io/normal/front/e/9/e956c695-bf0a-430c-a14e-196ae6ab7c9f.jpg?1783936574,Legendary Creature — Spirit,Daarken
+The Wasp- Winsome Avenger,2,2026,0.27,#341aff,https://cards.scryfall.io/normal/front/c/e/ce5fb436-fcc6-426f-a33b-a8ba904df0ff.jpg?1783903288,Legendary Creature — Human Hero,Raoul Vitale
+The Watcher in the Water,5,2023,2.98,#341aff,https://cards.scryfall.io/normal/front/1/c/1cb8e8bb-75a0-4b5e-b4b3-5d8f3795032d.jpg?1783916309,Legendary Creature — Kraken,Chris Cold
+The Water Crystal,4,2025,3.94,#341aff,https://cards.scryfall.io/normal/front/e/0/e0af8436-797b-4e1f-b21a-d8e93701c3c9.jpg?1783906626,Legendary Artifact,Pablo Mendoza
+The Wondrous Wasp,2,2026,0.74,#341aff,https://cards.scryfall.io/normal/front/4/8/484e80a4-1d5f-4c27-98a8-ee2ef9d6cbdc.jpg?1783902947,Legendary Creature — Human Hero,Gal Or
+They Came from the Pipes,5,2024,0.29,#341aff,https://cards.scryfall.io/normal/front/7/4/74c900b3-6db0-4bd9-afd2-d193e4aca09c.jpg?1783909661,Enchantment,Andreas Zafiratos
+Thieving Skydiver,2,2024,0.32,#341aff,https://cards.scryfall.io/normal/front/0/6/06996ff1-7f57-4e73-940a-a58c4482cadd.jpg?1783911936,Creature — Merfolk Rogue,Kieran Yanner
+Thing in the Ice // Awoken Horror,2,2025,0.81,#341aff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Horror // Creature — Kraken Horror,Svetlin Velinov
+Thopter Fabricator,3,2025,0.39,#341aff,https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg?1783907901,Artifact — Vehicle,Racrufi
+Thopter Spy Network,4,2023,0.39,#341aff,https://cards.scryfall.io/normal/front/b/a/babc5799-31f3-452e-a61d-5c11f9f81bf9.jpg?1783917163,Enchantment,Jung Park
+Thoughtcast,5,2025,9.26,#341aff,https://cards.scryfall.io/normal/front/0/f/0f9a3f71-d03c-4f32-bd9d-95a1d91c2ff5.jpg?1783907687,Sorcery,Lucie Louxor
+Thought Devourer,4,2001,1.36,#341aff,https://cards.scryfall.io/normal/front/b/a/ba7a96ee-e2d1-4d76-a09e-d6868ddd9282.jpg?1783945255,Creature — Beast,Jim Nelson
+Thoughtlace,1,1995,0.4,#341aff,https://cards.scryfall.io/normal/front/1/8/185674a4-db97-444d-b0e9-7dcfc245ce4b.jpg?1783947851,Instant,Mark Poole
+Thought Monitor,7,2025,0.4,#341aff,https://cards.scryfall.io/normal/front/1/8/18a6ea89-417c-4ee0-a410-8a0067b92967.jpg?1783906042,Artifact Creature — Construct,Martina Pilcerova
+Thought Reflection,7,2020,1.38,#341aff,https://cards.scryfall.io/normal/front/e/1/e169e197-5ef4-454d-a31f-fcadedb74cfc.jpg?1783930190,Enchantment,Chris Seaman
+Thought Scour,1,2026,7.39,#341aff,https://cards.scryfall.io/normal/front/d/4/d4d7ec8d-6161-4b8d-b068-8a48b9dc1e4b.jpg?1783903506,Instant,Inio Asano
+Thought Sponge,4,2019,0.31,#341aff,https://cards.scryfall.io/normal/front/7/0/70406543-ba78-4dd8-8f16-3c5a9ee458a1.jpg?1783932811,Creature — Sponge,Jason Kang
+Thousand-Faced Shadow,1,2022,2.37,#341aff,https://cards.scryfall.io/normal/front/8/9/89a698a5-f4ac-4b04-96dc-32e1eeef6ac7.jpg?1783923891,Creature — Human Ninja,Ekaterina Burmak
+Thousand Winds,6,2019,0.16,#341aff,https://cards.scryfall.io/normal/front/f/7/f73d6480-2ddb-465d-8d21-11163744378d.jpg?1783932774,Creature — Elemental,Raymond Swanland
+Threads of Disloyalty,3,2005,0.65,#341aff,https://cards.scryfall.io/normal/front/9/9/999440a5-9659-4218-8594-1950f1155975.jpg?1783944204,Enchantment — Aura,Anthony S. Waters
+Three Steps Ahead,1,2024,5.03,#341aff,https://cards.scryfall.io/normal/front/8/f/8fffd839-2337-4a14-9312-cee085a17f4b.jpg?1783911837,Instant,Francisco Miyara
+Three Wishes,3,1997,4.2,#341aff,https://cards.scryfall.io/normal/front/d/b/dbb2b253-7023-44d1-963b-eae98d48f498.jpg?1783946998,Instant,George Pratt
+Thryx- the Sudden Storm,5,2020,0.34,#341aff,https://cards.scryfall.io/normal/front/4/2/4238b089-c6d8-4e4b-b6a1-a0f89e3b4968.jpg?1783931574,Legendary Creature — Elemental Giant,Mathias Kollros
+Thunderclap Drake,2,2026,0.59,#341aff,https://cards.scryfall.io/normal/front/3/1/313fed71-cfbe-4c83-9437-ac14b2cb159b.jpg?1783903789,Creature — Drake,Kaitlyn McCulley
+Thundertrap Trainer,2,2024,0.76,#341aff,https://cards.scryfall.io/normal/front/9/c/9cf3af94-b7c8-415c-a5a1-d89967fd0bba.jpg?1783910839,Creature — Otter Wizard,Matt Stewart
+Tidal Barracuda,4,2020,9.04,#341aff,https://cards.scryfall.io/normal/front/a/a/aacdf4c2-9bc8-400a-8ffc-d6597d8d7da9.jpg?1783931218,Creature — Fish,Uriah Voth
+Tidal Control,3,1996,1.04,#341aff,https://cards.scryfall.io/normal/front/c/b/cb9a7b7d-3d37-4bb6-ab48-1fec2bfb4fdc.jpg?1783947189,Enchantment,Randy Gallegos
+Tidal Force,8,2013,0.48,#341aff,https://cards.scryfall.io/normal/front/1/3/13e2658d-28d7-4e22-ad44-03ab92ff666d.jpg?1783939679,Creature — Elemental,Phill Simmer
+Tidal Kraken,8,2005,0.72,#341aff,https://cards.scryfall.io/normal/front/5/6/569d1014-e04a-4f8d-a2b2-699b5be08d5d.jpg?1783944025,Creature — Kraken,Christopher Moeller
+Tidebinder Mage,2,2017,0.24,#341aff,https://cards.scryfall.io/normal/front/f/6/f6ed9fb1-de68-46ae-88d0-b3b4cd0e381e.jpg?1783935611,Creature — Merfolk Wizard,John Severin Brassell
+Tidespout Tyrant,8,2024,2.41,#341aff,https://cards.scryfall.io/normal/front/d/b/db68f47b-f49a-4978-acdd-453ecfb948da.jpg?1783913330,Creature — Djinn,Dany Orizio
+Tidings,5,2008,1.59,#341aff,https://cards.scryfall.io/normal/front/6/8/68d77020-b313-429f-9005-a36ecf8caa05.jpg?1783942813,Sorcery,Michael Komarck
+Tiger-Seal,1,2025,0.13,#341aff,https://cards.scryfall.io/normal/front/7/a/7aef2891-1269-4a1a-acea-0aa37ef544c4.jpg?1783904980,Creature — Cat Seal,Jinho Bae
+Time Reversal,5,2011,2.34,#341aff,https://cards.scryfall.io/normal/front/2/d/2d6500a1-5aea-4b83-b4dc-560fe547590d.jpg?1783941086,Sorcery,Howard Lyon
+Time Spiral,6,1998,98.12,#341aff,https://cards.scryfall.io/normal/front/f/3/f3d62dbd-63db-4ac9-950f-9852627f23f2.jpg?1783946354,Sorcery,Michael Sutfin
+Time Stop,6,2024,0.3,#341aff,https://cards.scryfall.io/normal/front/d/9/d938603b-0f1e-44c4-b86e-38e15f4a0d27.jpg?1783909077,Instant,Scott M. Fischer
+Timestream Navigator,2,2023,0.36,#341aff,https://cards.scryfall.io/normal/front/0/8/086afafe-6b6c-4a54-8ce7-0040295d309c.jpg?1783913879,Creature — Human Pirate Wizard,Zezhou Chen
+Time Stretch,10,2023,4.76,#341aff,https://cards.scryfall.io/normal/front/9/d/9dc791fd-d49c-4c66-b8fb-6b54ce842e90.jpg?1783918486,Sorcery,Dominik Mayer
+Timetwister,3,1993,5142.02,#341aff,https://cards.scryfall.io/normal/front/0/1/01bda3d7-122a-48a0-bab3-676c4a557b74.jpg?1783948574,Sorcery,Mark Tedin
+Time Walk,2,1993,2799.99,#341aff,https://cards.scryfall.io/normal/front/a/d/ade7d00d-4e7b-46e9-ace1-63f628a589fc.jpg?1783948572,Sorcery,Amy Weber
+Time Warp,5,2026,6.71,#341aff,https://cards.scryfall.io/normal/front/7/c/7c46dd99-8af8-4cf2-9f98-734f73d9c456.jpg?1783903014,Sorcery,Gintas Galvanauskas
+Timin- Youthful Geist,5,2021,0.43,#341aff,https://cards.scryfall.io/normal/front/a/3/a3d4102e-b48c-4da8-b181-092c7ab1849a.jpg?1783925003,Legendary Creature — Spirit,Randy Vargas
+Tishana's Tidebinder,3,2023,2.16,#341aff,https://cards.scryfall.io/normal/front/9/0/907b3d1d-8c85-4707-80b5-c4d832df9846.jpg?1783913786,Creature — Merfolk Wizard,Nino Vecia
+Titan of Littjara,6,2023,6.35,#341aff,https://cards.scryfall.io/normal/front/6/2/62807f83-b219-4769-afdd-2870deeb93c0.jpg?1783915483,Creature — Illusion,Aldo Domínguez
+Tolarian Entrancer,2,1997,1.8,#341aff,https://cards.scryfall.io/normal/front/c/2/c29dd04a-b3aa-48b6-beef-3314344b84a6.jpg?1783946737,Creature — Human Wizard,Bryan Talbot
+Tolarian Serpent,7,1997,1.13,#341aff,https://cards.scryfall.io/normal/front/9/2/9236a857-c4ca-4de2-a4a2-e0914d16b54b.jpg?1783946738,Creature — Serpent,Stuart Griffin
+Tomb of Horrors Adventurer,6,2022,0.38,#341aff,https://cards.scryfall.io/normal/front/3/0/30b5bf0c-e617-4a41-bfaa-2b299728a93f.jpg?1783922773,Creature — Elf Monk,Irina Nordsol
+Tomorrow- Azami's Familiar,6,2005,1.11,#341aff,https://cards.scryfall.io/normal/front/0/9/095813f9-d559-40bd-a50f-7c1f6e494e60.jpg?1783944201,Legendary Creature — Spirit,Christopher Rush
+Tony Stark // The Invincible Iron Man,2,2026,6.72,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Artificer Hero // Legendary Artifact Creature — Human Hero,Alexander Lozano
+Toothy- Imaginary Friend,4,2018,9.1,#341aff,https://cards.scryfall.io/normal/front/e/b/ebdf2f50-f69a-47c4-a75f-ff55781bb0c8.jpg?1783934877,Legendary Creature — Illusion,Zoltan Boros
+Topsy Turvy,3,2004,1.02,#341aff,https://cards.scryfall.io/normal/front/c/d/cdca743d-f861-4aec-b9cb-b7490dd3425a.jpg?1783944253,Enchantment,Jeff Miracola
+Torrent Elemental,5,2015,0.37,#d78f42,https://cards.scryfall.io/normal/front/d/c/dc4850e4-acb9-458d-952f-b3952cab2a5b.jpg?1783938700,Creature — Elemental,James Paick
+Torrential Gearhulk,6,2023,1.31,#341aff,https://cards.scryfall.io/normal/front/9/2/92872fea-2fb4-4154-815e-cad9d966e60f.jpg?1783915685,Artifact Creature — Construct,Svetlin Velinov
+Torrent Sculptor // Flamethrower Sonata,4,2021,0.21,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Merfolk Wizard // Sorcery,Slawomir Maniak
+Trade Routes,2,2005,4.75,#341aff,https://cards.scryfall.io/normal/front/5/7/57e5d7c9-36f7-4312-ada0-b6c2757487c8.jpg?1783944021,Enchantment,Matt Cavotta
+Trade Secrets,3,2011,1.48,#341aff,https://cards.scryfall.io/normal/front/5/8/58dadc78-fe87-40ac-94cb-128716d89d74.jpg?1783941232,Sorcery,Ron Spears
+Training Grounds,1,2023,9.14,#341aff,https://cards.scryfall.io/normal/front/9/9/991c27ed-f53c-48c6-8c12-282f44b8d441.jpg?1783916525,Enchantment,A. M. Sartor
+Trait Doctoring,1,2013,0.29,#341aff,https://cards.scryfall.io/normal/front/e/2/e21a7981-5940-4b75-907f-7600a742f946.jpg?1783940041,Sorcery,Clint Cearley
+Transcendent Dragon,6,2025,0.39,#341aff,https://cards.scryfall.io/normal/front/3/c/3c9a4205-eda8-4858-9d46-2428058c94fc.jpg?1783907181,Creature — Dragon,Diego Gisbert
+Transcendent Message,4,2023,0.35,#341aff,https://cards.scryfall.io/normal/front/3/2/3261c7e6-45be-44d1-8855-026359ba0ae7.jpg?1783917021,Instant,Liiga Smilshkalne
+Trap the Trespassers,3,2023,0.29,#341aff,https://cards.scryfall.io/normal/front/a/0/a077a046-300b-41d2-b891-c57ebe983ba2.jpg?1783916030,Instant,Tatiana Kirgetova
+Traumatize,5,2013,4.11,#341aff,https://cards.scryfall.io/normal/front/9/b/9b8784dd-83f9-41f8-aedc-f0f81073ffcb.jpg?1783939929,Sorcery,Greg Staples
+Traverse Eternity,4,2023,0.38,#341aff,https://cards.scryfall.io/normal/front/f/6/f6570c23-f135-4e81-9a4c-934c298a51ad.jpg?1783914663,Sorcery,Jeremy Paillotin
+Treacherous Trapezist,3,2022,0.09,#341aff,https://cards.scryfall.io/normal/front/4/5/456149a1-0f15-466a-8d07-803efb5721d5.jpg?1783920590,Creature — Porcupine Performer,Dave Greco
+Treachery,5,1999,43.67,#341aff,https://cards.scryfall.io/normal/front/6/1/613694aa-b169-400d-8063-2b83d8303611.jpg?1783946075,Enchantment — Aura,Matthew D. Wilson
+Treasure Hunt,2,2012,2.1,#341aff,https://cards.scryfall.io/normal/front/5/5/55db30a7-6834-4a64-8edc-05ce18166c91.jpg?1783940858,Sorcery,Aleksi Briclot
+Trench Behemoth,7,2020,0.76,#341aff,https://cards.scryfall.io/normal/front/9/0/909dc123-8234-4e81-bb7b-77404d94a87c.jpg?1783928735,Creature — Kraken,Svetlin Velinov
+Trench Gorger,8,2011,2.1,#341aff,https://cards.scryfall.io/normal/front/b/6/b631b71b-78f6-41bc-a26a-c761ee1671a1.jpg?1783941233,Creature — Leviathan,Hideaki Takamura
+Trickbind,2,2006,12.35,#341aff,https://cards.scryfall.io/normal/front/f/2/f2e58ff2-dea3-42b3-8c22-3e6202a7d433.jpg?1783943238,Instant,John Zeleznik
+Triskaidekaphile,2,2021,0.76,#341aff,https://cards.scryfall.io/normal/front/6/7/6750e203-1215-4203-b5b8-3f1b18940839.jpg?1783925628,Creature — Human Wizard,Slawomir Maniak
+Tromokratis,7,2020,0.43,#341aff,https://cards.scryfall.io/normal/front/1/6/160686f3-44fd-4f7a-81cf-d3b5b964bfba.jpg?1783928714,Legendary Creature — Kraken,Matt Stewart
+Troublesome Spirit,4,2000,0.28,#341aff,https://cards.scryfall.io/normal/front/2/3/23d7e856-6852-4b97-ae0e-a4becdfc8166.jpg?1783945787,Creature — Spirit,Adam Rex
+True-Name Nemesis,3,2018,3.21,#341aff,https://cards.scryfall.io/normal/front/2/d/2da0b45b-0ca9-40c4-bc7f-791039bc1876.jpg?1783934827,Creature — Merfolk Rogue,Zack Stella
+True Polymorph,6,2021,0.29,#341aff,https://cards.scryfall.io/normal/front/0/4/04a1f384-9266-425c-b739-09d74871fc7b.jpg?1783926505,Instant,Steve Prescott
+Tui and La- Moon and Ocean,4,2025,0.43,#341aff,https://cards.scryfall.io/normal/front/e/d/edf0d06a-4eef-40cb-951c-74d7e0ffae13.jpg?1783904828,Legendary Creature — Fish Spirit,Douzen
+Tunnel Vision,6,2005,5.43,#341aff,https://cards.scryfall.io/normal/front/a/e/ae3eba31-02eb-449a-8a36-899ada5664bc.jpg?1783943676,Sorcery,Dany Orizio
+Turbulent Dreams,2,2002,2.71,#341aff,https://cards.scryfall.io/normal/front/d/8/d879226b-8ee3-4a48-b03a-d183594dc586.jpg?1783945160,Sorcery,Wayne England
+Turnabout,4,2012,6.09,#341aff,https://cards.scryfall.io/normal/front/a/1/a11b59db-b1e7-47c4-aed9-a1792fc31ce9.jpg?1783940298,Instant,Dan Murayama Scott
+Turtles in Time,7,2026,0.58,#341aff,https://cards.scryfall.io/normal/front/b/d/bdb3efe7-7b12-4503-83e9-7977eb099db5.jpg?1783904110,Sorcery,Inkognit
+Twenty-Toed Toad,4,2024,4.63,#341aff,https://cards.scryfall.io/normal/front/1/b/1b3de0d8-5911-4743-8623-010f12c2055b.jpg?1783908491,Creature — Frog Wizard,Steve Prescott
+Twice Upon a Time // Unlikely Meeting,6,2023,0.17,#341aff,https://cards.scryfall.io/normal/front/9/d/9d504a87-f782-4b70-91da-c1944925e86a.jpg?1783914661,Sorcery // Sorcery — Adventure,Elizabeth Peiró
+Twincast,2,2009,6.55,#341aff,https://cards.scryfall.io/normal/front/f/3/f38eec33-a40e-4739-ad2c-2f57008cef4e.jpg?1783942387,Instant,Christopher Moeller
+Twining Twins // Swift Spiral,4,2023,0.28,#d78f42,https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1783915061,Creature — Faerie Wizard // Instant — Adventure,Fajareka Setiawan
+Ty Lee- Chi Blocker,3,2025,0.34,#341aff,https://cards.scryfall.io/normal/front/3/0/308cc687-9cb2-4e3a-98db-c5ba2a7da115.jpg?1783904981,Legendary Creature — Human Performer Ally,Gemi
+Ugin's Insight,5,2015,0.21,#341aff,https://cards.scryfall.io/normal/front/f/3/f37d5938-9c8f-4203-8f3f-d6e89ced28ef.jpg?1783938206,Sorcery,Tyler Jacobson
+Ultimecia- Temporal Threat,6,2025,0.71,#341aff,https://cards.scryfall.io/normal/front/b/6/b64e4475-f1c6-4d85-b42f-6d84d06855bb.jpg?1783906436,Legendary Creature — Human Warlock,Bachzim
+Unctus- Grand Metatect,3,2023,0.35,#341aff,https://cards.scryfall.io/normal/front/1/6/164b07e6-48ba-4789-bd8f-7cada1fec8a9.jpg?1783918054,Legendary Artifact Creature — Phyrexian Vedalken,Andrew Mar
+Undead Alchemist,4,2021,0.82,#341aff,https://cards.scryfall.io/normal/front/b/7/b7231a1c-f3aa-4346-9eb1-63e35ab3001c.jpg?1783925343,Creature — Zombie,Michael C. Hayes
+Undercover Operative,4,2022,0.37,#341aff,https://cards.scryfall.io/normal/front/4/e/4ecec953-ab86-409b-b618-04bb07ff3eac.jpg?1783923139,Creature — Shapeshifter Rogue,Tyler Walpole
+Unesh- Criosphinx Sovereign,6,2017,1.03,#341aff,https://cards.scryfall.io/normal/front/f/d/fdd1a8b2-f4ba-45af-9586-98a98834b8bc.jpg?1783936046,Legendary Creature — Sphinx,Adrian Majkrzak
+Unifying Theory,2,2001,0.45,#341aff,https://cards.scryfall.io/normal/front/8/a/8aa4bf82-65e7-4b0c-9f96-dd84a67dcfb2.jpg?1783945252,Enchantment,Ron Spears
+Universal Surveillance,3,2025,0.23,#341aff,https://cards.scryfall.io/normal/front/7/7/77e9ef36-bc1b-4919-9bb5-8fd6b2d431cc.jpg?1783906040,Sorcery,Aaron J. Riley
+Unnatural Selection,2,2001,2.7,#341aff,https://cards.scryfall.io/normal/front/c/5/c575e2cb-3990-4c73-b81c-e16311ec6bbb.jpg?1783945352,Enchantment,Kev Walker
+Unstable Shapeshifter,4,1997,0.9,#341aff,https://cards.scryfall.io/normal/front/8/4/84e8cbd4-f49d-420d-a027-3be64ca58989.jpg?1783946647,Creature — Shapeshifter,Terese Nielsen
+Unstoppable Plan,3,2025,3.07,#341aff,https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg?1783907901,Enchantment,Borja Pindado
+Upheaval,6,2021,0.29,#341aff,https://cards.scryfall.io/normal/front/b/e/befe74b1-c487-42bb-a1a1-4d13f3a86ff7.jpg?1783926787,Sorcery,Kev Walker
+Urza- Lord High Artificer,4,2023,15.49,#341aff,https://cards.scryfall.io/normal/front/7/b/7b7a348a-51f7-4dc5-8fe7-1c70fea5e050.jpg?1783915686,Legendary Creature — Human Artificer,Grzegorz Rutkowski
+Urza's Command,4,2022,0.35,#341aff,https://cards.scryfall.io/normal/front/b/9/b9b4a02c-e57f-4287-943e-6bc859ac149e.jpg?1783920102,Instant,Dominik Mayer
+Uthros Research Craft,3,2025,1.35,#341aff,https://cards.scryfall.io/normal/front/6/a/6ade097b-349f-4876-bdc8-7bcd051e9952.jpg?1783906066,Artifact — Spacecraft,Piotr Dura
+Uvilda- Dean of Perfection // Nassari- Dean of Expression,3,2021,0.25,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Djinn Wizard // Legendary Creature — Efreet Shaman,Jason Rainville
+Uyo- Silent Prophet,6,2013,0.35,#341aff,https://cards.scryfall.io/normal/front/5/0/50840915-545b-4de2-94bb-22a0b1e0dc7a.jpg?1783939679,Legendary Creature — Moonfolk Wizard,John Bolton
+Valeria Richards- Precocious,4,2026,1.58,#341aff,https://cards.scryfall.io/normal/front/5/e/5e0c357b-c5e8-4082-b1ec-85d40d10524c.jpg?1783903287,Legendary Creature — Human Scientist Hero,Justyna Dura
+Valley Floodcaller,3,2024,3.71,#341aff,https://cards.scryfall.io/normal/front/9/0/90b12da0-f666-471d-95f5-15d8c9b31c92.jpg?1783910840,Creature — Otter Wizard,Victor Adame Minguez
+Vanguard Suppressor,4,2022,0.78,#341aff,https://cards.scryfall.io/normal/front/3/3/3331d7dd-95c8-4813-a1eb-3966a2c08502.jpg?1783920932,Creature — Astartes Warrior,Fajareka Setiawan
+Vantress Gargoyle,2,2019,0.31,#341aff,https://cards.scryfall.io/normal/front/d/a/daff1c8d-0f25-4bec-bd50-208ae2ac0aac.jpg?1783932649,Artifact Creature — Gargoyle,Cristi Balanescu
+Vedalken Archmage,4,2020,15.22,#341aff,https://cards.scryfall.io/normal/front/5/0/508b3cb7-b434-4524-8ef0-7db7f7f22edd.jpg?1783930442,Creature — Vedalken Wizard,Kev Walker
+Vedalken Humiliator,4,2023,0.33,#341aff,https://cards.scryfall.io/normal/front/5/1/51b14afb-5603-49af-b545-1277341775ae.jpg?1783917162,Creature — Vedalken Wizard,Jehan Choo
+Vedalken Squirrel-Whacker,4,2022,0.17,#341aff,https://cards.scryfall.io/normal/front/7/b/7bdc091b-c528-4058-ae10-d9b209d5cee8.jpg?1783920587,Creature — Vedalken Guest,Vladimir Krisetskiy
+Veiled Crocodile,3,1998,0.5,#341aff,https://cards.scryfall.io/normal/front/9/b/9be15ae1-5262-40ba-937c-217a33d131da.jpg?1783946352,Enchantment,Paolo Parente
+Vendilion Clique,3,2018,3.92,#341aff,https://cards.scryfall.io/normal/front/c/d/cd702cf1-10ca-4448-9fb1-b6de635e839c.jpg?1783935170,Legendary Creature — Faerie Wizard,Willian Murai
+Venser- Shaper Savant,4,2022,1.21,#341aff,https://cards.scryfall.io/normal/front/7/7/77e19416-aa6c-46f1-b247-a94da5d1a13a.jpg?1783921909,Legendary Creature — Human Wizard,Aleksi Briclot
+Verity Circle,3,2021,0.68,#341aff,https://cards.scryfall.io/normal/front/5/8/58b0d8be-f2e7-4bc9-a700-ed4c06785ecf.jpg?1783924961,Enchantment,Volkan Baǵa
+Very Cryptic Command,4,2017,1.92,#341aff,https://cards.scryfall.io/normal/front/d/8/d8e84dd2-01f9-4fad-8a24-cc86424d09a2.jpg?1783935440,Instant,Zoltan Boros
+Very Cryptic Command,4,2017,2.55,#341aff,https://cards.scryfall.io/normal/front/2/d/2dfc9416-06d6-40af-8b3d-62371b3da7c5.jpg?1783935442,Instant,Zoltan Boros
+Very Cryptic Command,4,2017,2.2,#341aff,https://cards.scryfall.io/normal/front/1/2/12272ce6-ab1f-4576-9e50-21d324263c44.jpg?1783935441,Instant,Zoltan Boros
+Very Cryptic Command,4,2017,1.41,#341aff,https://cards.scryfall.io/normal/front/d/4/d41e6c51-d96a-436f-94c5-5d1e19c5e0d5.jpg?1783935440,Instant,Zoltan Boros
+Very Cryptic Command,4,2017,1.2,#341aff,https://cards.scryfall.io/normal/front/9/a/9a650610-20e2-4f16-b59c-2ea7779f6e47.jpg?1783935441,Instant,Wayne England
+Very Cryptic Command,4,2017,1.89,#341aff,https://cards.scryfall.io/normal/front/2/a/2a90b2b6-d96e-4c13-83be-849d2ec1d845.jpg?1783935441,Instant,Zoltan Boros
+Vesuvan Drifter,3,2023,0.33,#341aff,https://cards.scryfall.io/normal/front/f/2/f2785902-2757-406b-bc75-6f05e0edc98d.jpg?1783916526,Creature — Shapeshifter,Julia Metzger
+Vesuvan Duplimancy,4,2022,5.52,#341aff,https://cards.scryfall.io/normal/front/9/a/9a2119bc-a377-4156-89d4-56e7b5b494a8.jpg?1783921342,Enchantment,Wylie Beckert
+Vesuvan Shapeshifter,5,2021,0.33,#341aff,https://cards.scryfall.io/normal/front/0/b/0b1b59d2-ad4b-4dc6-a730-0d19f2774ae9.jpg?1783927833,Creature — Shapeshifter,Quinton Hoover
+Vexing Sphinx,3,2023,0.17,#341aff,https://cards.scryfall.io/normal/front/2/c/2c75f806-b900-403c-8de1-cc3173afc8f0.jpg?1783918484,Creature — Sphinx,Lars Grant-West
+Virtue of Knowledge // Vantress Visions,5,2023,4.94,#341aff,https://cards.scryfall.io/normal/front/d/f/df606cf5-67dc-46f4-8c79-1d2f1d054391.jpg?1783915112,Enchantment // Instant — Adventure,Piotr Dura
+Visions of Beyond,1,2018,5.15,#341aff,https://cards.scryfall.io/normal/front/f/0/f0b97772-9490-4db3-b4dd-a87d973680a5.jpg?1783933831,Instant,Terese Nielsen
+Visions of Duplicity,3,2021,0.31,#341aff,https://cards.scryfall.io/normal/front/f/2/f2b7a2ab-4b1b-4ab4-92b6-b6fc842fbea6.jpg?1783925371,Sorcery,Alexander Mokhov
+Vision- Spectral Synthezoid,8,2026,0.92,#341aff,https://cards.scryfall.io/normal/front/c/3/c3da7f82-d2f7-4aaa-b62a-238b3e3e4871.jpg?1783903066,Legendary Artifact Creature — Robot Hero,Aleksi Briclot
+Vizier of Many Faces,4,2024,0.29,#341aff,https://cards.scryfall.io/normal/front/f/4/f4f5deae-3fa7-4c06-abe1-753d94158a0a.jpg?1783913009,Creature — Shapeshifter Cleric,Ryan Yee
+Vizzerdrix,7,2005,0.18,#341aff,https://cards.scryfall.io/normal/front/9/a/9a82ffff-e02a-4ecb-a92d-8ed571beac46.jpg?1783944118,Creature — Rabbit Beast,Dave Dorman
+Vnwxt- Verbose Host,2,2025,0.44,#341aff,https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg?1783907900,Legendary Creature — Homunculus,Izzy
+Vodalian Hexcatcher,2,2022,5.53,#341aff,https://cards.scryfall.io/normal/front/4/e/4ec464dc-b1dd-4e45-b093-c3ad65a74050.jpg?1783921340,Creature — Merfolk Wizard,Dmitry Burmak
+Vodalian Knights,3,1994,0.98,#341aff,https://cards.scryfall.io/normal/front/6/8/68d97e1b-2526-4740-b354-f158734d1f72.jpg?1783947907,Creature — Merfolk Knight,Susan Van Camp
+Vodalian Mindsinger,3,2022,0.15,#d78f42,https://cards.scryfall.io/normal/front/2/1/211a9db2-8b5f-419d-8032-ac2a571dbb53.jpg?1783921339,Creature — Merfolk Wizard,Steve Prescott
+Vodalian War Machine,3,1994,0.56,#341aff,https://cards.scryfall.io/normal/front/c/d/cd962ff0-4aa6-453e-931e-bd36fc034273.jpg?1783947906,Creature — Wall,Amy Weber
+Voidmage Husher,4,2013,2.26,#341aff,https://cards.scryfall.io/normal/front/e/1/e199afa3-d16d-4b8e-b553-86bc3884aed1.jpg?1783940154,Creature — Human Wizard,Ryan Pancoast
+Voidmage Prodigy,2,2002,7.29,#341aff,https://cards.scryfall.io/normal/front/7/4/7441e7f9-a326-4f61-b7b1-e0dbed06046f.jpg?1783945075,Creature — Human Wizard,Scott M. Fischer
+Void Stalker,2,2012,0.22,#341aff,https://cards.scryfall.io/normal/front/7/f/7fc30e31-4796-4e98-992c-a56cd51ad3c9.jpg?1783940500,Creature — Elemental,Marco Nelor
+Volatile Stormdrake,2,2024,0.4,#341aff,https://cards.scryfall.io/normal/front/2/e/2e6e3232-8bb8-4504-9597-dfdfc6d634bd.jpg?1783911285,Creature — Drake,Campbell White
+Volcanic Eruption,3,1995,0.5,#341aff,https://cards.scryfall.io/normal/front/5/8/5828713a-edb3-4b11-b1f9-8f1bfc3c103f.jpg?1783947850,Sorcery,Douglas Shuler
+Volo- Itinerant Scholar,3,2022,0.37,#341aff,https://cards.scryfall.io/normal/front/8/6/862b6d5e-548f-4765-9d39-08d6115b4012.jpg?1783922772,Legendary Creature — Human Wizard,Andreas Zafiratos
+Voracious Bibliophile,4,2025,0.33,#341aff,https://cards.scryfall.io/normal/front/7/7/77d2c30b-3130-4d9d-bd3d-484fe6dc306d.jpg?1783907179,Creature — Dragon,Camille Alquier
+Voracious Greatshark,5,2024,0.12,#341aff,https://cards.scryfall.io/normal/front/c/2/c27b40dd-9b2a-4a99-a984-ee9cfdb091a1.jpg?1783908931,Creature — Shark,Mathias Kollros
+Vronos- Masked Inquisitor,5,2023,3.28,#341aff,https://cards.scryfall.io/normal/front/f/d/fdd2504b-ff9b-464c-9595-7dffab3bc5b9.jpg?1783915483,Legendary Planeswalker — Vronos,Ekaterina Burmak
+Vulture- Feathered Fiend,4,2026,0.65,#341aff,https://cards.scryfall.io/normal/front/a/f/af3951cc-c3af-4064-9354-af14c3273613.jpg?1783903065,Legendary Creature — Human Artificer Villain,Rimas Valeikis
+Wake Thrasher,3,2017,0.4,#341aff,https://cards.scryfall.io/normal/front/7/3/7340b21f-726d-47e8-a2bf-1cde21be70f4.jpg?1783935609,Creature — Merfolk Soldier,Jesper Ejsing
+Walk the Aeons,6,2021,1.57,#341aff,https://cards.scryfall.io/normal/front/7/9/794d09ae-a995-482f-848e-7f99477bd6f3.jpg?1783927829,Sorcery,Jeremy Jarvis
+Wall of Kelp,2,1995,2.43,#341aff,https://cards.scryfall.io/normal/front/5/2/52ff5051-e24b-4453-aaae-ed4f2bf213ab.jpg?1783947293,Creature — Plant Wall,Alan Rabinowitz
+Wall of Stolen Identity,4,2019,3.45,#341aff,https://cards.scryfall.io/normal/front/3/5/359cc32c-ba90-43e0-b584-09efd321a672.jpg?1783932811,Creature — Shapeshifter Wall,Jason Felix
+Wall of Wonder,4,2001,0.29,#341aff,https://cards.scryfall.io/normal/front/e/8/e8c73e58-e906-4c67-9f84-b20456629cb0.jpg?1783945520,Creature — Wall,Carl Critchlow
+Wanderwine Prophets,6,2007,15.71,#341aff,https://cards.scryfall.io/normal/front/6/c/6cdbb6ff-c945-4dd6-aba6-4fd4b77824c0.jpg?1783942895,Creature — Merfolk Wizard,Alex Horley-Orlandelli
+Wan Shi Tong- All-Knowing,5,2025,1.06,#341aff,https://cards.scryfall.io/normal/front/7/7/777fcc21-2856-4181-8ecd-c272f9769e36.jpg?1783904828,Legendary Creature — Bird Spirit,Axel Sauerwald
+Wan Shi Tong- Librarian,2,2025,34.67,#341aff,https://cards.scryfall.io/normal/front/e/2/e20da6b5-1057-4a28-9e85-07de714e262f.jpg?1783904979,Legendary Creature — Bird Spirit,Ryota Murayama
+Warkite Marauder,2,2023,0.3,#341aff,https://cards.scryfall.io/normal/front/b/e/be9c4e92-7a20-4070-96b2-57f310d27c12.jpg?1783913879,Creature — Human Pirate,Victor Adame Minguez
+Wash Out,4,2014,7.44,#341aff,https://cards.scryfall.io/normal/front/2/2/22e088e4-91bc-4b0f-b999-660c0c371a2e.jpg?1783939588,Sorcery,Volkan Baǵa
+Wasp- Shrinking Savior,3,2026,0.42,#341aff,https://cards.scryfall.io/normal/front/a/d/ad66392c-f117-4dfd-8ea1-86291e7e4ce5.jpg?1783903065,Legendary Creature — Human Hero,Ryan Pancoast
+Watcher of Hours,6,2024,0.31,#341aff,https://cards.scryfall.io/normal/front/d/8/d827fc3c-bc86-4ee9-9db9-461cb0276f6b.jpg?1783913045,Creature — Sphinx,Daniel Romanovsky
+Waterbender Ascension,2,2025,0.65,#341aff,https://cards.scryfall.io/normal/front/3/f/3f57e0f9-e232-489c-b991-d0d23f75d8dd.jpg?1783904979,Enchantment,Takeuchi Moto
+Waterbender's Restoration,2,2025,3.21,#341aff,https://cards.scryfall.io/normal/front/f/e/fe68e08e-8d84-4f87-b2e9-b552788d78e7.jpg?1783904827,Instant — Lesson,Phima
+Waterspout Elemental,5,2001,0.39,#341aff,https://cards.scryfall.io/normal/front/4/2/425156e6-8eee-4bff-8f2f-86edd9a4f73b.jpg?1783945622,Creature — Elemental,Mark Romanoski
+Water Whip,2,2025,0.64,#341aff,https://cards.scryfall.io/normal/front/f/8/f8783863-699b-4362-a211-7db7ab8f36ad.jpg?1783904782,Sorcery — Lesson,Rose Benjamin
+Wavebreak Hippocamp,3,2020,0.93,#341aff,https://cards.scryfall.io/normal/front/d/9/d900dff5-1196-443f-b9b0-b8e75c67c868.jpg?1783931573,Enchantment Creature — Horse Fish,Caio Monteiro
+Wave Goodbye,4,2026,1.57,#341aff,https://cards.scryfall.io/normal/front/8/f/8fb141d9-addd-47ad-bfc1-b5b376d4c950.jpg?1783904160,Sorcery,Hristo D. Chukov
+Waxen Shapethief,4,2025,0.43,#341aff,https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg?1783907899,Creature — Shapeshifter,Helge C. Balzer
+Weaver of Lies,7,2003,0.33,#341aff,https://cards.scryfall.io/normal/front/1/2/12172d0e-0c73-4482-9f83-2c23ace9b7a0.jpg?1783944917,Creature — Beast,Luca Zontini
+Weftwalking,6,2025,0.36,#341aff,https://cards.scryfall.io/normal/front/3/9/39d48ddd-4529-4284-9da3-5272ad362b9b.jpg?1783905972,Enchantment,Rovina Cai
+Welcome to the Fold,4,2016,0.16,#341aff,https://cards.scryfall.io/normal/front/2/d/2d07fbe1-e66a-4893-86ee-7752ad77b120.jpg?1783937783,Sorcery,David Palumbo
+Well-Laid Plans,3,2000,0.46,#341aff,https://cards.scryfall.io/normal/front/1/c/1c55eb8f-925a-42c1-9e48-d7f99cab3b01.jpg?1783945700,Enchantment,Kev Walker
+Well of Ideas,6,2020,2.31,#341aff,https://cards.scryfall.io/normal/front/e/7/e7796b82-5a7c-406e-be71-1f37abdbc44f.jpg?1783930189,Enchantment,Steve Prescott
+West Coast Expansion,2,2026,0.33,#341aff,https://cards.scryfall.io/normal/front/4/1/41533f78-4a4e-424a-9612-a8bdb2a14b4b.jpg?1783903287,Sorcery,E. M. Gist
+Wharf Infiltrator,2,2022,0.37,#341aff,https://cards.scryfall.io/normal/front/b/4/b434ba9e-528c-43b4-a463-0e697dce8d5d.jpg?1783922463,Creature — Human Horror,Daarken
+Wheel and Deal,4,2002,18.1,#341aff,https://cards.scryfall.io/normal/front/6/1/61f50a1a-f3d0-4fcf-bd32-0e173b0d3247.jpg?1783945075,Instant,Alan Pollack
+Whelming Wave,4,2020,1.19,#341aff,https://cards.scryfall.io/normal/front/d/d/ddb863a0-3ff8-42a3-a151-4ea9aa433336.jpg?1783928715,Sorcery,Slawomir Maniak
+Whim of Volrath,1,1997,8.25,#341aff,https://cards.scryfall.io/normal/front/e/2/e259da60-c8bc-4a77-98ed-e529dc067732.jpg?1783946647,Instant,Anthony S. Waters
+Whirlpool Warrior,3,2016,1.3,#d78f42,https://cards.scryfall.io/normal/front/1/0/10587371-5f50-4caa-ab2e-7d57b721b5e8.jpg?1783936839,Creature — Merfolk Warrior,Kev Walker
+Whir of Invention,3,2017,5.87,#341aff,https://cards.scryfall.io/normal/front/0/2/0279fd3c-9252-4958-9d7a-5f33aa25907e.jpg?1783936767,Instant,Christine Choi
+Willbreaker,5,2015,1.65,#341aff,https://cards.scryfall.io/normal/front/2/4/2465eafc-453c-4e4f-b369-0951b8a4b7bf.jpg?1783938345,Creature — Human Wizard,Dan Murayama Scott
+Will Kenrith,6,2022,0.83,#341aff,https://cards.scryfall.io/normal/front/4/0/406a3ae5-f57e-40ff-8eac-a01781f2329f.jpg?1783922460,Legendary Planeswalker — Will,Anna Steinbauer
+Will of the Temur,6,2025,0.91,#341aff,https://cards.scryfall.io/normal/front/d/2/d236aa15-f60c-4368-b796-4d41e0bc3358.jpg?1783907179,Sorcery,Irina Nordsol
+Windfall,3,2025,24.48,#341aff,https://cards.scryfall.io/normal/front/3/f/3fd291fa-43b8-4fa0-987d-65a022045a64.jpg?1783905164,Sorcery,Dan Mumford
+Windreader Sphinx,7,2020,0.29,#341aff,https://cards.scryfall.io/normal/front/d/0/d0346326-6bdf-4385-ab41-7b06e9f66ffd.jpg?1783930439,Creature — Sphinx,Min Yum
+Winged Boots,2,2024,9.73,#341aff,https://cards.scryfall.io/normal/front/1/1/116361c4-fddd-440a-ad02-8d71df733231.jpg?1783911933,Artifact — Equipment,Kim Sokol
+Winged Portent,3,2021,0.35,#d78f42,https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg?1783924876,Instant,Nicholas Gregory
+Winternight Stories,3,2025,1.57,#341aff,https://cards.scryfall.io/normal/front/6/4/64d9367c-f50c-4568-aa63-6760c44ecaeb.jpg?1783907385,Sorcery,Zara Alfonso
+Winter's Chill,1,1995,1.72,#341aff,https://cards.scryfall.io/normal/front/a/7/a779aca7-ff2c-48d8-9484-6ad04b2c6bcb.jpg?1783947507,Instant,Edward P. Beard, Jr.
+Wiretapping,5,2022,0.21,#341aff,https://cards.scryfall.io/normal/front/8/5/859ed6fc-1f9a-428d-82d8-8e4b5bae6d5a.jpg?1783923136,Enchantment,Jason A. Engle
+Wisdom of Ages,7,2026,0.31,#341aff,https://cards.scryfall.io/normal/front/b/2/b227ef04-33e4-44e8-a357-0ea3dfe5d49b.jpg?1783903684,Sorcery,Jabari Weathers
+Wishing Well,4,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/e/d/edeb20aa-b253-49b8-9947-c397a3a4002a.jpg?1783910839,Artifact,Steven Belledin
+Wizards of Thay,4,2022,1.52,#341aff,https://cards.scryfall.io/normal/front/9/5/952e4e6b-fe74-4f3c-95d1-8e043f72072c.jpg?1783922772,Creature — Human Wizard,Josh Hass
+Wizard's Spellbook,7,2021,0.33,#341aff,https://cards.scryfall.io/normal/front/b/6/b6ed0a4c-0234-4341-8dcb-5eea6a9632e7.jpg?1783926504,Artifact — Book,Iris Compiet
+Wonder,4,2021,3.34,#341aff,https://cards.scryfall.io/normal/front/6/7/675d6729-23da-4f0b-b222-fe54fe24dd90.jpg?1783926787,Creature — Incarnation,Volkan Baǵa
+Wonderscape Sage,2,2024,0.27,#341aff,https://cards.scryfall.io/normal/front/c/9/c949c600-cfb5-43e1-a410-e718cf36164a.jpg?1783911424,Creature — Moonfolk Wizard,Daneen Wilkerson
+Words of Wind,3,2002,2.73,#341aff,https://cards.scryfall.io/normal/front/5/5/5595a57a-a76c-467b-afaf-5affffc24f35.jpg?1783945074,Enchantment,Eric Peterson
+Workshop Elders,7,2023,0.27,#341aff,https://cards.scryfall.io/normal/front/0/0/0058a848-cb55-408a-a500-d97f573588f5.jpg?1783917161,Creature — Human Artificer,Iain McCaig
+Worldwalker Helm,3,2024,4.24,#341aff,https://cards.scryfall.io/normal/front/b/7/b74ad496-05bc-4c5a-9027-b14df9c387ab.jpg?1783912001,Artifact,Camille Alquier
+Wormfang Behemoth,5,2002,0.16,#341aff,https://cards.scryfall.io/normal/front/1/c/1c7f29aa-c069-4adb-b313-6a56849905d4.jpg?1783945126,Creature — Nightmare Fish Beast,Heather Hudson
+Wormfang Manta,7,2002,0.54,#341aff,https://cards.scryfall.io/normal/front/b/c/bc9bf91d-6f7c-4fb5-bbc6-c012212e62e9.jpg?1783945125,Creature — Nightmare Fish Beast,Heather Hudson
+Wrath of Marit Lage,5,1995,0.42,#341aff,https://cards.scryfall.io/normal/front/1/d/1d512f5c-0327-4d49-8a26-672574a49102.jpg?1783947507,Enchantment,Mike Raabe
+Wrong Turn,3,2020,0.44,#341aff,https://cards.scryfall.io/normal/front/3/b/3b69687d-191a-4bca-b1f7-eea27847c1af.jpg?1783928845,Instant,Filip Burburan
+Xenograft,5,2011,0.76,#341aff,https://cards.scryfall.io/normal/front/f/5/f52f08e1-b234-42e4-8f1f-485a4f6edb3b.jpg?1783941316,Enchantment,Daniel Ljunggren
+Yanling's Harbinger,5,2019,0.2,#341aff,https://cards.scryfall.io/normal/front/9/3/93aca389-6830-4297-97bc-e3a2a1a1d41a.jpg?1783932920,Creature — Bird,Zezhou Chen
+Y'shtola Rhul,6,2025,5.03,#341aff,https://cards.scryfall.io/normal/front/a/e/aef218fa-13a4-4653-95d6-6b3ef1b33a92.jpg?1783906625,Legendary Creature — Cat Druid,Immanuela Crovius
+Yuan-Ti Malison,2,2021,0.36,#341aff,https://cards.scryfall.io/normal/front/0/f/0f51afd9-7093-4aa3-ad5b-7383684d6285.jpg?1783926503,Creature — Snake Rogue,Oriana Menendez
+Yue- the Moon Spirit,4,2025,0.31,#341aff,https://cards.scryfall.io/normal/front/e/c/ecdac50f-c639-43fc-a03e-d488fac96ae2.jpg?1783904978,Legendary Creature — Spirit Ally,Yuumei
+Zahid- Djinn of the Lamp,6,2018,0.18,#341aff,https://cards.scryfall.io/normal/front/4/6/469e18c7-d023-4293-85e4-1aaf336f5d8c.jpg?1783933983,Legendary Creature — Djinn,Magali Villeneuve
+Zephid,6,1998,0.9,#341aff,https://cards.scryfall.io/normal/front/e/0/e0317fff-dbad-4c47-a191-0369d81cdda2.jpg?1783946351,Creature — Illusion,Daren Bader
+Zephyr Singer,4,2023,0.32,#341aff,https://cards.scryfall.io/normal/front/9/6/9678966b-65f1-405c-b8db-5f2d4f434933.jpg?1783917021,Creature — Siren Pirate,Lie Setiawan
+Zhou Yu- Chief Commander,7,1999,150.0,#341aff,https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg?1783946117,Legendary Creature — Human Soldier,Xu Xiaoming
+Zhuge Jin- Wu Strategist,3,1999,69.57,#341aff,https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg?1783946117,Legendary Creature — Human Advisor,Song Shikai
+Zimone's Hypothesis,5,2026,0.24,#341aff,https://cards.scryfall.io/normal/front/f/9/f91afbaf-e035-47cd-b493-0d5817fefa76.jpg?1783903786,Instant,Crystal Fae
+Zndrsplt- Eye of Wisdom,5,2018,3.74,#341aff,https://cards.scryfall.io/normal/front/7/6/76c33402-a022-4d2f-9a83-4b8ddc04e971.jpg?1783934878,Legendary Creature — Homunculus,Yongjae Choi
+Zndrsplt's Judgment,5,2022,0.27,#341aff,https://cards.scryfall.io/normal/front/a/a/aa97df52-1ae7-4cfe-842a-1b13deef00ae.jpg?1783923272,Sorcery,Bayard Wu
+Zur's Weirding,4,2005,2.67,#341aff,https://cards.scryfall.io/normal/front/7/4/741612e3-fe3a-4099-9d2b-4a654c4ce949.jpg?1783944016,Enchantment,rk post

--- a/magic_card_csv_files_by_color/W.csv
+++ b/magic_card_csv_files_by_color/W.csv
@@ -1,0 +1,1618 @@
+name,cmc,release_year,price,color,image,type_line,artist
+Aang- Airbending Master,5,2025,8.01,#ffffff,https://cards.scryfall.io/normal/front/d/e/de7a150b-1b0d-4928-a2cc-80a4b7412350.jpg?1783904837,Legendary Creature — Human Avatar Ally,Tomoyo Asatani
+Aang's Iceberg,3,2025,0.45,#ffffff,https://cards.scryfall.io/normal/front/7/2/720fbd87-b1c1-4b3b-97a1-46b943b115e3.jpg?1783905007,Enchantment,Matteo Bassini
+Abeyance,2,1997,28.65,#ffffff,https://cards.scryfall.io/normal/front/1/2/125a355d-bfcf-4125-aa6c-35e7dea6f63e.jpg?1783946751,Instant,Thomas Gianni
+Abuelo's Awakening,4,2023,0.24,#ffffff,https://cards.scryfall.io/normal/front/f/9/f93b725e-2b9c-4830-ac54-b2562afe09bb.jpg?1783913817,Sorcery,Eelis Kyttanen
+Academic Probation,2,2021,0.19,#ffffff,https://cards.scryfall.io/normal/front/0/5/05521edf-f47f-4e7a-aec5-cdc4ae7368c2.jpg?1783927395,Sorcery — Lesson,Cristi Balanescu
+Academy Rector,4,1999,78.83,#ffffff,https://cards.scryfall.io/normal/front/4/3/4367bc78-0912-4abd-8edd-bc792558d01a.jpg?1783946087,Creature — Human Cleric,Heather Hudson
+Acclaimed Contender,3,2023,0.36,#ffffff,https://cards.scryfall.io/normal/front/a/5/a508ffbe-aa58-4dae-b366-fea688b60755.jpg?1783917195,Creature — Human Knight,David Gaillet
+Act of Authority,3,2013,0.87,#ffffff,https://cards.scryfall.io/normal/front/e/1/e107bd35-eddd-40f7-aea8-3a1eec3363c0.jpg?1783939693,Enchantment,Véronique Meignaud
+Adarkar Valkyrie,6,2018,1.41,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc2a4abc-85da-46a6-a616-9aa607ce7372.jpg?1783934323,Snow Creature — Angel,Jeremy Jarvis
+Adeline- Resplendent Cathar,3,2025,2.23,#ffffff,https://cards.scryfall.io/normal/front/1/d/1de30c12-2011-495a-be25-f7a46b23e142.jpg?1783907131,Legendary Creature — Human Knight,Bryan Sola
+Adept Watershaper,3,2026,0.37,#ffffff,https://cards.scryfall.io/normal/front/6/e/6e53f246-8347-4632-9d5b-4aeb12f7b762.jpg?1783904512,Creature — Merfolk Cleric,Pauline Voss
+Adipose Offspring,4,2023,0.3,#ffffff,https://cards.scryfall.io/normal/front/6/8/68f91092-b679-46c1-9f0c-3b286ee1d02f.jpg?1783914683,Creature — Alien,John Tedrick
+Admonition Angel,6,2020,0.87,#ffffff,https://cards.scryfall.io/normal/front/a/6/a6e7713d-6054-46a7-a8bc-f09e7a81a571.jpg?1783929493,Creature — Angel,Steve Argyle
+Adorned Pouncer,2,2017,0.65,#ffffff,https://cards.scryfall.io/normal/front/8/6/865e267d-450c-4eeb-b61d-bd0ec5d8534a.jpg?1783936067,Creature — Cat,Slawomir Maniak
+Aegis Angel,6,2017,0.49,#ffffff,https://cards.scryfall.io/normal/front/3/d/3d27e65f-6d55-420e-a843-16097b50f7a2.jpg?1783936168,Creature — Angel,Aleksi Briclot
+Aegis of Honor,1,2001,2.29,#ffffff,https://cards.scryfall.io/normal/front/9/5/9561ffdb-f4dd-4b62-a2c2-933498e3a061.jpg?1783945285,Enchantment,Ron Spears
+Aegis of the Gods,2,2014,0.96,#ffffff,https://cards.scryfall.io/normal/front/f/2/f2b2f381-86a2-42ac-b694-dcde437d574f.jpg?1783939463,Enchantment Creature — Human Soldier,Yefim Kligerman
+Aerial Extortionist,5,2024,4.55,#ffffff,https://cards.scryfall.io/normal/front/5/3/5353bcb9-800d-4d74-95fa-42350a0f25de.jpg?1783913034,Creature — Bird Soldier,Deruchenko Alexander
+Aerial Surveyor,3,2022,1.1,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c474f31-336d-44df-a7da-27aefd220e22.jpg?1783923999,Artifact — Vehicle,Antonio José Manzanedo
+Aerith Gainsborough,3,2025,1.88,#ffffff,https://cards.scryfall.io/normal/front/e/8/e86328b6-ded2-41df-8b6e-4a770e7b171e.jpg?1783906655,Legendary Creature — Human Cleric,Nakamura8
+Aethergeode Miner,2,2017,0.14,#ffffff,https://cards.scryfall.io/normal/front/8/0/80bb3abd-ebaf-4dc2-97eb-ed4a2b005177.jpg?1783936787,Creature — Dwarf Scout,Winona Nelson
+Aetherstorm Roc,4,2016,0.29,#ffffff,https://cards.scryfall.io/normal/front/7/9/79fb7541-7a27-40a5-aabd-fce26df03485.jpg?1783937237,Creature — Bird,Scott Murphy
+Ageless Sentinels,4,2003,0.27,#ffffff,https://cards.scryfall.io/normal/front/c/c/ccaa4a19-8eba-4c43-8a9a-636e234df751.jpg?1783944896,Creature — Wall,Tony Szczudlo
+Agent Bishop- Man in Black,3,2026,0.41,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c769202-178c-442a-a9e2-aa08b5ae5c9a.jpg?1783904129,Legendary Creature — Human Soldier,Adrián Rodríguez Pérez
+Agent Phil Coulson,2,2026,0.38,#ffffff,https://cards.scryfall.io/normal/front/1/3/1383e587-df58-4b45-9067-b9399e90b9ed.jpg?1783902979,Legendary Creature — Human Spy Hero,Marc Aspinall
+Agrus Kos- Eternal Soldier,4,2022,1.67,#d78f42,https://cards.scryfall.io/normal/front/e/a/ea531418-6c7c-4e23-b681-6bfdd4a3eb79.jpg?1783919197,Legendary Creature — Spirit Soldier,Victor Adame Minguez
+Ainok Strike Leader,2,2025,2.56,#ffffff,https://cards.scryfall.io/normal/front/c/a/cabd77a6-0913-4522-891d-c8a412a536c2.jpg?1783907186,Creature — Dog Warrior,Alexander Mokhov
+Airbender Ascension,2,2025,1.29,#ffffff,https://cards.scryfall.io/normal/front/9/9/99a90d13-891c-45cc-b1d5-6080ebae5862.jpg?1783905006,Enchantment,Shiren
+Ajani- Adversary of Tyrants,4,2018,2.09,#ffffff,https://cards.scryfall.io/normal/front/4/c/4c565076-5db2-47ea-8ee0-4a4fd7bb353d.jpg?1783934611,Legendary Planeswalker — Ajani,Victor Adame Minguez
+Ajani- Caller of the Pride,3,2024,0.66,#ffffff,https://cards.scryfall.io/normal/front/5/9/59793f1c-8c7e-433e-9c09-40aa3ce931a1.jpg?1783909088,Legendary Planeswalker — Ajani,D. Alexander Gregory
+Ajani Goldmane,4,2010,4.63,#ffffff,https://cards.scryfall.io/normal/front/2/d/2d911053-a026-4b20-ba2d-dbcc367c1413.jpg?1783941838,Legendary Planeswalker — Ajani,Aleksi Briclot
+Ajani- Nacatl Pariah // Ajani- Nacatl Avenger,2,2024,9.4,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Cat Warrior // Legendary Planeswalker — Ajani,Chris Rallis
+Ajani- Outland Chaperone,3,2026,1.05,#ffffff,https://cards.scryfall.io/normal/front/6/1/6124a691-ae83-4d22-a177-0aee65b47064.jpg?1783904513,Legendary Planeswalker — Ajani,Daren Bader
+Ajani Resolute,2,2026,49.95,#ffffff,https://cards.scryfall.io/normal/front/a/5/a5e1a7dd-8c49-4435-935c-bcc78704082b.jpg?1784338228,Legendary Planeswalker — Ajani,Tyler Jacobson
+Ajani's Chosen,4,2026,0.29,#ffffff,https://cards.scryfall.io/normal/front/b/c/bc20cca0-303f-4463-85ae-26b80ff26211.jpg?1783903815,Creature — Cat Soldier,Wayne Reynolds
+Ajani's Influence,4,2018,0.32,#ffffff,https://cards.scryfall.io/normal/front/d/3/d38ad178-35a5-44ad-b80a-d746f3e6a45c.jpg?1783934491,Sorcery,Sidharth Chaturvedi
+Ajani's Last Stand,4,2018,0.22,#ffffff,https://cards.scryfall.io/normal/front/1/a/1aebbb57-31b3-4289-815e-4f529e29f3ea.jpg?1783934610,Enchantment,Slawomir Maniak
+Ajani Steadfast,4,2023,2.12,#ffffff,https://cards.scryfall.io/normal/front/5/1/51825d35-cdb2-40fa-ab89-1625161b04af.jpg?1783915454,Legendary Planeswalker — Ajani,Chris Rahn
+Ajani- Strength of the Pride,4,2019,9.95,#ffffff,https://cards.scryfall.io/normal/front/7/9/79883468-a37c-4894-8d05-6a4d150b7d59.jpg?1783933034,Legendary Planeswalker — Ajani,Chris Rallis
+Akroma- Angel of Wrath,8,2020,6.36,#ffffff,https://cards.scryfall.io/normal/front/b/f/bf1ef8ec-d915-41f2-b087-3d6d82e3db85.jpg?1783931206,Legendary Creature — Angel,Terese Nielsen
+Akroma's Vengeance,6,2020,0.43,#ffffff,https://cards.scryfall.io/normal/front/e/4/e45b4cba-cd60-4491-a334-30976d0990b7.jpg?1783931204,Sorcery,Aleksi Briclot
+Akroma's Will,4,2023,14.73,#ffffff,https://cards.scryfall.io/normal/front/6/0/608cdbdb-6f7e-438a-bab0-0e7782435f0f.jpg?1783913897,Instant,Antonio José Manzanedo
+Akroma- Vision of Ixidor,7,2020,10.41,#ffffff,https://cards.scryfall.io/normal/front/c/0/c0bdd07d-9fb9-4ee4-80db-494ee0cba58d.jpg?1783928892,Legendary Creature — Angel,Chris Rahn
+Alabaster Dragon,6,1997,0.69,#ffffff,https://cards.scryfall.io/normal/front/3/a/3a2fcc23-ac09-4ada-b194-424739c9c734.jpg?1783946752,Creature — Dragon,Bob Eggleton
+Alabaster Leech,1,2000,0.4,#ffffff,https://cards.scryfall.io/normal/front/c/8/c86b45d9-aba6-4c09-8605-037754ba7fd4.jpg?1783945720,Creature — Leech,Edward P. Beard, Jr.
+Alaborn Veteran,3,1998,0.79,#ffffff,https://cards.scryfall.io/normal/front/7/9/79d7992d-9acd-4eaa-b6e0-a47acb880548.jpg?1783946496,Creature — Human Knight,Henry Van Der Linde
+Aligned Heart,3,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/2/a235cbda-3dc3-4aed-a911-90f26c330157.jpg?1783907184,Enchantment,Aurore Folny
+Alisaie Leveilleur,3,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/b/a/ba96f831-02cb-4a74-a2e4-7f76444e3cd7.jpg?1783906371,Legendary Creature — Elf Wizard,Justyna Dura
+Alliance of Arms,1,2011,13.33,#ffffff,https://cards.scryfall.io/normal/front/e/e/eeb1f8ff-c32f-4d75-8c04-f97d05ba47d6.jpg?1783941258,Sorcery,Johann Bodin
+Allied Teamwork,3,2025,0.88,#ffffff,https://cards.scryfall.io/normal/front/8/a/8a347283-eb16-4339-945e-316a5ce9e2c5.jpg?1783904787,Enchantment,Gemi
+Alms Collector,4,2023,1.08,#ffffff,https://cards.scryfall.io/normal/front/3/6/367ac07a-a30f-4ebf-8877-27cd9ebe2f71.jpg?1783915728,Creature — Cat Cleric,Bram Sels
+Always Watching,3,2018,1.14,#ffffff,https://cards.scryfall.io/normal/front/c/f/cf65bfa0-9c05-4e9e-b4c7-d705e1a822c1.jpg?1783933993,Enchantment,Chase Stone
+Amazing Alliance,3,2025,3.26,#ffffff,https://cards.scryfall.io/normal/front/d/d/ddc2386e-18a4-49f0-9c08-da870dc6f96e.jpg?1783905375,Enchantment,Filipe Pagliuso
+Amazing Spider-Girl,5,2026,0.61,#ffffff,https://cards.scryfall.io/normal/front/7/9/794dda34-8bc5-4cb9-8460-07f93426dd34.jpg?1783903088,Legendary Creature — Spider Human Hero,Scott M. Fischer
+Anafenza- Kin-Tree Spirit,2,2022,0.29,#ffffff,https://cards.scryfall.io/normal/front/5/b/5ba5e8b8-ce9d-450c-8804-2f8e2ef51ff0.jpg?1783921437,Legendary Creature — Spirit Soldier,Ryan Yee
+Anafenza- Unyielding Lineage,3,2025,0.28,#ffffff,https://cards.scryfall.io/normal/front/2/9/29957f49-9a6b-42f6-b2fb-b48f653ab725.jpg?1783907422,Legendary Creature — Spirit Soldier,Matt Stewart
+Ancestor Dragon,6,2024,0.49,#ffffff,https://cards.scryfall.io/normal/front/d/f/df43d9d4-3fef-4a56-8b38-d52824117201.jpg?1783908968,Creature — Dragon,Shinchuen Chen
+Ancestor's Prophet,5,2002,0.52,#ffffff,https://cards.scryfall.io/normal/front/c/d/cdee956e-76b1-4ba7-a387-2fbfb853507d.jpg?1783945105,Creature — Human Cleric,Kev Walker
+Ancestral Tribute,7,2001,0.36,#ffffff,https://cards.scryfall.io/normal/front/3/f/3f28b2af-7891-49eb-a07f-5552b5fe3d15.jpg?1783945285,Sorcery,Edward P. Beard, Jr.
+Ancient Gold Dragon,7,2022,38.8,#ffffff,https://cards.scryfall.io/normal/front/4/2/421395b1-2694-42fd-bb90-0007e78adefc.jpg?1783922822,Creature — Elder Dragon,Simon Dominic
+Angelic Arbiter,7,2020,4.98,#ffffff,https://cards.scryfall.io/normal/front/8/6/8637d263-5d7e-45bc-aad3-d97f57e6898e.jpg?1783930480,Creature — Angel,Steve Argyle
+Angelic Chorus,5,2018,8.02,#ffffff,https://cards.scryfall.io/normal/front/d/9/d9e966cb-bb42-49d8-b351-114619b31497.jpg?1783934847,Enchantment,Jim Murray
+Angelic Destiny,4,2026,0.3,#ffffff,https://cards.scryfall.io/normal/front/a/5/a588b610-86bb-4a18-b54e-a12f7d7d15c8.jpg?1783903814,Enchantment — Aura,Jana Schirmer & Johannes Voss
+Angelic Field Marshal,4,2023,2.5,#ffffff,https://cards.scryfall.io/normal/front/4/9/496e9fe2-843c-4dfe-b94a-b542a2ddaae4.jpg?1783915727,Creature — Angel,Scott Murphy
+Angelic Guardian,6,2019,5.2,#ffffff,https://cards.scryfall.io/normal/front/e/0/e058dc51-b200-42ee-a345-a63cfaa397fe.jpg?1783932914,Creature — Angel,Sara Winters
+Angelic Overseer,5,2011,1.14,#ffffff,https://cards.scryfall.io/normal/front/2/2/221d999c-dde1-4a0f-87cf-9e9f44969f94.jpg?1783940998,Creature — Angel,Jason Chan
+Angelic Sell-Sword,5,2024,0.45,#ffffff,https://cards.scryfall.io/normal/front/7/5/7581a319-8d15-4b67-a3d5-b90f1e99079b.jpg?1783911971,Creature — Angel Mercenary,Ekaterina Burmak
+Angelic Skirmisher,6,2013,2.36,#ffffff,https://cards.scryfall.io/normal/front/b/e/beb04702-5cb2-4590-b675-9409ba52a395.jpg?1783940146,Creature — Angel,David Rapoza
+Angelic Sleuth,3,2022,0.42,#ffffff,https://cards.scryfall.io/normal/front/b/0/b0d044fe-9a6b-4994-9fad-2cc52696f90d.jpg?1783923378,Creature — Angel Advisor,Marc Simonetti
+Angelic Voices,4,1995,0.44,#ffffff,https://cards.scryfall.io/normal/front/1/e/1e9a66b2-7392-4030-a3a8-8f3697307a39.jpg?1783947376,Enchantment,Julie Baroh
+Angel of Condemnation,4,2017,0.51,#ffffff,https://cards.scryfall.io/normal/front/9/0/90dad070-e41d-419b-ae27-ace82b9ab2c5.jpg?1783936067,Creature — Angel,Slawomir Maniak
+Angel of Deliverance,8,2016,0.31,#ffffff,https://cards.scryfall.io/normal/front/f/4/f4e12f83-eab8-4113-ab63-3f7a830861d4.jpg?1783937830,Creature — Angel,Joseph Meehan
+Angel of Destiny,5,2020,9.43,#ffffff,https://cards.scryfall.io/normal/front/9/8/9897074a-0ac4-4d1a-9aac-e77830cc5c78.jpg?1783929425,Creature — Angel Cleric,Ryan Pancoast
+Angel of Finality,4,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/9/0/907d710c-c54a-4e13-b057-71e4cc73f087.jpg?1783917193,Creature — Angel,Howard Lyon
+Angel of Flight Alabaster,5,2021,0.25,#ffffff,https://cards.scryfall.io/normal/front/3/f/3ff8fbcd-5db9-4cde-9f56-243b1f4924f8.jpg?1783924978,Creature — Angel,Howard Lyon
+Angel of Glory's Rise,7,2021,0.54,#ffffff,https://cards.scryfall.io/normal/front/1/8/1865ab25-b01a-4e2c-bf19-ffcb0806358f.jpg?1783925355,Creature — Angel,Andrew Mar
+Angel of Grace,5,2019,0.99,#ffffff,https://cards.scryfall.io/normal/front/8/0/80164e61-3e94-4e10-9bd1-518b8dc7fc4c.jpg?1783933727,Creature — Angel,Ryan Yee
+Angel of Indemnity,6,2026,0.39,#ffffff,https://cards.scryfall.io/normal/front/4/1/41163f43-7357-4bbc-a1e7-9c8070135c93.jpg?1783903816,Creature — Angel Warrior,Denman Rooke
+Angel of Invention,5,2025,0.31,#ffffff,https://cards.scryfall.io/normal/front/9/8/98c42f02-6eda-4ef7-929f-b3a2ece9f650.jpg?1783907130,Creature — Angel,Volkan Baǵa
+Angel of Jubilation,4,2012,10.2,#ffffff,https://cards.scryfall.io/normal/front/1/6/16c5dfed-4dee-4e48-a445-89f03d7794e6.jpg?1783940743,Creature — Angel,Terese Nielsen
+Angel of Retribution,7,2002,0.31,#ffffff,https://cards.scryfall.io/normal/front/7/f/7f3215ba-e492-4cfd-aa16-0da4818eed1b.jpg?1783945171,Creature — Angel,rk post
+Angel of Salvation,8,2023,0.27,#ffffff,https://cards.scryfall.io/normal/front/9/e/9e71046b-1284-4d7f-93dd-a632c74d9cca.jpg?1783917193,Creature — Angel,D. Alexander Gregory
+Angel of Sanctions,5,2019,0.3,#ffffff,https://cards.scryfall.io/normal/front/f/3/f3f7f258-7ac0-4149-9d8c-712b5ea7f0a8.jpg?1783932791,Creature — Angel,Min Yum
+Angel of Serenity,7,2021,1.22,#ffffff,https://cards.scryfall.io/normal/front/6/0/60301fbc-1bd4-4c37-ad19-660d625a090a.jpg?1783927581,Creature — Angel,Aleksi Briclot
+Angel of the Dire Hour,7,2020,2.1,#ffffff,https://cards.scryfall.io/normal/front/b/7/b7ab81d4-aaf7-4c72-9651-5e1482126928.jpg?1783930481,Creature — Angel,Jack Wang
+Angel of the Ruins,7,2025,0.26,#ffffff,https://cards.scryfall.io/normal/front/4/a/4ad8d899-5901-4fc8-b4f0-adcc0d97fc6e.jpg?1783906047,Artifact Creature — Angel,Viko Menezes
+Angel's Grace,1,2021,3.78,#ffffff,https://cards.scryfall.io/normal/front/e/7/e78e39ea-20be-4196-992c-7ed2cb8150c1.jpg?1783927886,Instant,Zoltan Boros
+Animate Wall,1,1999,0.57,#ffffff,https://cards.scryfall.io/normal/front/e/c/ecdb3a14-c5cc-4655-9b0c-e8be153413af.jpg?1783946217,Enchantment — Aura,Richard Kane Ferguson
+Annex Sentry,3,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/2/9/29261589-ce89-435d-9497-bb8f8b911c7f.jpg?1783917750,Artifact Creature — Phyrexian Cleric,Sam Guay
+Anointed Peacekeeper,3,2022,0.31,#ffffff,https://cards.scryfall.io/normal/front/5/b/5b8127b5-3a65-411a-84bc-54e5c1be1477.jpg?1783921372,Creature — Human Cleric,Tia Masic
+Anointed Procession,4,2017,57.23,#ffffff,https://cards.scryfall.io/normal/front/9/a/9a52c265-6920-4929-ba0a-70da08df01f1.jpg?1783936544,Enchantment,Victor Adame Minguez
+Another Round,3,2024,0.4,#ffffff,https://cards.scryfall.io/normal/front/4/f/4f8dc511-e307-4412-bb79-375a6077312d.jpg?1783911862,Sorcery,Darrell Riche
+Antiquities on the Loose,3,2026,0.25,#ffffff,https://cards.scryfall.io/normal/front/6/8/68ee92cd-51af-4de5-bcc8-34d0bb2fd398.jpg?1783903707,Sorcery,Andreas Zafiratos
+Anti-Venom- Horrifying Healer,5,2025,6.7,#ffffff,https://cards.scryfall.io/normal/front/5/6/560384fe-7be0-4b93-a515-2fe687ab2492.jpg?1783905365,Legendary Creature — Symbiote Hero,Néstor Ossandón Leal
+An Unexpected Party // At the Door,4,2026,16.48,#ffffff,https://cards.scryfall.io/normal/front/3/a/3aa29fe8-1687-486f-b4df-c04977869ab1.jpg?1783902787,Enchantment // Sorcery — Adventure,Matt Stewart
+Ao- the Dawn Sky,5,2026,0.3,#ffffff,https://cards.scryfall.io/normal/front/e/0/e002d351-3795-4cd9-b389-9ed81077845e.jpg?1783903814,Legendary Creature — Dragon Spirit,Chris Rahn
+Apothecary White,4,2024,4.54,#ffffff,https://cards.scryfall.io/normal/front/4/f/4fedf84e-55ca-4334-a2c1-6e991112bb68.jpg?1783912585,Legendary Creature — Human Cleric,Anna Steinbauer
+Appa- Steadfast Guardian,4,2025,6.59,#ffffff,https://cards.scryfall.io/normal/front/8/2/829d91e9-4878-4e55-a262-ac0d55b65d4e.jpg?1783905005,Legendary Creature — Bison Ally,Maël Ollivier-Henry
+Appa- the Vigilant,7,2025,5.0,#ffffff,https://cards.scryfall.io/normal/front/e/5/e5ead59f-4c09-4b56-913e-4ff5d6d48ac2.jpg?1783904840,Legendary Creature — Bison Ally,Fahmi Fauzi
+Approach of the Second Sun,7,2017,5.54,#ffffff,https://cards.scryfall.io/normal/front/f/d/fdf59a6e-7708-45a1-884d-d12e9f7b9ed9.jpg?1783936543,Sorcery,Noah Bradley
+Arachne- Psionic Weaver,3,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c1f871a-bd85-402e-b474-1deb64c18a52.jpg?1783905365,Legendary Creature — Spider Human Hero,Steve Argyle
+Aradesh- the Founder,3,2024,0.27,#ffffff,https://cards.scryfall.io/normal/front/6/7/6701dae4-348e-40f6-9db4-d6f0039be831.jpg?1783912420,Legendary Creature — Human Soldier,Campbell White
+Arahbo- the First Fang,3,2024,0.9,#ffffff,https://cards.scryfall.io/normal/front/5/2/524a5d93-26ed-436d-a437-dc9460acce98.jpg?1783909130,Legendary Creature — Cat Avatar,Simon Dominic
+Arashin Foremost,3,2015,0.2,#ffffff,https://cards.scryfall.io/normal/front/1/f/1f88ecc5-df1d-47e6-8cf3-1d708e2389e4.jpg?1783938620,Creature — Human Warrior,David Palumbo
+Arbiter of Knollridge,7,2018,0.37,#ffffff,https://cards.scryfall.io/normal/front/1/f/1fc2e7c4-5dbe-49f4-8c3f-192e7544df74.jpg?1783934776,Creature — Giant Wizard,Brandon Dorman
+Archaeomancer's Map,3,2026,1.18,#ffffff,https://cards.scryfall.io/normal/front/3/6/3679b9c8-ebae-474a-b862-6397edbcc4ea.jpg?1783903814,Artifact,Ovidio Cartagena
+Archangel,7,1999,0.73,#ffffff,https://cards.scryfall.io/normal/front/2/6/26f40c78-9a10-46a9-9046-561c990736fc.jpg?1783946052,Creature — Angel,Quinton Hoover
+Archangel Avacyn // Avacyn- the Purifier,5,2025,3.47,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Angel // Legendary Creature — Angel,James Ryman
+Archangel Elspeth,4,2023,4.21,#ffffff,https://cards.scryfall.io/normal/front/3/5/35ed6263-bdd7-4013-ac8c-9b652d71a0db.jpg?1783917071,Legendary Planeswalker — Elspeth,Cynthia Sheppard
+Archangel of Strife,7,2017,1.01,#ffffff,https://cards.scryfall.io/normal/front/b/1/b15514f0-0dd8-4e49-a56e-ed829f4c9623.jpg?1783936312,Creature — Angel,Greg Staples
+Archangel of Thune,5,2020,65.05,#ffffff,https://cards.scryfall.io/normal/front/1/5/15c34447-b0f4-4fcc-b557-23c92850b31b.jpg?1783930222,Creature — Angel,James Ryman
+Archangel of Tithes,4,2024,5.0,#ffffff,https://cards.scryfall.io/normal/front/c/8/c853d04c-864b-491c-8c6f-72d2d4874d2f.jpg?1783911861,Creature — Angel,Denys Tsiperko
+Archangel of Wrath,4,2022,0.28,#d78f42,https://cards.scryfall.io/normal/front/2/d/2d00bab2-e95d-4296-a805-2a05e7640efb.jpg?1783921372,Creature — Angel,Miguel Mercado
+Archangel's Light,8,2012,0.65,#ffffff,https://cards.scryfall.io/normal/front/f/9/f99837b3-b487-43bb-846b-7a0e8afb6eef.jpg?1783940857,Sorcery,Volkan Baǵa
+Archivist of Oghma,2,2022,6.51,#ffffff,https://cards.scryfall.io/normal/front/f/6/f6589e02-8c84-4069-88d1-ebcc8520cae1.jpg?1783922823,Creature — Halfling Cleric,Stella Spente
+Archon of Coronation,6,2022,0.39,#ffffff,https://cards.scryfall.io/normal/front/2/c/2c306cf7-da52-4cc4-9272-bd7d78f1175d.jpg?1783923295,Creature — Archon,Antonio José Manzanedo
+Archon of Emeria,3,2020,2.13,#ffffff,https://cards.scryfall.io/normal/front/2/2/228c1650-da3c-4099-91b6-18e3873c9cdb.jpg?1783929424,Creature — Archon,Ryan Pancoast
+Archon of Justice,5,2020,0.19,#ffffff,https://cards.scryfall.io/normal/front/0/4/042b0148-5821-4105-9cda-a0e405eb8bee.jpg?1783930477,Creature — Archon,Jason Chan
+Archon of Redemption,5,2020,0.26,#ffffff,https://cards.scryfall.io/normal/front/a/9/a9e8eb41-3800-4553-843b-ec27a44e8d55.jpg?1783930477,Creature — Archon,Steven Belledin
+Archon of Sun's Grace,4,2026,0.29,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d3af89d-d22c-45e8-9fec-170ac9bb0a34.jpg?1783903812,Creature — Archon,Matt Stewart
+Archon of the Wild Rose,4,2023,0.29,#ffffff,https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1783915137,Creature — Archon,Chris Rahn
+Archpriest of Iona,1,2022,0.35,#ffffff,https://cards.scryfall.io/normal/front/0/b/0b0b1acd-68e5-4922-8b51-06fa7eda984c.jpg?1783922493,Creature — Human Cleric,Denman Rooke
+Arena Rector,4,2018,9.92,#ffffff,https://cards.scryfall.io/normal/front/6/0/60a24826-55fc-4b1b-98bf-3204ad852765.jpg?1783934872,Creature — Human Cleric,Ryan Pancoast
+Argent Dais,2,2024,0.23,#ffffff,https://cards.scryfall.io/normal/front/b/5/b56ad225-1249-4e94-898c-ca21b132e62d.jpg?1783911304,Artifact,Carlos Palma Cruchaga
+Armageddon,4,2018,14.73,#ffffff,https://cards.scryfall.io/normal/front/7/7/77f1f6ac-983f-4f3e-8906-47f774e8367b.jpg?1783935202,Sorcery,Chris Rahn
+Armament Master,2,2009,0.21,#ffffff,https://cards.scryfall.io/normal/front/9/7/975f7752-e981-4046-ae9b-90b20db6b23a.jpg?1783942176,Creature — Kor Soldier,Steven Belledin
+Armed with Proof,3,2024,0.31,#ffffff,https://cards.scryfall.io/normal/front/6/e/6e75470f-fe57-4b6e-a76b-5daf9d9caf0b.jpg?1783913052,Enchantment,Serena Malyon
+Armistice,3,2014,0.16,#ffffff,https://cards.scryfall.io/normal/front/b/0/b09148ec-cb92-4240-b446-135036174abc.jpg?1783938861,Enchantment,Dan Frazier
+Armored Skyhunter,4,2026,0.39,#ffffff,https://cards.scryfall.io/normal/front/7/0/707e9d2e-3934-4b90-878d-4699ac1cbe89.jpg?1783903813,Creature — Cat Knight,Denman Rooke
+Arrest,3,2012,0.93,#ffffff,https://cards.scryfall.io/normal/front/8/b/8b5b9233-d183-41d1-a0a8-fdcf240f9d73.jpg?1783940527,Enchantment — Aura,Christopher Moeller
+Ascend from Avernus,3,2022,2.32,#ffffff,https://cards.scryfall.io/normal/front/6/b/6b26c05b-f166-40ab-9693-2129b4bf75e9.jpg?1783922821,Sorcery,Bruce Brenneise
+Ashes of the Abhorrent,2,2017,0.75,#ffffff,https://cards.scryfall.io/normal/front/4/e/4e8eb264-dadb-440c-af85-273e755f1db6.jpg?1783935806,Enchantment,Daarken
+Assemble the Players,2,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg?1783912930,Enchantment,Evyn Fong
+Astelli Reclaimer,5,2025,0.3,#ffffff,https://cards.scryfall.io/normal/front/4/f/4fb36405-cd28-432f-b0a4-e74ff8be928d.jpg?1783906000,Creature — Angel Warrior,Carly Milligan
+Astral Drift,3,2020,0.3,#ffffff,https://cards.scryfall.io/normal/front/0/7/07a2c7fa-7aea-4da4-b7d5-9c24f5024c74.jpg?1783931203,Enchantment,Anna Steinbauer
+Astrid Peth,2,2023,4.63,#ffffff,https://cards.scryfall.io/normal/front/4/c/4cda3aa2-5fac-4188-bdad-dc369a089d00.jpg?1783914683,Legendary Creature — Human,Ekaterina Burmak
+A Tale for the Ages,2,2023,0.2,#ffffff,https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg?1783915126,Enchantment,Julie Dillon
+Atalya- Samite Master,5,2000,1.61,#ffffff,https://cards.scryfall.io/normal/front/9/0/90500e7a-f76d-453a-bda0-d56d3f7c7534.jpg?1783945719,Legendary Creature — Human Cleric,Rebecca Guay
+Augusta- Order Returned,3,2026,0.19,#ffffff,https://cards.scryfall.io/normal/front/a/0/a0d1df84-0cb6-44fb-9916-d766d93f1519.jpg?1783903864,Legendary Creature — Spirit Advisor,Bryan Sola
+Auratog,2,1997,0.96,#ffffff,https://cards.scryfall.io/normal/front/8/6/86dca066-d5e3-442a-95a0-e695c1d5850c.jpg?1783946669,Creature — Atog,Jeff Miracola
+Aurelia's Vindicator,4,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg?1783912930,Creature — Angel,Victor Adame Minguez
+Aurification,4,2002,6.73,#ffffff,https://cards.scryfall.io/normal/front/9/3/93d9e9ea-9f88-4206-8960-b5ebe839ee16.jpg?1783945103,Enchantment,Gary Ruddell
+Auriok Champion,2,2017,9.64,#ffffff,https://cards.scryfall.io/normal/front/7/4/74b769c1-48a0-448b-98d9-0d86526ef51e.jpg?1783935559,Creature — Human Cleric,Eric Deschamps
+Auriok Salvagers,4,2013,0.31,#ffffff,https://cards.scryfall.io/normal/front/e/6/e6bc3347-6d07-4609-ae7b-4f4596a065b7.jpg?1783940008,Creature — Human Soldier,Randy Gallegos
+Auriok Steelshaper,2,2003,0.74,#ffffff,https://cards.scryfall.io/normal/front/4/d/4dd09c01-5a77-4992-96ae-c395a5966a92.jpg?1783944563,Creature — Human Soldier,Dany Orizio
+Auriok Windwalker,4,2004,0.58,#ffffff,https://cards.scryfall.io/normal/front/4/3/4315d060-9858-405c-a442-c7a278134f00.jpg?1783944411,Creature — Human Wizard,Jeremy Jarvis
+Auron- Venerated Guardian,4,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/c/b/cb82d614-13d8-40ec-9213-8e6852d37c9c.jpg?1783906371,Legendary Creature — Human Spirit Samurai,Colin Boyer
+Auspicious Ancestor,4,1996,0.69,#ffffff,https://cards.scryfall.io/normal/front/7/f/7f6f9ec3-6033-4cd4-a52e-31a559559a93.jpg?1783947125,Creature — Human Cleric,Zina Saunders
+Austere Command,6,2026,0.38,#ffffff,https://cards.scryfall.io/normal/front/a/8/a8bc7912-e201-468a-b251-140205cb741c.jpg?1783903253,Sorcery,Taurin Clarke
+Authority of the Consuls,1,2024,5.01,#ffffff,https://cards.scryfall.io/normal/front/4/2/42ce2d7f-5924-47c0-b5ed-dacf9f9617a0.jpg?1783909087,Enchantment,Lake Hurwitz
+Automated Assembly Line,2,2024,0.35,#ffffff,https://cards.scryfall.io/normal/front/f/e/fe9e2a76-1324-4b8e-b23c-10c04aca1870.jpg?1783912419,Artifact,David Álvarez
+Avacyn- Angel of Hope,8,2025,30.05,#ffffff,https://cards.scryfall.io/normal/front/7/4/74e5dcec-ef1d-4461-bb23-61d98ff082dd.jpg?1783907976,Legendary Creature — Angel,Jason Chan
+Avacyn- Guardian Angel,5,2014,1.8,#ffffff,https://cards.scryfall.io/normal/front/a/7/a79662d5-3b6f-4c5a-8540-63c201027b66.jpg?1783939204,Legendary Creature — Angel,Winona Nelson
+Avacyn's Memorial,8,2021,8.99,#ffffff,https://cards.scryfall.io/normal/front/c/8/c8134a08-4c7f-419e-940d-95bc9f630ae2.jpg?1783925373,Legendary Artifact,Kasia 'Kafis' Zielińska
+Avatar of Hope,8,2003,0.43,#ffffff,https://cards.scryfall.io/normal/front/a/f/af5d9362-4f6a-43ad-9494-9c2014a4b5ad.jpg?1783944857,Creature — Avatar,Mark Zug
+Avatar's Wrath,4,2025,3.71,#ffffff,https://cards.scryfall.io/normal/front/4/8/4811072d-fac0-40dd-a5cf-9694d51b12cf.jpg?1783905002,Sorcery,Ainezu
+Aven Brigadier,6,2002,2.13,#ffffff,https://cards.scryfall.io/normal/front/d/a/da24ef56-8d54-4146-97e9-4abded807545.jpg?1783945103,Creature — Bird Soldier,Greg Staples
+Avenge,6,2026,0.42,#ffffff,https://cards.scryfall.io/normal/front/8/b/8b385779-bc6b-4f67-8724-d8ae136d1436.jpg?1783903299,Sorcery,Alex Horley-Orlandelli
+Avenger en-Dal,2,2000,0.31,#ffffff,https://cards.scryfall.io/normal/front/f/c/fcf6f711-c0bc-4e12-b9d0-41581924e13c.jpg?1783945844,Creature — Human Spellshaper,Ron Spencer
+Avengers Assemble!,5,2026,1.04,#ffffff,https://cards.scryfall.io/normal/front/b/f/bf736399-af74-4f52-9159-67ea67d0cf83.jpg?1783902981,Enchantment,Alex Horley-Orlandelli
+Avenging Angel,5,1997,1.73,#ffffff,https://cards.scryfall.io/normal/front/2/8/28333138-60bc-459b-a0cd-1b7fd19c89cd.jpg?1783946669,Creature — Angel,Matthew D. Wilson
+Avenging Huntbonder,5,2022,0.3,#ffffff,https://cards.scryfall.io/normal/front/0/5/05e201fa-fdd3-45bf-89a2-dae8c896aa28.jpg?1783923295,Creature — Human Warrior,Evyn Fong
+Aven Interrupter,3,2024,3.14,#ffffff,https://cards.scryfall.io/normal/front/d/3/d3ca43a4-d194-440f-8099-f1fa103a108d.jpg?1783911861,Creature — Bird Rogue,Daniel Romanovsky
+Aven Mindcensor,3,2017,1.36,#ffffff,https://cards.scryfall.io/normal/front/4/0/403a50cc-fa16-42a4-b9f2-d8327e5d1bb6.jpg?1783936544,Creature — Bird Wizard,Eric Deschamps
+Aven Shrine,3,2001,0.43,#ffffff,https://cards.scryfall.io/normal/front/9/8/9890be7f-35af-43b7-b255-25be4ff20dc0.jpg?1783945282,Enchantment,Wayne England
+Axis of Mortality,6,2017,1.01,#ffffff,https://cards.scryfall.io/normal/front/3/b/3b9d72a8-8acf-42c6-8adf-cbaecb4a985a.jpg?1783935805,Enchantment,Bastien L. Deharme
+Aysen Crusader,4,1995,0.97,#ffffff,https://cards.scryfall.io/normal/front/7/9/7908cfdc-5ed6-48a8-a5b9-351864f8b4fd.jpg?1783947304,Creature — Human Knight,NéNé Thomas
+Aysen Highway,6,1995,0.96,#ffffff,https://cards.scryfall.io/normal/front/a/d/adfa87eb-9a11-459c-bff8-87bb09b61b87.jpg?1783947304,Enchantment,NéNé Thomas
+Balance,2,2016,1.95,#ffffff,https://cards.scryfall.io/normal/front/c/e/ce648aa3-098b-4af0-a433-fd290bc85904.jpg?1783937636,Sorcery,Kev Walker
+Balancing Act,4,2001,1.65,#ffffff,https://cards.scryfall.io/normal/front/7/d/7d6cb368-43f7-4d06-9cd5-492df5766567.jpg?1783945282,Sorcery,Scott M. Fischer
+Balan- Wandering Knight,4,2023,0.45,#ffffff,https://cards.scryfall.io/normal/front/0/4/049ebad9-bf65-48e2-9640-c11b5f04e38b.jpg?1783915727,Legendary Creature — Cat Knight,Svetlin Velinov
+Baldin- Century Herdmaster,6,2025,0.3,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc018483-69a7-4c4c-adfe-44071f53a7de.jpg?1783907130,Legendary Creature — Human Warrior,Zoltan Boros
+Baneslayer Angel,5,2020,2.96,#ffffff,https://cards.scryfall.io/normal/front/4/b/4bd3014b-94bb-4a9f-92cf-239a2dcc7e97.jpg?1783930746,Creature — Angel,Greg Staples
+Barbara Wright,2,2023,0.86,#ffffff,https://cards.scryfall.io/normal/front/4/1/414bdd33-549d-4690-917c-ea48decffbbb.jpg?1783914681,Legendary Creature — Human Advisor,Irina Nordsol
+Barren Glory,6,2007,1.4,#ffffff,https://cards.scryfall.io/normal/front/1/2/12220d53-3356-4541-aa43-a0de6ed3f7d0.jpg?1783943130,Enchantment,Dave Kendall
+Basri Ket,3,2020,1.56,#ffffff,https://cards.scryfall.io/normal/front/9/8/98c85699-2daf-4e87-a3be-465d02bd64bb.jpg?1783930745,Legendary Planeswalker — Basri,Kieran Yanner
+Basri's Aegis,4,2020,0.09,#ffffff,https://cards.scryfall.io/normal/front/5/7/577657ed-162f-4104-b0af-ee9733e90f20.jpg?1783930624,Sorcery,Paul Scott Canavan
+Basri's Lieutenant,4,2020,0.34,#ffffff,https://cards.scryfall.io/normal/front/7/4/74b1eae0-1bf8-4922-a9e3-45c01ece9005.jpg?1783930745,Creature — Human Knight,Matt Stewart
+Basri- Tomorrow's Champion,1,2025,0.3,#ffffff,https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg?1783907922,Legendary Creature — Human Knight,Kai Carpenter
+Bastion Protector,3,2026,0.32,#ffffff,https://cards.scryfall.io/normal/front/1/5/1582488a-ad15-487e-9271-6d9330b46fb4.jpg?1783903254,Creature — Human Soldier,Uzuri
+Battle Angels of Tyr,4,2022,28.74,#ffffff,https://cards.scryfall.io/normal/front/4/c/4c91dbf4-94fa-45d0-b8ed-a778b11d789b.jpg?1783922818,Creature — Angel Knight,Fajareka Setiawan
+Battle at the Helvault,6,2023,4.87,#ffffff,https://cards.scryfall.io/normal/front/0/d/0de0eaeb-9b62-427d-9873-d84de1740ddc.jpg?1783915486,Enchantment — Saga,Alix Branwyn
+Battlegrace Angel,5,2015,1.22,#ffffff,https://cards.scryfall.io/normal/front/1/c/1cf72b23-a951-4e88-a52b-b3abe8f16bf4.jpg?1783938429,Creature — Angel,Matt Stewart
+Battle of Hoover Dam,4,2024,0.34,#ffffff,https://cards.scryfall.io/normal/front/5/9/59c0f13a-4e83-4e0b-a790-1f78b5ee6a64.jpg?1783912419,Enchantment,Campbell White
+Battletide Alchemist,5,2008,3.73,#ffffff,https://cards.scryfall.io/normal/front/9/a/9a5357e0-ff69-4bb9-9a02-b0372e0ea5e5.jpg?1783942808,Creature — Kithkin Cleric,Steve Prescott
+Beacon of Destiny,2,2003,0.43,#ffffff,https://cards.scryfall.io/normal/front/3/0/30b1cad7-4e96-4ebe-8c99-4ed9217becf3.jpg?1783944930,Creature — Human Cleric,Tim Hildebrandt
+Beacon of Immortality,6,2007,15.05,#ffffff,https://cards.scryfall.io/normal/front/f/0/f0b9b5da-d3fa-4d70-a71a-a2342dbfd527.jpg?1783943081,Instant,Rob Alexander
+Beast Walkers,3,1995,0.53,#d78f42,https://cards.scryfall.io/normal/front/9/9/99b42f6c-5c7e-4ba8-b0fb-ac8564aaf825.jpg?1783947303,Creature — Human Beast Soldier,Heather Hudson
+Beatrix- Loyal General,6,2025,0.81,#ffffff,https://cards.scryfall.io/normal/front/9/d/9da83b07-4978-4af7-be51-8aa8f35ec0bb.jpg?1783906435,Legendary Creature — Human Soldier,Bachzim
+Belonging,6,2026,0.28,#ffffff,https://cards.scryfall.io/normal/front/a/9/a930c3f1-9c59-4627-829a-3cefb87ae2f4.jpg?1783904607,Creature — Elemental Incarnation,Danny Schwartz
+Beloved Princess,1,2024,3.14,#ffffff,https://cards.scryfall.io/normal/front/a/9/a905ed56-16cd-455f-8bba-8daef06a07da.jpg?1783908200,Creature — Human Noble,Evyn Fong
+Benalish Commander,4,2021,0.24,#ffffff,https://cards.scryfall.io/normal/front/9/a/9a8d57fb-abe1-483b-8b94-85d39a1c31e1.jpg?1783927880,Creature — Human Soldier,Paolo Parente
+Benalish Marshal,3,2018,0.84,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc395215-a2ec-49e1-9b1b-f8fcfe73e361.jpg?1783933992,Creature — Human Knight,Mark Zug
+Benevolent Offering,4,2021,1.28,#ffffff,https://cards.scryfall.io/normal/front/d/0/d080c35d-f2c6-4f4e-8f7c-305b319d4cde.jpg?1783924980,Instant,Ryan Yee
+Bennie Bracks- Zoologist,4,2024,11.47,#ffffff,https://cards.scryfall.io/normal/front/9/0/90645549-20f1-4fe9-8363-7f67c20fa3b6.jpg?1783913033,Legendary Creature — Elf Druid,Eric Deschamps
+Beregond of the Guard,4,2023,0.31,#ffffff,https://cards.scryfall.io/normal/front/6/a/6aad41a6-e894-43f8-a4b5-abc206836306.jpg?1783916037,Legendary Creature — Human Soldier,Campbell White
+Beyond the Quiet,5,2025,0.39,#ffffff,https://cards.scryfall.io/normal/front/c/e/ce503869-8130-4afe-9691-4e90376b4bc4.jpg?1783905999,Sorcery,Yohann Schepacz
+Beza- the Bounding Spring,4,2024,4.53,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc310a26-b6a0-4e42-98ab-bdfd7b06cb63.jpg?1783910866,Legendary Creature — Elemental Elk,Martin Wittfooth
+Bishop of Binding,4,2018,0.25,#ffffff,https://cards.scryfall.io/normal/front/a/a/aaadceb3-8a57-45de-b3f1-aca94f20de18.jpg?1783935342,Creature — Vampire Cleric,Bastien L. Deharme
+Bishop of Rebirth,5,2017,0.44,#ffffff,https://cards.scryfall.io/normal/front/3/d/3d654bec-4eb2-4df6-b71e-ce59a718f903.jpg?1783935804,Creature — Vampire Cleric,Tommy Arnold
+Bishop of Wings,2,2019,3.96,#ffffff,https://cards.scryfall.io/normal/front/c/a/ca42da05-330d-4050-a580-dc00f6faff24.jpg?1783933032,Creature — Human Cleric,Matt Stewart
+Black Panther- Claws of Bast,3,2026,6.57,#ffffff,https://cards.scryfall.io/normal/front/4/c/4cb5a5ad-35fb-4e90-bc8b-d70a9d3bfba7.jpg?1783903001,Legendary Creature — Human Warrior Hero,Alex Horley-Orlandelli
+Black Panther- Most Dangerous,3,2026,0.92,#ffffff,https://cards.scryfall.io/normal/front/a/1/a10f1578-2b8a-49c6-ab59-dd2c5fb1d69f.jpg?1783903088,Legendary Creature — Human Warrior Hero,Dan Dos Santos
+Black Widow- Intel Expert,3,2026,2.31,#ffffff,https://cards.scryfall.io/normal/front/4/9/49671454-db5d-4b0f-a609-7f717dd96d24.jpg?1783903109,Legendary Creature — Human Spy Hero,Thanh Tuấn
+Blade Splicer,3,2023,0.27,#ffffff,https://cards.scryfall.io/normal/front/3/d/3dac9526-388d-487e-a790-066f83050794.jpg?1783917190,Creature — Phyrexian Human Artificer,Greg Staples
+Blaze of Glory,1,1993,99.48,#ffffff,https://cards.scryfall.io/normal/front/2/d/2d636573-287d-4f6f-93b0-12ddd8f3e6d1.jpg?1783948590,Instant,Richard Thomas
+Blazing Archon,9,2024,0.43,#ffffff,https://cards.scryfall.io/normal/front/f/5/f5e43875-ab5e-4233-892d-fc2c5687fae8.jpg?1783913350,Creature — Archon,Zoltan Boros & Gabor Szikszai
+Blessed Reversal,2,2003,0.4,#ffffff,https://cards.scryfall.io/normal/front/8/0/806d854b-a165-4d40-86d7-d6a0aa17ce18.jpg?1783944854,Instant,Christopher Moeller
+Blessed Sanctuary,5,2020,4.12,#ffffff,https://cards.scryfall.io/normal/front/f/f/ff80029e-650e-469d-8393-0edf7d9cd695.jpg?1783930511,Enchantment,Anastasia Ovchinnikova
+Blessed Wind,9,2000,0.44,#ffffff,https://cards.scryfall.io/normal/front/3/c/3cb624d6-9aec-498c-8df9-6fd025c74487.jpg?1783945799,Sorcery,Anthony S. Waters
+Blessing,2,1995,0.6,#ffffff,https://cards.scryfall.io/normal/front/e/e/eea35ac3-071d-4a42-9a7a-9104fe63bddc.jpg?1783947875,Enchantment — Aura,Julie Baroh
+Blinding Angel,5,2005,5.1,#ffffff,https://cards.scryfall.io/normal/front/e/0/e04256f8-c275-4a24-8a95-371d424f7a01.jpg?1783944119,Creature — Angel,Todd Lockwood
+Blinding Light,3,1999,0.87,#ffffff,https://cards.scryfall.io/normal/front/4/6/46408a88-4e96-48c0-98e2-d0d3ccecf459.jpg?1783946052,Sorcery,John Coulthart
+Blind Obedience,2,2024,6.39,#ffffff,https://cards.scryfall.io/normal/front/d/8/d859e1f9-feb3-497a-af0b-f74fee46861f.jpg?1783913350,Enchantment,Seb McKinnon
+Blinking Spirit,4,2005,0.27,#ffffff,https://cards.scryfall.io/normal/front/6/9/692ac387-be1f-48e0-945e-cbb1254d395c.jpg?1783944116,Creature — Spirit,Allen Williams
+Bonescythe Sliver,4,2023,4.97,#ffffff,https://cards.scryfall.io/normal/front/7/a/7ae24f37-0788-4f53-af5a-c6c1f2b64894.jpg?1783915453,Creature — Sliver,Lius Lasahido
+Boon-Bringer Valkyrie,5,2023,0.54,#ffffff,https://cards.scryfall.io/normal/front/8/4/84e1cc7d-e645-4b0e-b117-63f93528ed12.jpg?1783917067,Creature — Angel Warrior,Heonhwa
+Boon of the Spirit Realm,5,2023,7.36,#ffffff,https://cards.scryfall.io/normal/front/a/5/a588fc39-ed88-4262-96cd-908fadc7f049.jpg?1783915485,Enchantment,Gaboleps
+Boon Reflection,5,2020,12.51,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d4032a7-600c-4b30-a012-fe3cde1be9c9.jpg?1783930220,Enchantment,Chris Seaman
+Boreas Charger,3,2021,0.32,#ffffff,https://cards.scryfall.io/normal/front/3/c/3cab81be-47d7-4f76-b031-072ac1a7fbc2.jpg?1783924977,Creature — Pegasus,Christine Choi
+Boromir- Warden of the Tower,3,2023,6.14,#ffffff,https://cards.scryfall.io/normal/front/f/6/f6bc3720-2892-4dda-8f30-079a1ac8e1e2.jpg?1783916338,Legendary Creature — Human Soldier,Yigit Koroglu
+Boss's Chauffeur,5,2022,0.31,#ffffff,https://cards.scryfall.io/normal/front/1/4/147a0ccf-3408-48c7-b4a8-6d81aed39f18.jpg?1783923377,Creature — Elf Citizen,Yangtian Li
+Bounty Agent,2,2020,0.35,#ffffff,https://cards.scryfall.io/normal/front/1/5/1542ad81-169e-4ac8-bd85-038494489594.jpg?1783931204,Creature — Human Soldier,Randy Vargas
+Brave the Elements,1,2011,6.67,#ffffff,https://cards.scryfall.io/normal/front/4/6/46357985-9b59-4ad7-aa18-4c8c28fe8bb5.jpg?1783941555,Instant,Kekai Kotaki
+Breathkeeper Seraph,6,2021,1.69,#ffffff,https://cards.scryfall.io/normal/front/9/9/992244dc-d988-41ce-9e3d-cd8034ccc50f.jpg?1783924997,Creature — Angel,Alexander Mokhov
+Brightling,3,2018,0.73,#ffffff,https://cards.scryfall.io/normal/front/b/1/b11d200b-4bf0-4510-8bdb-9de310516286.jpg?1783934871,Creature — Shapeshifter,Steve Argyle
+Brigid- Clachan's Heart // Brigid- Doun's Mind,3,2026,0.62,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Kithkin Warrior // Legendary Creature — Kithkin Soldier,Zoltan Boros
+Brigid- Hero of Kinsbaile,4,2007,6.5,#ffffff,https://cards.scryfall.io/normal/front/d/a/da70a20f-213e-4d79-a46f-1ef1fc3f4a51.jpg?1783942917,Legendary Creature — Kithkin Archer,Steve Prescott
+Brigone- Soldier of Meletis,2,2024,1.43,#ffffff,https://cards.scryfall.io/normal/front/2/0/20ecadef-8aa3-4bca-8744-adbc809083c3.jpg?1783908862,Legendary Creature — Human Soldier,Daisuke Tatsuma
+Brilliant Restoration,7,2022,2.32,#ffffff,https://cards.scryfall.io/normal/front/6/4/64f7a506-0aa1-4c2d-b322-e0e9179d05fb.jpg?1783923925,Sorcery,Wylie Beckert
+Brilliant Wings,2,2025,38.45,#ffffff,https://cards.scryfall.io/normal/front/c/3/c358af5d-61e3-4c4d-9d7d-2f3e43210339.jpg?1783904653,Enchantment — Aura,Erion Makuo
+Brimaz- King of Oreskos,3,2014,8.92,#ffffff,https://cards.scryfall.io/normal/front/f/5/f54eb705-6326-4bac-bf0e-68d42db7a270.jpg?1783939586,Legendary Creature — Cat Soldier,Peter Mohrbacher
+Bringer of the White Dawn,9,2004,1.66,#d78f42,https://cards.scryfall.io/normal/front/9/e/9e5a7117-b1e2-46bd-873e-baf9d9fac009.jpg?1783944410,Creature — Bringer,Kev Walker
+Bronzebeak Foragers,4,2023,0.63,#ffffff,https://cards.scryfall.io/normal/front/d/a/dadfcd91-3000-448e-a304-be425ff68644.jpg?1783913914,Creature — Dinosaur,Brian Valeza
+Bronze Guardian,5,2021,1.25,#ffffff,https://cards.scryfall.io/normal/front/8/c/8cd5cc66-2ade-4142-9269-7d9905b029e5.jpg?1783927610,Artifact Creature — Golem,Grzegorz Rutkowski
+Brotherhood Scribe,2,2024,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/7/b751250e-ebf2-42b1-9a45-779b39974ba7.jpg?1783912418,Creature — Human Artificer,Jarel Threat
+Brought Back,2,2019,2.53,#ffffff,https://cards.scryfall.io/normal/front/a/e/aecdc315-95e5-450c-bedc-998eea46cf8c.jpg?1783933031,Instant,Mitchell Malloy
+Bruna- the Fading Light,7,2025,4.3,#ffffff,https://cards.scryfall.io/normal/front/6/f/6fccdb60-5fce-4a6e-a709-b986f9a4b653.jpg?1783908189,Legendary Creature — Angel Horror,Clint Cearley
+Brutal Cathar // Moonrage Brute,3,2021,0.31,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Soldier Werewolf // Creature — Werewolf,Karl Kopinski
+Bulwark Ox,2,2025,0.36,#ffffff,https://cards.scryfall.io/normal/front/1/0/106944b2-f3ae-4350-be33-61b9f92fc92f.jpg?1783907920,Creature — Ox Mount,Brent Hollowell
+By Gnome Means,3,2017,0.28,#ffffff,https://cards.scryfall.io/normal/front/e/6/e6921466-edac-40fc-8f5e-d8b2e766d1dd.jpg?1783935464,Enchantment,Sean Murray
+Bygone Bishop,3,2022,0.36,#ffffff,https://cards.scryfall.io/normal/front/c/f/cf879fc7-9f84-40a7-a7be-9cc98a720af5.jpg?1783922492,Creature — Spirit Cleric,Jason A. Engle
+By Invitation Only,5,2021,0.34,#ffffff,https://cards.scryfall.io/normal/front/4/6/46764e49-64da-4a94-b61c-75e006b2c5a9.jpg?1783924927,Sorcery,Micah Epstein
+Caduceus- Staff of Hermes,3,2024,6.5,#ffffff,https://cards.scryfall.io/normal/front/2/b/2b60f18e-4709-4b91-a342-74eb3fca71e1.jpg?1783910988,Legendary Artifact — Equipment,Evan Shipard
+Call for Unity,5,2017,0.17,#ffffff,https://cards.scryfall.io/normal/front/e/e/eeca4557-98aa-433b-a3ee-050e4a3e6d88.jpg?1783936781,Enchantment,John Severin Brassell
+Call the Coppercoats,3,2022,7.44,#ffffff,https://cards.scryfall.io/normal/front/e/2/e203daaf-bd68-4251-9106-00299b3ad662.jpg?1783923293,Instant,Cristi Balanescu
+Call the Gatewatch,3,2016,0.51,#ffffff,https://cards.scryfall.io/normal/front/4/7/4719ac60-2cff-4abb-b9cc-b677d3ac945c.jpg?1783937928,Sorcery,Yefim Kligerman
+Call to Arms,2,1995,0.76,#ffffff,https://cards.scryfall.io/normal/front/a/9/a92f0d4a-23d8-47d4-b910-d142e0eefd3d.jpg?1783947529,Enchantment,Randy Gallegos
+Cantivore,3,2001,0.51,#ffffff,https://cards.scryfall.io/normal/front/b/5/b5243fc3-176b-44a3-9f1a-ab069a08757a.jpg?1783945281,Creature — Lhurgoyf,Daren Bader
+Captain America- Liberator,5,2026,3.21,#ffffff,https://cards.scryfall.io/normal/front/b/f/bfa75d51-307f-45da-8fac-81bb32830ee9.jpg?1783903085,Legendary Creature — Human Soldier Hero,E. M. Gist
+Captain America- Skybound,5,2026,2.9,#ffffff,https://cards.scryfall.io/normal/front/4/9/49d952d9-8584-435a-bf45-62bf13887083.jpg?1783903086,Legendary Creature — Human Soldier Hero,Ron Lemen
+Captain America- Steve Rogers,5,2026,2.76,#ffffff,https://cards.scryfall.io/normal/front/c/d/cdbfb76f-0ec1-445f-8341-0a64f495c79f.jpg?1783902999,Legendary Creature — Human Soldier Hero,Alexander Lozano
+Captain America- Super-Soldier,3,2026,4.32,#ffffff,https://cards.scryfall.io/normal/front/3/3/33631d6c-c584-42ff-afe5-2647b5fb321f.jpg?1783902981,Legendary Creature — Human Soldier Hero,Anna Podedworna
+Captain America- Unbowed,4,2026,3.02,#ffffff,https://cards.scryfall.io/normal/front/1/f/1f482932-a157-4884-934c-20fca1da7a66.jpg?1783903109,Legendary Creature — Human Soldier Hero,Thanh Tuấn
+Captain America- Wings of Freedom,3,2026,0.38,#ffffff,https://cards.scryfall.io/normal/front/c/8/c87ca9ce-5034-4137-99cc-c2b28f298912.jpg?1783902978,Legendary Creature — Human Soldier Hero,Dan Dos Santos
+Captain Marvel- Earth's Protector,5,2026,0.9,#ffffff,https://cards.scryfall.io/normal/front/e/b/eb098550-22e6-4079-8c59-ed9ec2f764e3.jpg?1783902976,Legendary Creature — Human Kree Hero,Victor Adame Minguez
+Captain Marvel- Shooting Star,7,2026,20.17,#ffffff,https://cards.scryfall.io/normal/front/b/c/bc52fc96-69ea-4eda-97ec-6f54014797c2.jpg?1783903085,Legendary Creature — Human Kree Hero,PINDURSKI
+Captain of the Watch,6,2015,0.41,#ffffff,https://cards.scryfall.io/normal/front/6/e/6e201980-e220-44dc-beab-ad13c20332bd.jpg?1783938638,Creature — Human Soldier,Greg Staples
+Captured by the Consulate,4,2016,0.22,#ffffff,https://cards.scryfall.io/normal/front/e/0/e0c20018-4446-4c2b-bdc5-53fcf1fbc3bf.jpg?1783937235,Enchantment — Aura,Tyler Jacobson
+Caretaker's Talent,3,2024,8.38,#ffffff,https://cards.scryfall.io/normal/front/a/d/ad5ea98a-e36e-4ab9-b4da-cc572f3777db.jpg?1783910865,Enchantment — Class,Lindsey Look
+Cartographer's Hawk,2,2020,0.56,#ffffff,https://cards.scryfall.io/normal/front/1/b/1b1d26c3-ce06-4d46-87fc-7623edae85b2.jpg?1783931225,Creature — Bird,Donato Giancola
+Case of the Uneaten Feast,1,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/a/c/ac63941b-3f78-4bd3-8b05-ca12aaaa006c.jpg?1783912926,Enchantment — Case,Titus Lunter
+Cataclysmic Gearhulk,5,2023,0.3,#ffffff,https://cards.scryfall.io/normal/front/d/5/d5b8efa8-2d62-45b8-9e48-6be0a4ee944d.jpg?1783917189,Artifact Creature — Construct,Victor Adame Minguez
+Catapult Master,5,2010,1.36,#ffffff,https://cards.scryfall.io/normal/front/5/4/544df614-277e-43dd-8611-3ec1e1747f57.jpg?1783941768,Creature — Human Soldier,Terese Nielsen
+Catastrophe,6,1998,3.58,#ffffff,https://cards.scryfall.io/normal/front/2/9/294d21dc-5c76-4449-936f-9b7541d37c86.jpg?1783946377,Sorcery,Andrew Robinson
+Cathars' Crusade,5,2025,8.6,#ffffff,https://cards.scryfall.io/normal/front/5/2/5296e353-2efc-4d72-a877-7957eff630b9.jpg?1783908185,Enchantment,Karl Kopinski
+Cavalier of Dawn,5,2019,7.69,#ffffff,https://cards.scryfall.io/normal/front/f/7/f7b1919e-c0c1-4ac7-9061-a337b6fe7273.jpg?1783933033,Creature — Elemental Knight,Daarken
+Ceaseless Conflict,5,2026,0.24,#ffffff,https://cards.scryfall.io/normal/front/a/0/a0e18f74-7fa6-4e3a-bc80-390a25055205.jpg?1783903866,Sorcery,Liiga Smilshkalne
+Cecil- Dark Knight // Cecil- Redeemed Paladin,1,2025,0.75,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Knight // Legendary Creature — Human Knight,Josu Hernaiz
+Celestial Ancient,5,2016,0.6,#ffffff,https://cards.scryfall.io/normal/front/b/9/b942e6ca-fd5a-4462-9413-c82483601b61.jpg?1783936845,Creature — Elemental,Mark Tedin
+Celestial Archon,5,2018,0.24,#ffffff,https://cards.scryfall.io/normal/front/c/4/c40cb58f-370f-487a-9a96-bdce173aa3c6.jpg?1783934321,Enchantment Creature — Archon,Matt Stewart
+Celestial Armor,3,2024,0.42,#ffffff,https://cards.scryfall.io/normal/front/8/0/809ee8ad-1573-49e5-9e84-b7cdd29efcae.jpg?1783909129,Artifact — Equipment,Olena Richards
+Celestial Convergence,4,2000,1.44,#ffffff,https://cards.scryfall.io/normal/front/e/8/e8e5c9ca-b453-488b-8702-fc74907a8335.jpg?1783945799,Enchantment,Ray Lago
+Celestial Dawn,3,1999,0.76,#ffffff,https://cards.scryfall.io/normal/front/3/a/3a51b3c5-7b4a-4ed3-be33-5b854c005b99.jpg?1783946215,Enchantment,Liz Danforth
+Celestial Force,8,2011,1.13,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d51a3f0-2546-43c1-9a92-625997a24e9b.jpg?1783941255,Creature — Elemental,Véronique Meignaud
+Celestial Gatekeeper,5,2003,1.93,#ffffff,https://cards.scryfall.io/normal/front/0/b/0b4dc1d3-53a1-411b-abf9-f5e4e80edc63.jpg?1783944931,Creature — Bird Cleric,Christopher Moeller
+Celestial Judgment,6,2021,0.24,#ffffff,https://cards.scryfall.io/normal/front/5/f/5fd29cd7-9950-49c0-9e71-d6b0f944292c.jpg?1783925382,Sorcery,Alexander Mokhov
+Celestial Kirin,4,2005,1.02,#ffffff,https://cards.scryfall.io/normal/front/0/0/003e99a0-2caa-407b-be40-92ec17836eb3.jpg?1783944174,Legendary Creature — Kirin Spirit,Adam Rex
+Celestial Mantle,6,2020,10.76,#ffffff,https://cards.scryfall.io/normal/front/1/3/136dfcf5-130a-4d75-9785-a090215a29b1.jpg?1783930475,Enchantment — Aura,Steve Argyle
+Celestial Purge,2,2010,10.85,#ffffff,https://cards.scryfall.io/normal/front/1/a/1a5dbac5-273c-4452-a9c2-32fb6086a8d1.jpg?1783942073,Instant,Nils Hamm
+Celestine- the Living Saint,5,2022,27.35,#ffffff,https://cards.scryfall.io/normal/front/a/0/a099cbd2-e92a-433a-bc51-0aa2f8fc6857.jpg?1783920947,Legendary Creature — Human Warrior,Irina Nordsol
+Cemetery Protector,4,2021,0.88,#ffffff,https://cards.scryfall.io/normal/front/c/0/c00731eb-69fe-42f3-9919-66a4cdec00f7.jpg?1783924926,Creature — Human Soldier,Chris Rallis
+Chained to the Rocks,1,2013,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/5/a5af083f-5820-4185-ac04-4c4368f7703c.jpg?1783939823,Enchantment — Aura,Aaron Miller
+Champion of the Clachan,4,2026,0.16,#ffffff,https://cards.scryfall.io/normal/front/4/6/46ce3474-381c-433b-acd8-4e628d0048d2.jpg?1783904510,Creature — Kithkin Knight,Edgar Sánchez Hidalgo
+Champion of the Parish,1,2016,1.04,#ffffff,https://cards.scryfall.io/normal/front/e/c/ec2120ff-a6d4-4192-96c0-33c139155ddf.jpg?1783937860,Creature — Human Soldier,Svetlin Velinov
+Champions from Beyond,2,2025,5.16,#ffffff,https://cards.scryfall.io/normal/front/d/1/d1031ce5-063f-4c38-a6a9-abc15d254dfc.jpg?1783906370,Enchantment,Darius Zablockis
+Champions of Minas Tirith,6,2023,0.32,#ffffff,https://cards.scryfall.io/normal/front/3/4/34301efe-7085-476b-90e6-7ecd778b2970.jpg?1783916037,Creature — Human Soldier,Tatiana Kirgetova
+Chancellor of the Annex,7,2011,3.23,#ffffff,https://cards.scryfall.io/normal/front/b/e/be1b482a-badb-4b9a-ab63-2e7944826aa0.jpg?1783941327,Creature — Phyrexian Angel,Min Yum
+Charismatic Conqueror,2,2023,21.9,#ffffff,https://cards.scryfall.io/normal/front/5/9/599c934d-bfff-43ce-a545-6e3cde124515.jpg?1783913915,Creature — Vampire Soldier,Bram Sels
+Charming Prince,2,2024,0.38,#ffffff,https://cards.scryfall.io/normal/front/a/a/aa7b47e1-7e32-4f2f-aecf-bac7ca197081.jpg?1783908943,Creature — Human Noble,Randy Vargas
+Chivalric Alliance,2,2023,14.17,#ffffff,https://cards.scryfall.io/normal/front/f/9/f96d4b03-e3b0-4b24-869d-4270b813b518.jpg?1783917292,Enchantment,Jim Pavelec
+Cho-Arrim Alchemist,1,1999,0.45,#ffffff,https://cards.scryfall.io/normal/front/4/2/42c9d49d-61eb-4f33-b06b-03bdd990efd0.jpg?1783945984,Creature — Human Spellshaper,Scott M. Fischer
+Cho-Arrim Bruiser,6,1999,0.46,#ffffff,https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg?1783945983,Creature — Ogre Rebel,Paolo Parente
+Chocobo Knights,4,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/e/8/e874e435-7ade-4299-9803-1358c0f07a8f.jpg?1783906370,Creature — Human Knight,Néstor Ossandón Leal
+Cho-Manno- Revolutionary,4,2007,0.46,#ffffff,https://cards.scryfall.io/normal/front/f/e/fe04dfe7-6376-4c12-9404-0e1ae0942917.jpg?1783943080,Legendary Creature — Human Rebel,Steven Belledin
+Chronosavant,6,2006,0.36,#ffffff,https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg?1783943257,Creature — Giant,Pete Venters
+Cid- Freeflier Pilot,2,2025,0.42,#ffffff,https://cards.scryfall.io/normal/front/a/f/afa9e3e6-a633-46ad-b52a-48574b2f3d07.jpg?1783906369,Legendary Creature — Human Warrior Pilot,Billy Christian
+Circle of Solace,4,2002,0.37,#ffffff,https://cards.scryfall.io/normal/front/0/7/07f567dc-8a60-40e1-b947-199872d8df08.jpg?1783945101,Enchantment,Greg Hildebrandt & Tim Hildebrandt
+Citadel Siege,4,2021,0.3,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c13bc7c-a536-44d0-8c89-49ff33bee326.jpg?1783925354,Enchantment,Steven Belledin
+Citywide Bust,3,2020,0.26,#ffffff,https://cards.scryfall.io/normal/front/3/3/33d1a51a-abf0-458c-98ae-98fcf4063fd9.jpg?1783931201,Sorcery,Victor Adame Minguez
+Claim Jumper,3,2026,0.36,#ffffff,https://cards.scryfall.io/normal/front/1/1/11bda4c5-099f-489e-b64b-f4719241cf9d.jpg?1783903812,Creature — Rabbit Mercenary,Gaboleps
+Clarion Conqueror,3,2025,2.12,#ffffff,https://cards.scryfall.io/normal/front/f/8/f892d156-371c-4391-8ae6-25513c5032b0.jpg?1783907419,Creature — Dragon,Nathaniel Himawan
+Cleansing,3,1994,10.6,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc1973a3-1410-4c6d-9b09-bd9d18646a1e.jpg?1783947949,Sorcery,Pete Venters
+Clever Concealment,4,2026,4.7,#ffffff,https://cards.scryfall.io/normal/front/4/1/41d45a8a-ea1d-4fbc-86d2-5d6340f3b639.jpg?1783903251,Instant,Jurijus Chitrovas
+Cloud- Midgar Mercenary,2,2025,21.66,#ffffff,https://cards.scryfall.io/normal/front/2/c/2cf7e8a3-fad7-413d-b17c-7519a9cf5fb5.jpg?1783906652,Legendary Creature — Human Soldier Mercenary,Kazto Furuya
+Cloud's Limit Break,2,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/1/e/1eb10082-4f0a-41f9-9a70-0d3c7ead249f.jpg?1783906371,Instant,Billy Christian
+Cloudsteel Kirin,3,2022,0.36,#ffffff,https://cards.scryfall.io/normal/front/a/1/a13ddda7-da6e-415e-8886-295514f862d4.jpg?1783923925,Artifact Creature — Equipment Kirin,Jonathan Kuo
+Codsworth- Handy Helper,3,2024,25.24,#ffffff,https://cards.scryfall.io/normal/front/b/b/bbdfbd21-61b1-4ebd-8d37-bce2a391a7e9.jpg?1783912418,Legendary Artifact Creature — Robot,Alex Konstad
+Coin of Fate,2,2025,0.15,#ffffff,https://cards.scryfall.io/normal/front/c/d/cde3765f-e25c-4d16-b361-448167ed8736.jpg?1783906369,Artifact,Kotetsu Kinoshita
+Collector Protector,5,2004,0.45,#ffffff,https://cards.scryfall.io/normal/front/7/d/7de4c754-dfff-4c0b-93c6-3725ad1efbb0.jpg?1783944265,Creature — Human Gamer,Christopher Rush
+Collector's Cage,2,2024,0.93,#ffffff,https://cards.scryfall.io/normal/front/a/3/a33703bb-51c0-4d57-9d06-1148507ddc4f.jpg?1783912004,Artifact,Bartek Fedyczak
+Combat Calligrapher,4,2026,0.24,#ffffff,https://cards.scryfall.io/normal/front/3/c/3c154814-72e4-4cca-a927-66c58602ae80.jpg?1783903811,Creature — Bird Cleric,Joseph Weston
+Comeuppance,4,2024,4.79,#ffffff,https://cards.scryfall.io/normal/front/b/6/b63d828d-4f62-424b-969a-00dcc4651b56.jpg?1783913033,Instant,Igor Krstic
+Commander Eesha,4,2002,3.04,#ffffff,https://cards.scryfall.io/normal/front/3/6/3607f6a9-b8d2-4119-9f70-95dcedc0662d.jpg?1783945137,Legendary Creature — Bird Soldier,Rebecca Guay
+Commander's Insignia,4,2025,0.35,#ffffff,https://cards.scryfall.io/normal/front/8/a/8a800591-04a9-40d9-acfe-eebc04e8291b.jpg?1783907130,Enchantment,Anastasia Ovchinnikova
+Common Cause,3,1999,0.4,#ffffff,https://cards.scryfall.io/normal/front/e/a/eae4c25f-2005-4ac0-a5f0-2fc250520995.jpg?1783945982,Enchantment,John Matson
+Concerted Effort,4,2005,5.57,#ffffff,https://cards.scryfall.io/normal/front/4/a/4afa3367-eb7e-4c92-96a1-2b6865b24f52.jpg?1783943704,Enchantment,Michael Sutfin
+Condemn,1,2024,1.19,#ffffff,https://cards.scryfall.io/normal/front/e/e/ee6a541f-a72e-4aa5-bced-430e5158ca85.jpg?1783908596,Instant,Rovina Cai
+Conjurer's Mantle,2,2023,1.63,#ffffff,https://cards.scryfall.io/normal/front/5/1/51ddebe2-aad6-4097-ac02-fa6c99f30de7.jpg?1783917292,Artifact — Equipment,Fiona Hsieh
+Conqueror's Pledge,5,2009,0.35,#ffffff,https://cards.scryfall.io/normal/front/1/a/1af1844a-601a-48c1-bf96-921d2d2e2aa1.jpg?1783942175,Sorcery,Kev Walker
+Consulate Crackdown,5,2017,0.14,#ffffff,https://cards.scryfall.io/normal/front/0/2/02fb7a26-fbf0-4b91-847b-cfc46e01a342.jpg?1783936782,Enchantment,Jonas De Ro
+Containment Priest,2,2020,0.47,#ffffff,https://cards.scryfall.io/normal/front/a/2/a24e8dba-5c86-4e32-8a52-61402f7fe9f0.jpg?1783930743,Creature — Human Cleric,John Stanko
+Continue?,2,2026,2.29,#ffffff,https://cards.scryfall.io/normal/front/2/c/2c99c472-8820-43d8-9dfa-508dc3d07478.jpg?1783904172,Instant,Irina Nordsol
+Contractual Safeguard,3,2022,1.45,#ffffff,https://cards.scryfall.io/normal/front/f/0/f0428cba-a895-4dbd-b495-8f358bb632cf.jpg?1783923376,Instant,Gaboleps
+Convalescence,2,1998,0.29,#ffffff,https://cards.scryfall.io/normal/front/0/f/0fd49a61-42ba-400a-8ca9-9f6058bf85ca.jpg?1783946532,Enchantment,D. Alexander Gregory
+Convalescent Care,3,2002,0.31,#ffffff,https://cards.scryfall.io/normal/front/4/8/48f3ad80-d000-496a-b704-d09e07981b6e.jpg?1783945100,Enchantment,Greg Hildebrandt
+Cornered Market,3,1999,0.59,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d4f3c1d-d25e-4263-ab2b-19534c852678.jpg?1783945982,Enchantment,Edward P. Beard, Jr.
+Cosmic Intervention,4,2021,4.09,#ffffff,https://cards.scryfall.io/normal/front/9/3/933c4a54-5c3a-496b-aa35-edf791155d8d.jpg?1783928340,Instant,Alexander Mokhov
+Cosmogrand Zenith,3,2025,4.82,#ffffff,https://cards.scryfall.io/normal/front/b/3/b3c1e5e3-4e6b-456a-958c-7a75c38f8183.jpg?1783905999,Creature — Human Soldier,Anna Steinbauer
+Council's Judgment,3,2024,0.6,#ffffff,https://cards.scryfall.io/normal/front/4/0/4005e82f-0b30-4165-87e2-51250c00adb0.jpg?1783911948,Sorcery,Kev Walker
+Courageous Resolve,3,2023,0.64,#ffffff,https://cards.scryfall.io/normal/front/5/e/5e6ce397-e888-46a6-aa1f-0954df95179f.jpg?1783914196,Instant,Matt Stewart
+Court of Ardenvale,4,2023,9.96,#ffffff,https://cards.scryfall.io/normal/front/4/b/4bd87c87-885c-4e30-9bbc-eccd75af5fbc.jpg?1783914984,Enchantment,Donato Giancola
+Court of Grace,4,2020,3.14,#ffffff,https://cards.scryfall.io/normal/front/0/2/02f0be1b-554e-4b61-b495-6e2a7369cdb1.jpg?1783928885,Enchantment,Denman Rooke
+Cover of Winter,3,2006,0.45,#ffffff,https://cards.scryfall.io/normal/front/9/1/91d9bb89-d8f8-4dff-8b94-3f7b8aa8f299.jpg?1783943373,Snow Enchantment,Wayne Reynolds
+Crackdown,3,1999,9.59,#ffffff,https://cards.scryfall.io/normal/front/a/7/a7009fd8-1d80-41bb-a1b0-fea9c909c63d.jpg?1783945982,Enchantment,Rebecca Guay
+Crack in Time,4,2023,0.22,#ffffff,https://cards.scryfall.io/normal/front/5/5/559e77be-42a2-47cf-a2cf-057b37384cb4.jpg?1783914682,Enchantment,Eliz Roxs
+Cradle of Vitality,4,2020,0.57,#ffffff,https://cards.scryfall.io/normal/front/4/c/4caae1f4-dfb0-466f-9fa6-eb014767e3c8.jpg?1783930477,Enchantment,Trevor Hairsine
+Crested Sunmare,5,2017,8.59,#ffffff,https://cards.scryfall.io/normal/front/7/3/732fa4c9-11da-4bdb-96af-aa37c74be25f.jpg?1783936066,Creature — Horse,Lucas Graciano
+Crisis of Conscience,6,2023,0.3,#ffffff,https://cards.scryfall.io/normal/front/3/0/308d9672-58a7-4ec8-a20d-7054d76fde37.jpg?1783914680,Sorcery,Borja Pindado
+Crovax- Ascendant Hero,6,2021,0.55,#ffffff,https://cards.scryfall.io/normal/front/9/4/94a9dfa5-0e94-433e-8f4a-edfa2dac4913.jpg?1783927879,Legendary Creature — Human Noble,Pete Venters
+Crusading Knight,4,2000,1.12,#ffffff,https://cards.scryfall.io/normal/front/a/4/a4ab4640-1871-41dd-bd21-64741e21ba37.jpg?1783945718,Creature — Human Knight,Edward P. Beard, Jr.
+Crystal Barricade,2,2024,1.72,#ffffff,https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg?1783909129,Artifact Creature — Wall,Rockey Chen
+Cubwarden,4,2020,0.35,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc322744-5d8f-448d-b868-381bb86b68f9.jpg?1783931091,Creature — Cat,Kekai Kotaki
+Curious Colossus,7,2026,0.65,#ffffff,https://cards.scryfall.io/normal/front/5/8/582b6e5d-0bab-471d-af4d-19438c5fd524.jpg?1783904510,Creature — Giant Warrior,Raoul Vitale
+Curse of Conformity,5,2021,0.28,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a88083d-726a-4239-b849-2a4431ef1cd7.jpg?1783925382,Enchantment — Aura Curse,Chris Cold
+Curse of Silence,1,2021,0.33,#ffffff,https://cards.scryfall.io/normal/front/9/e/9e7819d5-12a9-4719-91b2-8dd1ba6f3800.jpg?1783925660,Enchantment — Aura Curse,Irina Nordsol
+Custodi Soulbinders,4,2021,0.27,#ffffff,https://cards.scryfall.io/normal/front/6/a/6a0dd7ba-673e-4f69-8cd3-806784501dc2.jpg?1783924976,Creature — Human Cleric,Karla Ortiz
+Cyan- Vengeful Samurai,7,2025,0.18,#ffffff,https://cards.scryfall.io/normal/front/a/1/a1e779b4-32dd-406b-8b68-48f6df458005.jpg?1783906370,Legendary Creature — Human Samurai,Christian Angel
+Daghatar the Adamant,4,2015,0.17,#d78f42,https://cards.scryfall.io/normal/front/2/b/2b7eed1e-7b28-4900-a6ac-67f167476c11.jpg?1783938714,Legendary Creature — Human Warrior,Zack Stella
+Damning Verdict,5,2022,11.64,#ffffff,https://cards.scryfall.io/normal/front/5/b/5be40c34-6df0-4471-b99b-850ae2be9923.jpg?1783923375,Sorcery,Gaboleps
+Dancer's Chakrams,4,2025,0.31,#ffffff,https://cards.scryfall.io/normal/front/2/7/27ec595f-406b-4539-8d2e-eb98df1a0fc9.jpg?1783906369,Artifact — Equipment,Domco.
+Dancing Sword,2,2021,0.26,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c3d7824-1297-408c-a11f-0622cab9c4c3.jpg?1783926537,Artifact — Equipment,Wisnu Tan
+Danitha- Benalia's Hope,5,2022,0.86,#ffffff,https://cards.scryfall.io/normal/front/8/4/845e5663-2959-44ae-b4c6-d6ea41f01d6e.jpg?1783921367,Legendary Creature — Human Knight,Magali Villeneuve
+Danitha Capashen- Paragon,3,2022,13.33,#ffffff,https://cards.scryfall.io/normal/front/b/f/bf204f62-999b-4a2c-95de-a733d9c54f1a.jpg?1783919219,Legendary Creature — Human Knight,Lie Setiawan
+Darien- King of Kjeldor,6,2024,1.81,#ffffff,https://cards.scryfall.io/normal/front/5/0/50875c99-c5c3-41dd-a0f9-08c98edfebc9.jpg?1783913032,Legendary Creature — Human Soldier,Michael Phillippi
+Daring Archaeologist,4,2018,0.19,#ffffff,https://cards.scryfall.io/normal/front/3/0/306ebfe1-428d-4f38-950e-b72a44262c25.jpg?1783935050,Creature — Human Artificer,Sidharth Chaturvedi
+Darksteel Splicer,7,2023,2.73,#ffffff,https://cards.scryfall.io/normal/front/2/a/2a4f3d89-86dc-45df-9593-d8a7c336ebac.jpg?1783917292,Creature — Phyrexian Artificer,Steven Belledin
+Dawnbreak Reclaimer,6,2018,1.02,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6d097f4-4831-4611-81d9-3a09b7926d1a.jpg?1783934774,Creature — Angel,Tyler Jacobson
+Dawnbringer Charioteers,4,2014,0.28,#ffffff,https://cards.scryfall.io/normal/front/e/c/eca7b7d9-8b69-411a-8a1d-9b7d0492e7d0.jpg?1783939463,Creature — Human Soldier,Ryan Alexander Lee
+Dawn Elemental,4,2003,0.55,#ffffff,https://cards.scryfall.io/normal/front/f/d/fd90a303-25fb-460b-bd55-6249f61c361c.jpg?1783944893,Creature — Elemental,Anthony S. Waters
+Dawn of a New Age,2,2023,3.59,#ffffff,https://cards.scryfall.io/normal/front/c/b/cb966ee6-bf1b-4bb6-9277-8de6f3918ae2.jpg?1783916335,Enchantment,Anato Finnstark
+Dawn of Hope,2,2018,0.56,#ffffff,https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg?1783934203,Enchantment,Sung Choi
+Dawn's Truce,2,2024,7.54,#ffffff,https://cards.scryfall.io/normal/front/8/f/8f72bfa0-efef-48ce-aff8-d5818ed71ba6.jpg?1783910863,Instant,Justin Gerard
+Daybreak Coronet,2,2018,5.12,#ffffff,https://cards.scryfall.io/normal/front/8/1/818537cd-4c95-4538-b61f-c276a6fc8864.jpg?1783933871,Enchantment — Aura,Johannes Voss
+Day of Destiny,4,2022,0.4,#ffffff,https://cards.scryfall.io/normal/front/5/6/56b27e0c-bf8e-43d6-b99d-3e25d4954d34.jpg?1783921439,Legendary Enchantment,Daren Bader
+Day of Judgment,4,2024,0.9,#ffffff,https://cards.scryfall.io/normal/front/9/6/96e84bdc-8a9a-4c58-ba8b-9f052fd60069.jpg?1783909086,Sorcery,Vincent Proce
+Dazzling Theater // Prop Room,7,2024,0.74,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1783909514,Enchantment — Room // Enchantment — Room,Henry Peters
+Deafening Silence,1,2025,5.16,#ffffff,https://cards.scryfall.io/normal/front/d/0/d0269de7-f273-44ac-806b-a36a5cfc6812.jpg?1783905795,Enchantment,Skinnyelbows
+Dearly Departed,6,2021,0.12,#ffffff,https://cards.scryfall.io/normal/front/2/7/27c38500-1eb5-4ea5-8dcd-53bf4e1ee09c.jpg?1783925353,Creature — Spirit,Daniel Ljunggren
+Deathless Angel,6,2010,1.37,#ffffff,https://cards.scryfall.io/normal/front/0/4/049fb314-184c-4411-9035-f04215659056.jpg?1783942009,Creature — Angel,Johann Bodin
+Death or Glory,5,2000,0.78,#ffffff,https://cards.scryfall.io/normal/front/8/1/81f967c9-b38d-489d-96cc-44a6b1804e10.jpg?1783945718,Sorcery,Jeff Easley
+Debt of Loyalty,3,1997,13.55,#ffffff,https://cards.scryfall.io/normal/front/d/1/d19ed33b-42d4-4a5d-a763-cfb43348769c.jpg?1783946749,Instant,Pete Venters
+Declaration in Stone,2,2022,0.38,#ffffff,https://cards.scryfall.io/normal/front/6/f/6f5513a2-e63d-44df-b8a5-37c298e38e3c.jpg?1783923293,Sorcery,Tyler Jacobson
+Decree of Justice,4,2020,0.28,#ffffff,https://cards.scryfall.io/normal/front/f/3/f3150eef-b1e9-44d8-a561-eaeb80e38020.jpg?1783931200,Sorcery,Lius Lasahido
+Deep Gnome Terramancer,2,2022,8.77,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc75f9f1-5873-450f-a0b2-871b55036954.jpg?1783922514,Creature — Gnome Wizard,David Sladek
+Defender of the Order,4,2003,0.28,#ffffff,https://cards.scryfall.io/normal/front/2/3/236b1c88-20a0-479e-91fb-16bb77f699fe.jpg?1783944928,Creature — Human Cleric,Darrell Riche
+Defenders of Humanity,3,2022,0.49,#ffffff,https://cards.scryfall.io/normal/front/4/9/495c6b21-3e2b-417c-9387-6747993cbffe.jpg?1783920947,Enchantment,Games Workshop
+Defiler of Faith,5,2022,0.38,#ffffff,https://cards.scryfall.io/normal/front/2/c/2cfe404d-1a27-4627-9284-56188d92d5d5.jpg?1783921366,Creature — Phyrexian Human,Magali Villeneuve
+Degavolver,2,2001,0.35,#d78f42,https://cards.scryfall.io/normal/front/3/6/36a52c3a-2f58-4b4d-b3c6-f9a08e25c7de.jpg?1783945358,Creature — Volver,Ron Spencer
+Deicide,2,2014,0.15,#ffffff,https://cards.scryfall.io/normal/front/6/0/6012964c-eb76-4581-82ae-aec2d36f0d56.jpg?1783939462,Instant,Jason Chan
+Deification,2,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/5/2/52ce799e-cb9e-4d74-8b13-a5f4559e13a9.jpg?1783916530,Enchantment,Maxime Minard
+Delaying Shield,4,2001,6.84,#ffffff,https://cards.scryfall.io/normal/front/1/4/14e8195a-d0e4-4b11-b413-765ed1cae834.jpg?1783945280,Enchantment,Luca Zontini
+Delney- Streetwise Lookout,3,2024,33.84,#ffffff,https://cards.scryfall.io/normal/front/b/e/be219928-3d0e-4d00-b124-152ce8a8c13b.jpg?1783912925,Legendary Creature — Human Scout,Darren Tan
+Deploy the Gatewatch,6,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/3/4/34f4c453-97b4-4cd5-a766-85e5647f71d5.jpg?1783915452,Sorcery,Wesley Burt
+Deploy to the Front,7,2014,1.77,#ffffff,https://cards.scryfall.io/normal/front/1/0/10744088-b028-43aa-8a77-cd2a430fbfb6.jpg?1783938873,Sorcery,Aaron Miller
+Depopulate,4,2022,0.32,#ffffff,https://cards.scryfall.io/normal/front/c/5/c53c1898-9107-4bf8-b249-d0502fb9596d.jpg?1783923159,Sorcery,Jokubas Uogintas
+Descend upon the Sinful,6,2024,0.38,#ffffff,https://cards.scryfall.io/normal/front/8/3/83245e11-a020-4d81-9d83-e1505f1d125e.jpg?1783911947,Sorcery,Tyler Jacobson
+Devastating Mastery,6,2021,0.36,#ffffff,https://cards.scryfall.io/normal/front/3/b/3b6be019-29b9-4c81-9899-aefeaf9cc977.jpg?1783927392,Sorcery,Jake Murray
+Devoted Caretaker,1,2001,3.28,#ffffff,https://cards.scryfall.io/normal/front/8/d/8d400b63-de3e-4805-a51d-c4c0dfbb7033.jpg?1783945279,Creature — Human Cleric,Clyde Caldwell
+Devout Invocation,7,2013,2.23,#ffffff,https://cards.scryfall.io/normal/front/8/a/8a286954-fb40-4440-9f0e-a28367c6823c.jpg?1783939944,Sorcery,David Palumbo
+Devout Lightcaster,3,2009,0.24,#ffffff,https://cards.scryfall.io/normal/front/1/6/16e31e43-84d3-429e-9e81-60b325989c93.jpg?1783942174,Creature — Kor Cleric,Shelly Wan
+Dictate of Heliod,5,2015,0.52,#ffffff,https://cards.scryfall.io/normal/front/f/9/f964c561-96ac-4558-b46e-ba2c472d5807.jpg?1783938103,Enchantment,Terese Nielsen
+Digsite Engineer,3,2021,0.85,#ffffff,https://cards.scryfall.io/normal/front/d/7/d79b8974-796c-4f88-a0cb-5afbaf26fd24.jpg?1783927609,Creature — Dwarf Artificer,Zoltan Boros
+Dimensional Breach,7,2003,0.62,#ffffff,https://cards.scryfall.io/normal/front/f/1/f18f2832-07c5-47be-8966-b250fb997f78.jpg?1783944893,Sorcery,Dave Dorman
+Dion- Bahamut's Dominant // Bahamut- Warden of Light,4,2025,0.74,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Noble Knight // Legendary Enchantment Creature — Saga Dragon,Kevin Glint
+Disciple of Caelus Nin,5,2022,0.29,#ffffff,https://cards.scryfall.io/normal/front/f/6/f60b6143-ffc4-47d4-9e30-edf1f576b6ef.jpg?1783919717,Creature — Human Wizard,Steve Argyle
+Dismantling Wave,3,2026,0.21,#ffffff,https://cards.scryfall.io/normal/front/3/9/39e7bb05-96df-4e76-90a6-3f3625b7965a.jpg?1783903248,Sorcery,Uzuri
+Divine Deflection,1,2012,0.26,#ffffff,https://cards.scryfall.io/normal/front/e/c/ec06e42f-e294-44ef-8fa8-1d1a4c2090d8.jpg?1783940736,Instant,Steve Prescott
+Divine Presence,3,2000,1.79,#ffffff,https://cards.scryfall.io/normal/front/2/8/28cb898d-d6ce-410a-83bf-37962cca2735.jpg?1783945717,Enchantment,Ron Spears
+Divine Reckoning,4,2019,0.77,#ffffff,https://cards.scryfall.io/normal/front/c/b/cbb97027-d6bc-4529-960d-6b0ab2af9c50.jpg?1783932791,Sorcery,Greg Staples
+Divine Retribution,2,1996,0.65,#ffffff,https://cards.scryfall.io/normal/front/7/5/75629aa3-426e-4e25-a7ab-71e03436e061.jpg?1783947123,Instant,Charles Gillespie
+Divine Sacrament,3,2023,0.43,#ffffff,https://cards.scryfall.io/normal/front/a/7/a77d4044-f2bd-470a-8468-a319e0a21d8d.jpg?1783918517,Enchantment,Ekaterina Burmak
+Divine Transformation,4,1994,21.83,#ffffff,https://cards.scryfall.io/normal/front/a/8/a89ad9fd-33a6-4d31-9f4c-8bf192882f21.jpg?1783948086,Enchantment — Aura,NéNé Thomas
+Divine Visitation,5,2026,0.5,#ffffff,https://cards.scryfall.io/normal/front/d/a/dabd95db-b4ca-446b-bb68-6f52cec9ed2a.jpg?1783903248,Enchantment,Flavio Greco Paglia
+Djeru- With Eyes Open,5,2017,0.33,#ffffff,https://cards.scryfall.io/normal/front/2/2/2234df89-0835-4a17-b5d8-2334ee8f692d.jpg?1783936062,Legendary Creature — Human Warrior,Kieran Yanner
+Doctor Strange- Surgeon,5,2026,1.81,#ffffff,https://cards.scryfall.io/normal/front/f/8/f872a2cd-e684-47be-885f-27a4666399fa.jpg?1783903085,Legendary Creature — Human Doctor Hero,Erikas Perl
+Dogged Hunter,3,2001,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/5/b50d4337-9b71-429b-b6bc-2d70299a6e76.jpg?1783945279,Creature — Human Nomad,rk post
+Do-It-Yourself Seraph,6,2017,0.56,#ffffff,https://cards.scryfall.io/normal/front/0/e/0e4f4e8c-6519-4b35-b7b5-54a4c4e32c18.jpg?1783935464,Artifact Creature — Cyborg Angel,David Sladek
+Dollmaker's Shop // Porcelain Gallery,8,2024,5.26,#ffffff,https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1783909512,Enchantment — Room // Enchantment — Room,Chris Cold
+Dominaria's Judgment,3,2001,0.43,#ffffff,https://cards.scryfall.io/normal/front/9/7/9703d090-b415-48e2-8158-dd8fc57ecc50.jpg?1783945631,Instant,John Avon
+Don't Move,5,2026,1.39,#ffffff,https://cards.scryfall.io/normal/front/c/5/c55e5f0d-8a4b-4b6f-ab43-1268b6fac74e.jpg?1783903322,Sorcery,John Byrne
+Doomed Artisan,3,2019,0.35,#ffffff,https://cards.scryfall.io/normal/front/d/e/ded9c409-7131-4b3f-a6b9-25fa32c5ec2c.jpg?1783932816,Creature — Human Artificer,Victor Adame Minguez
+Doomskar,5,2021,0.86,#ffffff,https://cards.scryfall.io/normal/front/1/3/130ee895-1e5e-4f82-bb66-e1275bac75dd.jpg?1783928285,Sorcery,Piotr Dura
+Doorkeeper Thrull,2,2024,0.7,#ffffff,https://cards.scryfall.io/normal/front/8/0/80a1cd28-d2a5-4d1a-aa03-a6a5958ae432.jpg?1783912925,Creature — Thrull,Camille Alquier
+Dora Milaje Elite,2,2026,0.54,#ffffff,https://cards.scryfall.io/normal/front/1/d/1d1e00e3-7f3c-4a49-859b-398283c38e61.jpg?1783903300,Creature — Human Warrior,Mateus Manhanini
+Dragonscale General,4,2015,0.2,#ffffff,https://cards.scryfall.io/normal/front/d/f/df904cc6-3ee0-4326-a854-818695aa2890.jpg?1783938713,Creature — Human Warrior,Volkan Baǵa
+Drannith Magistrate,2,2020,14.59,#ffffff,https://cards.scryfall.io/normal/front/9/8/98b0a4a8-9319-451b-9b79-b0bca7a41e91.jpg?1783931091,Creature — Human Wizard,Kieran Yanner
+Drawn Together,4,2004,0.56,#ffffff,https://cards.scryfall.io/normal/front/5/0/50fa9cd0-2152-4c01-a5d7-d257ae109d0f.jpg?1783944264,Enchantment,Pete “Fear Me” Venters
+Drogskol Cavalry,7,2016,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/6/46c262c8-9daa-4ed8-b519-11b5895de89f.jpg?1783937821,Creature — Spirit Knight,Igor Kieryluk
+Drogskol Reinforcements,4,2021,0.95,#ffffff,https://cards.scryfall.io/normal/front/c/8/c86bdb28-9b0c-426d-b603-cc10cd301cc6.jpg?1783925010,Creature — Spirit Soldier,Antonio José Manzanedo
+Drumbellower,3,2026,1.81,#ffffff,https://cards.scryfall.io/normal/front/c/1/c19e0ebf-ca94-4684-8b2c-68e592b65a24.jpg?1783903810,Creature — Spirit,Lie Setiawan
+Duelist's Heritage,3,2025,1.93,#ffffff,https://cards.scryfall.io/normal/front/4/5/45834bc6-be8d-4064-930d-efc73cf3c64d.jpg?1783904807,Enchantment,Robin Har
+Dusk // Dawn,9,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/5/f/5f2facfb-dfde-4e5b-8f6d-4fabb4c85519.jpg?1783913033,Sorcery // Sorcery,Kasia 'Kafis' Zielińska
+Dusk Legion Duelist,2,2023,2.06,#ffffff,https://cards.scryfall.io/normal/front/7/3/7305a8d3-5403-4483-92af-863dc91c6084.jpg?1783917064,Creature — Vampire Soldier,Ryan Valle
+Dust Animus,2,2024,0.23,#ffffff,https://cards.scryfall.io/normal/front/7/0/70719e7b-6f02-4c1a-9f11-79b2b0d9846a.jpg?1783911858,Creature — Spirit,Uriah Voth
+Dust Elemental,4,2007,0.4,#ffffff,https://cards.scryfall.io/normal/front/1/4/144e9391-f417-464b-8c04-c952193997c7.jpg?1783943170,Creature — Elemental,rk post
+Duty Beyond Death,2,2026,1.87,#ffffff,https://cards.scryfall.io/normal/front/d/d/ddde574a-e442-42cc-a1ce-82243395de4c.jpg?1783903511,Instant,Kazuma Ichikawa
+Eagle of Deliverance,6,2023,1.05,#ffffff,https://cards.scryfall.io/normal/front/a/4/a4631187-9a5b-43d5-92d8-de6e609d2a03.jpg?1783913964,Creature — Bird Soldier,Sidharth Chaturvedi
+Earnest Fellowship,2,2001,1.25,#ffffff,https://cards.scryfall.io/normal/front/6/6/66392169-5c6f-46bf-b0df-5670e40aecd9.jpg?1783945282,Enchantment,Heather Hudson
+Earthshape,3,2025,7.24,#ffffff,https://cards.scryfall.io/normal/front/d/8/d873c678-c8f2-40f0-ab03-a2fdf5187aea.jpg?1783904839,Instant,Fahmi Fauzi
+Eerie Interlude,3,2021,8.37,#ffffff,https://cards.scryfall.io/normal/front/4/b/4ba9f15f-00d2-4797-9228-91b320e85705.jpg?1783928332,Instant,Svetlin Velinov
+Eidolon of Astral Winds,3,2024,0.33,#ffffff,https://cards.scryfall.io/normal/front/f/d/fd62f1de-853e-4fc3-9137-8f419c5972f6.jpg?1783908870,Enchantment Creature — Spirit,Dan Murayama Scott
+Eidolon of Countless Battles,3,2026,0.33,#ffffff,https://cards.scryfall.io/normal/front/4/a/4ad6fcb1-7c35-4111-8f1e-d18a2fae5638.jpg?1783903808,Enchantment Creature — Spirit,Raymond Swanland
+Eidolon of Obstruction,2,2020,0.21,#ffffff,https://cards.scryfall.io/normal/front/2/f/2f48f802-df9d-45b2-afea-98699bcdf0d6.jpg?1783931599,Enchantment Creature — Spirit,Jason Rainville
+Eiganjo Dynastorian // Replenish,3,2026,1.17,#ffffff,https://cards.scryfall.io/normal/front/0/9/09d1f048-f411-4677-a0dc-dbddd06fe694.jpg?1783903863,Creature — Fox Advisor // Sorcery,Aldo Domínguez
+Eight-and-a-Half-Tails,2,2022,0.51,#ffffff,https://cards.scryfall.io/normal/front/e/f/ef722374-0305-4c30-ab45-cb772b252faf.jpg?1783922494,Legendary Creature — Fox Cleric,Daren Bader
+Eightfold Maze,3,1999,47.03,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg?1783946133,Instant,Shang Huitong
+Eirdu- Carrier of Dawn // Isilu- Carrier of Twilight,5,2026,2.6,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elemental God // Legendary Creature — Elemental God,Lucas Graciano
+Elder Land Wurm,7,1995,0.45,#ffffff,https://cards.scryfall.io/normal/front/b/1/b188d0d4-cd7c-4314-ae65-cb49e4674241.jpg?1783947871,Creature — Dragon Wurm,Quinton Hoover
+Elena- Turk Recruit,3,2025,0.23,#ffffff,https://cards.scryfall.io/normal/front/d/1/d16553a3-65c3-4dec-af92-123d1e5dce10.jpg?1783906368,Legendary Creature — Human Assassin,Magali Villeneuve
+Elenda's Hierophant,3,2023,4.75,#ffffff,https://cards.scryfall.io/normal/front/d/1/d12f728a-1bbb-4bee-96d4-d721292997ba.jpg?1783913913,Creature — Vampire Cleric,Miranda Meeks
+Elesh Norn- Grand Cenobite,7,2017,19.85,#ffffff,https://cards.scryfall.io/normal/front/7/8/78c2bfef-06a5-4c7f-8283-ea3fb673b7a1.jpg?1783935557,Legendary Creature — Phyrexian Praetor,Igor Kieryluk
+Elesh Norn- Mother of Machines,5,2023,23.89,#ffffff,https://cards.scryfall.io/normal/front/4/4/44dcab01-1d13-4dfc-ae2f-fbaa3dd35087.jpg?1783918082,Legendary Creature — Phyrexian Praetor,Martina Fačková
+Elesh Norn // The Argent Etchings,4,2023,7.52,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Phyrexian Praetor // Enchantment — Saga,Magali Villeneuve
+Elite Archers,6,2003,0.25,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2341478-2a91-4ce8-881a-21e826b55c34.jpg?1783944846,Creature — Human Soldier Archer,Greg Staples
+Elite Inquisitor,2,2011,0.32,#ffffff,https://cards.scryfall.io/normal/front/c/9/c9411c44-92a8-4f5d-b3de-d80046649c8c.jpg?1783940996,Creature — Human Soldier,Jana Schirmer & Johannes Voss
+Elite Spellbinder,3,2021,0.27,#ffffff,https://cards.scryfall.io/normal/front/9/d/9d3a7998-ccac-45ad-a4e9-3a2cb057f63b.jpg?1783927390,Creature — Human Cleric,Ryan Pancoast
+Elspeth Conquers Death,5,2020,1.14,#ffffff,https://cards.scryfall.io/normal/front/e/a/ea20208b-1939-4c69-8cfd-c0a42f9dc427.jpg?1783931598,Enchantment — Saga,Ryan Yee
+Elspeth- Knight-Errant,4,2013,8.8,#ffffff,https://cards.scryfall.io/normal/front/7/4/746d56ef-7ac5-403b-bca3-1cd267de97df.jpg?1783940006,Legendary Planeswalker — Elspeth,Volkan Baǵa
+Elspeth Resplendent,5,2022,4.71,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c606af0-f3d1-44a4-b24e-ee1263569b1f.jpg?1783923158,Legendary Planeswalker — Elspeth,Anna Steinbauer
+Elspeth's Devotee,4,2020,0.24,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f82064c-b335-454c-9be6-9fbcb21aa8e5.jpg?1783931499,Creature — Human Soldier,Caroline Gariba
+Elspeth's Talent,4,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/5/2/52b20ab7-2a35-479b-bdc4-88ecde5d496c.jpg?1783917250,Enchantment — Aura,Jeremy Wilson
+Elspeth- Storm Slayer,5,2025,36.37,#ffffff,https://cards.scryfall.io/normal/front/7/3/73a065e3-b530-4e62-ab3c-4f6f908184ec.jpg?1783907414,Legendary Planeswalker — Elspeth,Ekaterina Burmak
+Elspeth- Sun's Champion,6,2024,1.99,#ffffff,https://cards.scryfall.io/normal/front/4/6/46dc2519-2729-4bbd-8892-fab6186bf116.jpg?1783913033,Legendary Planeswalker — Elspeth,Eric Deschamps
+Elspeth- Sun's Nemesis,4,2020,0.8,#ffffff,https://cards.scryfall.io/normal/front/8/1/81aec42f-abb7-42f9-96f5-f1ee2f94db52.jpg?1783931598,Legendary Planeswalker — Elspeth,Livia Prima
+Elspeth Tirel,5,2010,3.9,#ffffff,https://cards.scryfall.io/normal/front/e/b/ebe9116e-7b04-4f2a-aa67-89a42c6e1801.jpg?1783941746,Legendary Planeswalker — Elspeth,Michael Komarck
+Elspeth- Undaunted Hero,5,2020,0.45,#ffffff,https://cards.scryfall.io/normal/front/b/f/bf9867e5-9d69-400c-a84f-3b085a4fd510.jpg?1783931499,Legendary Planeswalker — Elspeth,Steven Belledin
+Emeria Angel,4,2025,0.33,#ffffff,https://cards.scryfall.io/normal/front/2/4/2406ab7c-c6be-421a-a92c-048441a01acd.jpg?1783907128,Creature — Angel,Jim Murray
+Emeria's Call // Emeria- Shattered Skyclave,7,2020,4.43,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Land,Matt Stewart
+Emeria Shepherd,7,2020,2.96,#ffffff,https://cards.scryfall.io/normal/front/a/9/a99dd58d-9fed-4d85-9bb5-f9c91834cab8.jpg?1783929490,Creature — Angel,Cynthia Sheppard
+Emeritus of Truce // Swords to Plowshares,3,2026,1.7,#ffffff,https://cards.scryfall.io/normal/front/9/8/9869a753-5e41-4098-ab41-e75b4396ec50.jpg?1783903705,Creature — Cat Cleric // Instant,Aleksi Briclot
+Emiel the Blessed,4,2022,14.4,#d78f42,https://cards.scryfall.io/normal/front/0/f/0f594562-7e9f-47e6-a033-fb70e3cf1e10.jpg?1783921937,Legendary Creature — Unicorn,Antonio José Manzanedo
+Empty City Ruse,1,2025,1.73,#ffffff,https://cards.scryfall.io/normal/front/3/a/3a2f358d-93a9-4cd7-a846-3cc55042e4fe.jpg?1783904863,Sorcery,Viacom
+Empyrial Storm,6,2018,0.41,#ffffff,https://cards.scryfall.io/normal/front/d/b/dbfb7f01-87bf-4eb6-8a8f-3401f37c3ebf.jpg?1783934345,Sorcery,Mark Poole
+End Hostilities,5,2014,0.33,#ffffff,https://cards.scryfall.io/normal/front/8/0/80a53ed7-a7b7-40d8-9239-cf6f205dbc59.jpg?1783939095,Sorcery,Jason Rainville
+Endless Foot Assault,3,2026,2.77,#ffffff,https://cards.scryfall.io/normal/front/3/8/387f6f60-69da-4965-9ab9-57bdb763a013.jpg?1783904172,Enchantment,Ryan Valle
+Endless Horizons,4,2008,7.64,#ffffff,https://cards.scryfall.io/normal/front/3/2/32385604-dcff-41e4-97a5-fcf230033a87.jpg?1783942696,Enchantment,Joshua Hagler
+Enduring Angel // Angelic Enforcer,5,2021,2.22,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Angel // Creature — Angel,Irina Nordsol
+Enduring Ideal,7,2005,2.47,#ffffff,https://cards.scryfall.io/normal/front/7/d/7dc7091e-0c98-434d-9190-dcab813d3e14.jpg?1783944172,Sorcery,Daren Bader
+Enduring Innocence,3,2024,3.58,#ffffff,https://cards.scryfall.io/normal/front/0/8/08f79439-b8f8-418f-9772-26d81844749e.jpg?1783909512,Enchantment Creature — Sheep Glimmer,Liiga Smilshkalne
+Enduring Renewal,4,1995,1.74,#ffffff,https://cards.scryfall.io/normal/front/b/e/be77edac-9a8b-4b7f-a859-27df76b10aa6.jpg?1783947526,Enchantment,Harold McNeill
+Enlightened Tutor,1,2023,38.32,#ffffff,https://cards.scryfall.io/normal/front/1/c/1c9675fb-1a89-420f-aea8-50e0642f549c.jpg?1783918516,Instant,Howard Lyon
+Entrapment Maneuver,4,2016,0.5,#ffffff,https://cards.scryfall.io/normal/front/f/4/f4dcebe1-bfc7-4f7d-ad8c-91a4b9f23eef.jpg?1783937091,Instant,Filip Burburan
+Entreat the Angels,3,2024,0.42,#ffffff,https://cards.scryfall.io/normal/front/f/f/ff4411bc-ed4e-4d54-9e1b-21fc77b0e415.jpg?1783909633,Sorcery,Todd Lockwood
+Ephemerate,1,2026,4.19,#ffffff,https://cards.scryfall.io/normal/front/6/2/621e3239-b527-4154-bce6-b51241809fc5.jpg?1783903323,Instant,Mateus Manhanini
+Equipoise,3,1997,4.53,#ffffff,https://cards.scryfall.io/normal/front/5/3/53783312-3551-4361-ab02-c9651ce2a926.jpg?1783947008,Enchantment,Adam Rex
+Erode,1,2026,5.82,#ffffff,https://cards.scryfall.io/normal/front/3/2/32e670da-7563-4f6a-a7db-4c126a440eb8.jpg?1783903705,Instant,Florian Herold
+Escarpment Fortress,5,2024,0.48,#ffffff,https://cards.scryfall.io/normal/front/c/1/c11c9e60-fc14-48fe-bca9-b74f82301835.jpg?1783910897,Creature — Wall,Vaigintas Pakenis
+Esper Sentinel,1,2021,57.99,#ffffff,https://cards.scryfall.io/normal/front/f/3/f3537373-ef54-4578-9d05-6216420ee349.jpg?1783926893,Artifact Creature — Human Soldier,Eric Deschamps
+Essence Channeler,2,2024,0.54,#ffffff,https://cards.scryfall.io/normal/front/5/a/5aaf7e4c-4d5d-4acc-a834-e6c4a7629408.jpg?1783910861,Creature — Bat Cleric,Wylie Beckert
+Essence of Orthodoxy,5,2023,0.4,#ffffff,https://cards.scryfall.io/normal/front/6/0/604233dc-0520-47d0-8d3d-816f45c9f087.jpg?1783916907,Creature — Phyrexian,Oriana Menendez
+Essence Sliver,4,2003,8.75,#ffffff,https://cards.scryfall.io/normal/front/1/3/1346fa14-1d9f-4c6a-887d-d3a93de00743.jpg?1783944929,Creature — Sliver,Glen Angus
+Eternal Dragon,7,2021,0.42,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f57fc0c-cab1-4eb0-a58a-0c7a762f1572.jpg?1783926233,Creature — Dragon Spirit,Justin Sweet
+Ethereal Champion,5,1999,0.38,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c1733e2-bee2-4b85-b165-d4329402578b.jpg?1783946212,Creature — Avatar,Terese Nielsen
+Ethersworn Canonist,2,2020,5.74,#ffffff,https://cards.scryfall.io/normal/front/a/b/abc8e0f8-fdb9-4f24-a3e3-439f6cc3ebdc.jpg?1783930216,Artifact Creature — Human Cleric,Izzy
+Evangelize,5,2006,0.33,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f58e1aa-587c-4f89-9552-1128c8c2da1a.jpg?1783943256,Sorcery,Randy Elliott
+Everett K. Ross- Hapless Attaché,3,2026,0.45,#ffffff,https://cards.scryfall.io/normal/front/d/d/dd33edfe-578f-4b24-bd27-5a965b6c14ad.jpg?1783903300,Legendary Creature — Human Advisor,Alexander Mokhov
+Everybody Lives!,2,2023,14.02,#ffffff,https://cards.scryfall.io/normal/front/9/d/9dab0052-7f0c-4b56-847f-20552666a271.jpg?1783914680,Instant,Alice Xia Zhang
+Everything Comes to Dust,10,2023,5.29,#ffffff,https://cards.scryfall.io/normal/front/f/b/fb4b912c-07d4-42a1-8f3b-d5f34cca087f.jpg?1783914681,Sorcery,Lie Setiawan
+Evra- Halcyon Witness,6,2018,0.34,#ffffff,https://cards.scryfall.io/normal/front/0/2/02f57a57-8ce8-4d01-9b91-99ec0623d1e9.jpg?1783935044,Legendary Creature — Avatar,Johannes Voss
+Exalted Angel,6,2024,1.2,#ffffff,https://cards.scryfall.io/normal/front/7/a/7a6b087b-a3ac-4c4d-a519-ec5584b4b42d.jpg?1783913032,Creature — Angel,Michael Sutfin
+Exalted Sunborn,5,2025,14.14,#ffffff,https://cards.scryfall.io/normal/front/7/e/7e1fe101-f634-41e5-9aa4-e8d7474535dc.jpg?1783905997,Creature — Angel Wizard,Scott M. Fischer
+Excavation Technique,4,2021,0.36,#ffffff,https://cards.scryfall.io/normal/front/3/2/32ffc8eb-9518-455c-ada5-8b7596896dcf.jpg?1783927611,Sorcery,Francisco Miyara
+Excise the Imperfect,3,2023,0.39,#ffffff,https://cards.scryfall.io/normal/front/e/c/ec4d501d-dacf-4f49-8756-f1190e244405.jpg?1783917290,Instant,Denis Zhbankov
+Exemplar of Light,4,2026,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/7/b7393efb-da40-4b55-a6ff-ce774f0815f9.jpg?1783903957,Creature — Angel,Ekaterina Burmak
+Exile,3,1999,1.41,#ffffff,https://cards.scryfall.io/normal/front/b/f/bf6e3ca4-5b56-40bb-bec7-c92fc7eb50d2.jpg?1783946212,Instant,Rob Alexander
+Exiled Doomsayer,2,2003,0.16,#ffffff,https://cards.scryfall.io/normal/front/7/4/74aaf095-143a-43fc-a858-b1e82a4b906e.jpg?1783944893,Creature — Human Cleric,Brian Snõddy
+Exorcist,2,1994,10.64,#ffffff,https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg?1783947949,Creature — Human Cleric,Drew Tucker
+Expel the Interlopers,5,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/b/b/bbdf088c-3067-4df2-92f7-95fed5b304b8.jpg?1783907128,Sorcery,Andreas Zafiratos
+Exquisite Archangel,7,2017,4.22,#ffffff,https://cards.scryfall.io/normal/front/d/0/d04018c9-510c-4610-9daa-677434628805.jpg?1783936779,Creature — Angel,Brad Rigney
+Extraction Specialist,3,2022,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/4/b404d6c7-0b65-4c6a-b141-9dffbeb120db.jpg?1783923159,Creature — Human Rogue,Irina Nordsol
+Eye of Singularity,4,1997,2.51,#ffffff,https://cards.scryfall.io/normal/front/f/a/fa84e4ad-738a-4d23-a84c-06c39ff4200b.jpg?1783947007,World Enchantment,Eric Peterson
+Fabled Hero,3,2013,0.3,#ffffff,https://cards.scryfall.io/normal/front/6/4/642d9a5c-5697-4747-adce-5a71bcf1c086.jpg?1783939820,Creature — Human Soldier,Aaron Miller
+Fabrication Foundry,2,2023,0.28,#ffffff,https://cards.scryfall.io/normal/front/3/2/323a05ee-8296-41c0-94ab-00913d9d84f1.jpg?1783913813,Artifact,Racrufi
+Faithbound Judge // Sinner's Judgment,3,2021,0.79,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Spirit Soldier // Enchantment — Aura Curse,Svetlin Velinov
+Faith Healer,2,1998,3.22,#ffffff,https://cards.scryfall.io/normal/front/5/d/5d51ff6a-ba1b-4015-8d0b-df1a1bb5a0c1.jpg?1783946375,Creature — Human Cleric,Randy Gallegos
+Faith's Reward,4,2016,1.73,#ffffff,https://cards.scryfall.io/normal/front/f/a/fa19fe94-0302-4d08-9821-fa0db722048a.jpg?1783937336,Instant,Raymond Swanland
+Falcon and Redwing,3,2026,1.06,#ffffff,https://cards.scryfall.io/normal/front/e/5/e565fb47-acca-4348-87bb-afdadbf55e8a.jpg?1783903300,Legendary Creature — Human Bird Hero,Allen Douglas
+Fall of the Thran,6,2018,0.32,#ffffff,https://cards.scryfall.io/normal/front/3/a/3a613a01-6145-4e34-987c-c9bdcb068370.jpg?1783935046,Enchantment — Saga,Jason Felix
+False Dawn,2,2001,0.27,#ffffff,https://cards.scryfall.io/normal/front/1/6/1695e0ba-005a-4652-aea7-e1d1f9ff5d66.jpg?1783945357,Sorcery,Dave Dorman
+False Prophet,4,2011,0.6,#ffffff,https://cards.scryfall.io/normal/front/f/4/f41a43ba-1867-4ce3-97fe-5ae67d3f36c3.jpg?1783941254,Creature — Human Cleric,Eric Peterson
+Farewell,6,2024,6.03,#ffffff,https://cards.scryfall.io/normal/front/1/1/114d2180-093b-4838-97ad-badbc8ee50b0.jpg?1783913032,Sorcery,Seb McKinnon
+Far Out,3,2022,0.2,#ffffff,https://cards.scryfall.io/normal/front/8/9/89c47667-1ae3-464b-9c5f-732a08a53707.jpg?1783920616,Enchantment,Bram Sels
+Fated Clash,5,2025,8.23,#ffffff,https://cards.scryfall.io/normal/front/b/d/bd84f688-a2bb-4f1e-ae24-1a5cf8a05445.jpg?1783904654,Sorcery,Lius Lasahido
+Fated Retribution,7,2014,0.34,#ffffff,https://cards.scryfall.io/normal/front/8/1/8158b330-2868-4147-907e-4d86e44cfaad.jpg?1783939583,Instant,Jonas De Ro
+Fateful Absence,2,2021,0.4,#ffffff,https://cards.scryfall.io/normal/front/e/c/eca8d6f8-c6f1-437c-99e2-4281eae14a6f.jpg?1783925659,Instant,Eric Deschamps
+Favor of the Mighty,2,2007,0.57,#ffffff,https://cards.scryfall.io/normal/front/2/0/20d858be-4c03-4819-94e9-ca4ca3de9032.jpg?1783942915,Kindred Enchantment — Giant,Larry MacDougall
+Felidar Guardian,4,2024,27.0,#ffffff,https://cards.scryfall.io/normal/front/9/b/9b464549-a84d-44bf-a684-d59db5babc6d.jpg?1783913095,Creature — Cat Beast,Rowynn Ellis
+Felidar Retreat,4,2024,0.97,#ffffff,https://cards.scryfall.io/normal/front/8/9/89e3cc09-5057-4c05-88fc-d6cda809fc74.jpg?1783908940,Enchantment,Ralph Horsley
+Felidar Sovereign,6,2015,1.95,#ffffff,https://cards.scryfall.io/normal/front/0/3/039499c3-0b35-4e8e-b0c9-bdf0b4cd90d5.jpg?1783938220,Creature — Cat Beast,Zoltan Boros & Gabor Szikszai
+Fell the Mighty,5,2024,0.3,#ffffff,https://cards.scryfall.io/normal/front/5/a/5a3e8132-6576-456c-8777-9e8cb52595fc.jpg?1783913031,Sorcery,Raymond Swanland
+Feudkiller's Verdict,6,2008,0.38,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a1fff8e-0379-4d56-b726-f5cc56e63d48.jpg?1783942807,Kindred Sorcery — Giant,Dan Murayama Scott
+Fey Steed,4,2021,0.27,#ffffff,https://cards.scryfall.io/normal/front/c/e/ce2bfc76-04b4-46ed-b495-33221256afbb.jpg?1783926258,Creature — Elk,Jonathan Kuo
+Field Marshal,3,2007,3.85,#ffffff,https://cards.scryfall.io/normal/front/1/e/1e22d287-274e-4222-9ed7-3e609a84ac07.jpg?1783943081,Creature — Human Soldier,Stephen Tappin
+Field-Tested Frying Pan,3,2023,0.28,#ffffff,https://cards.scryfall.io/normal/front/1/d/1d770a59-1c54-407e-9c58-8d8b6f44c90a.jpg?1783916036,Artifact — Equipment,Nino Is
+Fiendslayer Paladin,3,2017,0.78,#ffffff,https://cards.scryfall.io/normal/front/6/7/6788d4ac-86f1-4ac5-915d-fdfe7e408443.jpg?1783936166,Creature — Human Knight,Wesley Burt
+Fight or Flight,4,2000,2.17,#ffffff,https://cards.scryfall.io/normal/front/4/6/46bde162-3737-4b93-a27a-63b909a4183d.jpg?1783945717,Enchantment,Randy Gallegos
+Filigree Vector,4,2023,12.33,#ffffff,https://cards.scryfall.io/normal/front/9/7/97fb9c9a-2278-42d0-9632-3a7e8faff74d.jpg?1783917289,Artifact Creature — Phyrexian Construct,Lorenzo Mastroianni
+Finale of Glory,2,2024,2.44,#ffffff,https://cards.scryfall.io/normal/front/1/e/1e71b0fb-2d36-4b81-bd5b-c3fd083e3e97.jpg?1783912564,Sorcery,Stanton Feng
+Final Judgment,6,2005,1.1,#ffffff,https://cards.scryfall.io/normal/front/2/5/2503e136-031f-498a-b042-4077baebe8f8.jpg?1783944215,Sorcery,Kev Walker
+Final Showdown,1,2024,5.42,#ffffff,https://cards.scryfall.io/normal/front/3/5/358968f9-45bd-4022-b6bc-f1f7e0adf0e7.jpg?1783911857,Instant,Izzy
+Firemane Commando,4,2026,0.93,#ffffff,https://cards.scryfall.io/normal/front/c/8/c86269cc-bf4d-44b4-ad4b-8356857c532f.jpg?1783903808,Creature — Angel Soldier,Andrew Mar
+Flamescroll Celebrant // Revel in Silence,2,2021,0.21,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Shaman // Instant,Uriah Voth
+Flare of Fortitude,4,2024,3.76,#ffffff,https://cards.scryfall.io/normal/front/3/7/37b41b59-0296-443b-8a62-8d5c4641ef66.jpg?1783911302,Instant,Winona Nelson
+Flavor Judge,2,2020,0.18,#ffffff,https://cards.scryfall.io/normal/front/a/b/abce5940-e84f-4f9f-89a9-13da1cd7fd43.jpg?1783931350,Creature — Bird Advisor,Mike Burns
+Flawless Maneuver,3,2023,20.88,#ffffff,https://cards.scryfall.io/normal/front/a/b/ab12f69e-1491-47a8-8c46-d85bbf637ff6.jpg?1783915723,Instant,Zoltan Boros
+Flicker,2,1999,7.44,#ffffff,https://cards.scryfall.io/normal/front/f/5/f55e7ec5-6488-483f-8020-b48e1a951f09.jpg?1783946084,Sorcery,Douglas Shuler
+Flickerform,2,2017,2.02,#ffffff,https://cards.scryfall.io/normal/front/6/4/64266c41-b123-41e1-8006-07f2037bba72.jpg?1783936307,Enchantment — Aura,Ron Spears
+Flowerfoot Swordmaster,1,2025,0.49,#ffffff,https://cards.scryfall.io/normal/front/a/d/ad113af1-d9d1-4471-ab7c-9804308a501d.jpg?1783904693,Creature — Mouse Soldier,Ampreh
+Flowering of the White Tree,2,2023,11.0,#ffffff,https://cards.scryfall.io/normal/front/2/2/2203b2cd-48e5-471a-85fe-dc81012e5d61.jpg?1783916332,Legendary Enchantment,Erikas Perl
+Flumph,2,2021,2.22,#ffffff,https://cards.scryfall.io/normal/front/c/d/cdc86e78-8911-4a0d-ba3a-7802f8d991ef.jpg?1783926532,Creature — Jellyfish,Brian Valeza
+Folk Hero,2,2026,0.97,#ffffff,https://cards.scryfall.io/normal/front/8/5/85bf7c95-4534-435b-bb25-f39340ecf9be.jpg?1783903247,Legendary Enchantment — Background,John Tyler Christopher
+Force Bubble,4,2003,0.48,#ffffff,https://cards.scryfall.io/normal/front/7/4/742ac116-86ed-4ce6-9805-76f47a41c4c4.jpg?1783944892,Enchantment,Alan Pollack
+Force of Virtue,4,2019,0.41,#ffffff,https://cards.scryfall.io/normal/front/9/7/9736d6f4-5ff6-4006-b45d-8e630382d160.jpg?1783933164,Enchantment,Livia Prima
+Forge Anew,3,2023,5.92,#ffffff,https://cards.scryfall.io/normal/front/5/6/56274b88-6e3f-4538-bb0c-eb5e52a58ef3.jpg?1783916332,Enchantment,Craig J Spearing
+Formation,2,1995,1.0,#ffffff,https://cards.scryfall.io/normal/front/7/8/78446ead-61b0-485f-a5a9-b3e72d8075a7.jpg?1783947526,Instant,Ken Meyer, Jr.
+Form of the Approach of the Second Sun,5,2022,0.15,#ffffff,https://cards.scryfall.io/normal/front/2/1/2149da9d-35ad-4f32-8072-fb515100b2fd.jpg?1783920616,Enchantment,Aaron J. Riley
+For the Emperor!,4,2022,0.67,#ffffff,https://cards.scryfall.io/normal/front/3/c/3c3e9950-b0b9-425c-8b14-f6450882bd57.jpg?1783920946,Sorcery,Games Workshop
+Fortunate Few,5,2017,0.4,#ffffff,https://cards.scryfall.io/normal/front/d/8/d84361bb-abc3-4b2d-9475-700fd262703b.jpg?1783935951,Sorcery,Jesper Ejsing
+Fortune- Loyal Steed,3,2024,0.27,#ffffff,https://cards.scryfall.io/normal/front/0/6/069294a8-e65a-47af-942f-7e99d18658f2.jpg?1783911857,Legendary Creature — Beast Mount,Artur Nakhodkin
+Forum Filibuster,5,2026,0.28,#ffffff,https://cards.scryfall.io/normal/front/1/c/1c2fcf3e-63ce-45bd-afc4-2c11f54c70c4.jpg?1783903863,Enchantment,Inkognit
+Fountain Watch,5,1999,2.2,#ffffff,https://cards.scryfall.io/normal/front/6/9/690daa19-1842-4605-9bda-bf67e4ede3c4.jpg?1783945981,Creature — Human Cleric,Jeff Miracola
+Four Knocks,3,2023,0.66,#ffffff,https://cards.scryfall.io/normal/front/0/2/02fe50fc-6c6c-43e7-ad0e-8f13a254da2a.jpg?1783914678,Enchantment,Darren Tan
+Frankie Peanuts,4,2020,0.19,#ffffff,https://cards.scryfall.io/normal/front/4/4/440c3e8b-d9c6-46cd-9f39-86db077fb89d.jpg?1783931350,Legendary Creature — Elephant Rogue,Thomas M. Baxa
+Friendly Neighborhood,4,2025,0.29,#ffffff,https://cards.scryfall.io/normal/front/1/7/17a18e2f-221f-4fc2-8dab-25bf12fb8756.jpg?1783905362,Enchantment — Aura,Pablo Mendoza
+Frodo- Determined Hero,2,2023,0.98,#ffffff,https://cards.scryfall.io/normal/front/8/3/83d1b37c-a8c6-4690-8701-3395397711e7.jpg?1783916219,Legendary Creature — Halfling Warrior,Magali Villeneuve
+Frodo- Sauron's Bane,1,2023,0.33,#d78f42,https://cards.scryfall.io/normal/front/7/d/7d86dc2e-6f0c-4714-9d30-5d099d3b895c.jpg?1783916334,Legendary Creature — Halfling Citizen,Dmitry Burmak
+From Father to Son,2,2025,0.36,#ffffff,https://cards.scryfall.io/normal/front/0/c/0c730a3b-334e-466b-bb9b-4b41fce2af6d.jpg?1783906649,Sorcery,Jeremy Chong
+From the Rubble,6,2023,0.3,#ffffff,https://cards.scryfall.io/normal/front/9/f/9f7f7c5c-592b-4d22-968b-e5162b024b6e.jpg?1783913913,Enchantment,Ryan Valle
+Frontline Medic,3,2022,0.21,#ffffff,https://cards.scryfall.io/normal/front/3/e/3e9ad9ce-f862-4663-9a36-caf0844eb416.jpg?1783922492,Creature — Human Cleric,Willian Murai
+Fumigate,5,2025,0.34,#ffffff,https://cards.scryfall.io/normal/front/9/7/976f6850-e646-4b51-a103-25240658672d.jpg?1783906046,Sorcery,Svetlin Velinov
+Galepowder Mage,4,2022,0.25,#ffffff,https://cards.scryfall.io/normal/front/2/2/222b4c5a-2cd0-4851-9f2f-8685a658ebb4.jpg?1783922490,Creature — Kithkin Wizard,Jeremy Jarvis
+Gandalf the White,5,2023,8.41,#ffffff,https://cards.scryfall.io/normal/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg?1783916333,Legendary Creature — Avatar Wizard,Magali Villeneuve
+Gandalf- White Rider,4,2023,2.88,#ffffff,https://cards.scryfall.io/normal/front/b/4/b422ce26-06fb-4748-9c01-32c4be914a77.jpg?1783916219,Legendary Creature — Avatar Wizard,Ekaterina Burmak
+Gatewatch Beacon,3,2023,0.38,#ffffff,https://cards.scryfall.io/normal/front/0/8/08b3a1bb-1191-4484-80b0-71cf9f8e510b.jpg?1783915484,Artifact,Deruchenko Alexander
+Gatta and Luzzu,3,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/4/7/4742c222-1f29-4e1a-a545-798d175255ca.jpg?1783906368,Legendary Creature — Human Soldier,Takeuchi Moto
+Geist-Honored Monk,5,2021,0.39,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d09ef1d-3552-43a3-91c7-0d14c0f06780.jpg?1783928331,Creature — Human Monk,Clint Cearley
+General Jarkeld,4,1995,0.93,#ffffff,https://cards.scryfall.io/normal/front/6/a/6a4f5a28-0bd2-4cc4-b67f-324e89193caa.jpg?1783947525,Legendary Creature — Human Soldier,Richard Thomas
+General Leo Cristophe,5,2025,0.22,#ffffff,https://cards.scryfall.io/normal/front/3/9/39384ab7-54da-43e3-8fbc-5c171b7ca7f4.jpg?1783906369,Legendary Creature — Human Soldier,Lee Woo-chul
+General Tazri,5,2016,0.99,#d78f42,https://cards.scryfall.io/normal/front/3/4/34e9aa86-1a31-4c0f-928d-923f066286b6.jpg?1783937927,Legendary Creature — Human Ally,Chris Rahn
+Generous Gift,3,2026,5.15,#ffffff,https://cards.scryfall.io/normal/front/8/f/8f895e9c-9def-4516-89a8-fe580e20ed0d.jpg?1783903506,Instant,Rudy Siswanto
+Generous Pup,2,2024,5.27,#ffffff,https://cards.scryfall.io/normal/front/7/3/730f6a8c-7119-4226-bf37-442cf5ec90c4.jpg?1783908869,Creature — Dog,Julia Metzger
+Gerrard Capashen,5,2010,0.46,#ffffff,https://cards.scryfall.io/normal/front/4/4/447c8c98-ac0e-4a12-a99e-f75d82b7a51f.jpg?1783942021,Legendary Creature — Human Soldier,Brom
+Gerrard's Wisdom,4,1999,0.81,#ffffff,https://cards.scryfall.io/normal/front/b/3/b38a3f26-0376-4f10-b630-7ec6659c0556.jpg?1783946049,Sorcery,Heather Hudson
+Get Lost,2,2023,3.58,#ffffff,https://cards.scryfall.io/normal/front/5/2/522aa72b-2b8c-484c-872b-f082101cee35.jpg?1783913812,Instant,Eli Minaya
+Ghostly Dancers,5,2024,0.4,#ffffff,https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg?1783909509,Creature — Spirit,Josh Newton
+Ghosts of the Innocent,7,2005,0.31,#ffffff,https://cards.scryfall.io/normal/front/c/5/c5b10c5f-261f-4301-b675-d1f52b859360.jpg?1783943699,Creature — Spirit,Kev Walker
+Ghostway,3,2024,5.12,#ffffff,https://cards.scryfall.io/normal/front/0/2/02842e77-7475-4fe5-9d2e-f3c8ba56bc88.jpg?1783913345,Instant,Jim Murray
+Giada- Font of Hope,2,2024,0.55,#ffffff,https://cards.scryfall.io/normal/front/8/a/8ae6fc26-cfad-4da8-98d9-49c27c24d293.jpg?1783909085,Legendary Creature — Angel,Kai Carpenter
+Giant Killer // Chop Down,1,2019,0.34,#ffffff,https://cards.scryfall.io/normal/front/7/5/75754468-2850-42e6-ab22-61ff7b9d1214.jpg?1783932673,Creature — Human Peasant // Instant — Adventure,Jesper Ejsing
+Gideon- Ally of Zendikar,4,2015,1.81,#ffffff,https://cards.scryfall.io/normal/front/1/8/187e887c-c39d-4d25-a506-cdc95fc70316.jpg?1783938219,Legendary Planeswalker — Gideon,Eric Deschamps
+Gideon Blackblade,3,2024,1.3,#ffffff,https://cards.scryfall.io/normal/front/4/1/41326ca6-f815-4af7-b022-67db127bc125.jpg?1783913347,Legendary Planeswalker — Gideon,Viktor Titov
+Gideon- Champion of Justice,4,2021,0.36,#ffffff,https://cards.scryfall.io/normal/front/c/f/cf6d8ac0-4dd2-4a34-bb12-7cfede95e14b.jpg?1783927577,Legendary Planeswalker — Gideon,David Rapoza
+Gideon Jura,5,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/d/6/d608df31-bcc6-4fec-89f1-5cefe5c2ec99.jpg?1783915451,Legendary Planeswalker — Gideon,Aleksi Briclot
+Gideon of the Trials,3,2017,1.72,#ffffff,https://cards.scryfall.io/normal/front/9/5/959ce13f-519f-4472-bbd1-f26a972723d7.jpg?1783936539,Legendary Planeswalker — Gideon,Izzy
+Gideon's Avenger,3,2011,0.63,#ffffff,https://cards.scryfall.io/normal/front/b/b/bb0a0d33-8862-433b-a078-82472e5f9af0.jpg?1783941103,Creature — Human Soldier,Randy Gallegos
+Gideon's Battle Cry,4,2019,0.13,#ffffff,https://cards.scryfall.io/normal/front/5/2/52de8fc6-6d9b-402e-a6c8-4c39b0c92f07.jpg?1783933360,Sorcery,Zoltan Boros
+Gideon's Intervention,4,2017,0.27,#ffffff,https://cards.scryfall.io/normal/front/6/e/6e2524fb-ec90-4f8e-b851-f78034edef3f.jpg?1783936539,Enchantment,Daarken
+Gideon's Phalanx,7,2015,0.2,#ffffff,https://cards.scryfall.io/normal/front/3/0/30142729-de9a-4a0b-b060-8f68e1ef234d.jpg?1783938363,Instant,James Ryman
+Gideon's Resolve,5,2017,0.16,#ffffff,https://cards.scryfall.io/normal/front/a/3/a30b8c40-39ac-423f-b7da-845a16cd1b63.jpg?1783936437,Enchantment,Jakub Kasper
+Gift of Estates,2,1997,5.85,#ffffff,https://cards.scryfall.io/normal/front/3/4/342b5afe-544f-4fa1-a833-4e0590b41eed.jpg?1783946849,Sorcery,Kaja Foglio
+Gift of Immortality,3,2026,0.41,#ffffff,https://cards.scryfall.io/normal/front/4/a/4ae22015-073a-4666-9e3b-15dcf61f50ce.jpg?1783903247,Enchantment — Aura,Marco Turini
+Gilraen- Dúnedain Protector,3,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/0/7/07efe592-5851-4577-b73f-0bb232feb68b.jpg?1783916036,Legendary Creature — Human Noble,Marie Magny
+Gisela- the Broken Blade,4,2025,19.51,#ffffff,https://cards.scryfall.io/normal/front/0/4/04506bad-3856-4184-8dda-941ded60f41a.jpg?1783908181,Legendary Creature — Angel Horror,Clint Cearley
+Giver of Runes,1,2019,11.88,#ffffff,https://cards.scryfall.io/normal/front/4/e/4e117771-5a8b-4812-b487-32ba34b7f724.jpg?1783933162,Creature — Kor Cleric,Seb McKinnon
+Glarecaster,6,2002,0.4,#ffffff,https://cards.scryfall.io/normal/front/7/e/7e505e8e-51aa-4415-81e6-cf022279edb0.jpg?1783945097,Creature — Bird Cleric,Dan Frazier
+Gleam of Authority,2,2015,0.35,#ffffff,https://cards.scryfall.io/normal/front/9/6/96847438-eb09-4e3f-8ebf-f064b88f70c9.jpg?1783938617,Enchantment — Aura,Jakub Kasper
+Glimmer Lens,2,2023,3.33,#ffffff,https://cards.scryfall.io/normal/front/c/9/c9262000-e6f3-4da1-ad1c-038f65d3bef6.jpg?1783918163,Artifact — Equipment,Sidharth Chaturvedi
+Global Ruin,5,2000,0.39,#ffffff,https://cards.scryfall.io/normal/front/3/3/336474b4-2cf5-44c0-b72c-f75f1a7ed928.jpg?1783945717,Sorcery,Greg Staples
+Glorious Anthem,3,2020,0.45,#ffffff,https://cards.scryfall.io/normal/front/1/7/17d154d3-7ae5-43ff-9978-d974285e2c89.jpg?1783930741,Enchantment,Raymond Swanland
+Glorious Protector,4,2022,0.39,#ffffff,https://cards.scryfall.io/normal/front/3/e/3e63385a-e32f-4abc-aff6-bb022b2f56f7.jpg?1783922491,Creature — Angel Cleric,PINDURSKI
+Glory,5,2023,0.39,#ffffff,https://cards.scryfall.io/normal/front/6/b/6b01ebcf-8451-486e-84f6-8e6e1bb9d6e3.jpg?1783918516,Creature — Incarnation,Donato Giancola
+Glory-Bound Initiate,2,2017,0.12,#ffffff,https://cards.scryfall.io/normal/front/2/4/24e23a06-4ed3-4948-aca5-fbdda03f4f2a.jpg?1783936539,Creature — Human Warrior,David Palumbo
+Glowrider,3,2003,3.49,#ffffff,https://cards.scryfall.io/normal/front/9/a/9ad94e39-0aac-46bb-a7f2-bd88c537cb9c.jpg?1783944929,Creature — Human Cleric,Scott M. Fischer
+God-Eternal Oketra,5,2019,1.93,#ffffff,https://cards.scryfall.io/normal/front/d/f/df70f155-2336-421c-8a9d-69772d2b51a8.jpg?1783933481,Legendary Creature — Zombie God,Grzegorz Rutkowski
+Godsend,3,2014,3.68,#ffffff,https://cards.scryfall.io/normal/front/2/d/2dcf3975-7f81-4bdd-810d-476f46444b7a.jpg?1783939460,Legendary Artifact — Equipment,Daniel Ljunggren
+Gods Willing,1,2021,0.5,#ffffff,https://cards.scryfall.io/normal/front/5/7/57e547cd-eba4-4a75-9c4e-8eeb6e00ddc4.jpg?1783927443,Instant,Dominik Mayer
+Golden Wish,5,2002,0.46,#ffffff,https://cards.scryfall.io/normal/front/d/c/dc409ded-41f3-4f14-8199-72a9fe98bac0.jpg?1783945136,Sorcery,Alan Pollack
+Goldmane Griffin,5,2019,0.19,#ffffff,https://cards.scryfall.io/normal/front/6/7/67edcb9b-f56b-4a34-b4bd-d22ee929041a.jpg?1783932923,Creature — Griffin,Paul Scott Canavan
+Goring Ceratops,7,2017,0.72,#ffffff,https://cards.scryfall.io/normal/front/8/3/8309f684-5912-4191-9f64-d573f1cc84c9.jpg?1783935801,Creature — Dinosaur,Zezhou Chen
+Graceful Antelope,4,2001,0.28,#ffffff,https://cards.scryfall.io/normal/front/9/4/948f0d9d-4e05-48b4-8652-1f8f41d35563.jpg?1783945277,Creature — Antelope,Heather Hudson
+Grand Abolisher,2,2024,18.58,#ffffff,https://cards.scryfall.io/normal/front/e/e/ee793ed2-7d59-4640-8868-ad486600df2c.jpg?1783912003,Creature — Human Cleric,Aurore Folny
+Grand Crescendo,2,2025,3.52,#ffffff,https://cards.scryfall.io/normal/front/c/2/c2157a04-f9e8-47b7-bf8d-763d794159f5.jpg?1783907127,Instant,Raluca Marinescu
+Grand Master of Flowers,4,2021,0.38,#ffffff,https://cards.scryfall.io/normal/front/8/c/8ca4ffff-404e-4e8e-8fd6-4e64d4828fc7.jpg?1783926531,Legendary Planeswalker — Bahamut,Ekaterina Burmak
+Grasping Giant,6,2020,0.59,#ffffff,https://cards.scryfall.io/normal/front/a/2/a238aa9c-661e-449a-8f05-70b7954e544f.jpg?1783931492,Creature — Giant,Jinho Bae
+Grasp of Fate,3,2023,0.51,#ffffff,https://cards.scryfall.io/normal/front/4/3/43787574-7700-47ab-b57c-98ef968cce71.jpg?1783915451,Enchantment,Lie Setiawan
+Graven Dominator,6,2006,0.15,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6dc44f8-ff1d-4c5a-971d-c3ce9a65f35d.jpg?1783943530,Creature — Gargoyle,Carl Critchlow
+Greater Auramancy,2,2008,39.39,#ffffff,https://cards.scryfall.io/normal/front/1/1/1177787f-bf1e-438b-9615-97d03b04128c.jpg?1783942768,Enchantment,Chuck Lukacs
+Grey Host Reinforcements,4,2023,0.27,#ffffff,https://cards.scryfall.io/normal/front/7/d/7d72498c-7ac0-41f7-8f8a-47fda31d99e5.jpg?1783916033,Creature — Spirit Soldier,Patrik Hell
+Greymond- Avacyn's Stalwart,4,2023,67.34,#ffffff,https://cards.scryfall.io/normal/front/b/7/b7848325-c46e-4e63-90d0-c9524380eb63.jpg?1783915139,Legendary Creature — Human Soldier,Bram Sels
+Guan Yu- Sainted Warrior,5,1999,48.42,#ffffff,https://cards.scryfall.io/normal/front/1/5/1575fadf-cd5c-4b4f-8965-c006e571334b.jpg?1783946132,Legendary Creature — Human Soldier Warrior,Qiao Dafu
+Guardian Archon,6,2021,0.22,#ffffff,https://cards.scryfall.io/normal/front/6/1/6168ca14-b8d6-4149-bc61-dc1965d2f5b4.jpg?1783927608,Creature — Archon,Scott M. Fischer
+Guardian of Faith,3,2026,0.53,#ffffff,https://cards.scryfall.io/normal/front/0/3/037739cd-e05c-4aae-9123-f924e420010c.jpg?1783903808,Creature — Spirit Knight,Brian Valeza
+Guardian of Ghirapur,3,2023,0.38,#ffffff,https://cards.scryfall.io/normal/front/9/5/9503a1e6-f0bf-44d0-a28b-56fbfcff1ff2.jpg?1783917062,Creature — Angel,Cynthia Sheppard
+Guardian of New Benalia,2,2022,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/3/43da76ee-fec3-4b2e-915d-10cf8d518d2c.jpg?1783921365,Creature — Human Soldier,Ernanda Souza
+Guardian Scalelord,5,2026,0.34,#ffffff,https://cards.scryfall.io/normal/front/8/4/8415c0b3-9bf7-4c45-a215-4a73f1a42cbd.jpg?1783903809,Creature — Dragon,Victor Adame Minguez
+Guardian Seraph,4,2009,0.54,#ffffff,https://cards.scryfall.io/normal/front/a/8/a84613ce-9b59-4ef6-8c76-5b208ff9de88.jpg?1783942402,Creature — Angel,Paul Bonner
+Guardian Sunmare,5,2025,0.35,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg?1783907919,Creature — Horse Mount,Christina Kraus
+Guide of Souls,1,2024,2.9,#ffffff,https://cards.scryfall.io/normal/front/7/6/76c3cad2-1e25-4abe-878d-9194de6fcc27.jpg?1783911300,Creature — Human Cleric,Ryan Valle
+Gustcloak Savior,5,2015,0.25,#ffffff,https://cards.scryfall.io/normal/front/5/3/5303ce82-e82a-498e-af4f-16a56d8188ff.jpg?1783938638,Creature — Bird Soldier,Jim Nelson
+Gwaihir- Greatest of the Eagles,5,2023,0.38,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c17c3bb-aa20-43b0-8a28-b46a18b060ef.jpg?1783916034,Legendary Creature — Bird Noble,Jesper Ejsing
+Haazda Shield Mate,3,2006,0.29,#ffffff,https://cards.scryfall.io/normal/front/8/9/8940e8c6-1423-4dbf-89c8-9055bf15d4ec.jpg?1783943445,Creature — Human Soldier,Ron Spears
+Hada Freeblade,1,2010,4.26,#ffffff,https://cards.scryfall.io/normal/front/0/9/099718e6-9896-4d5e-8edb-3bc9a15c81ec.jpg?1783942032,Creature — Human Soldier Ally,Cyril Van Der Haegen
+Hakoda- Selfless Commander,4,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/9/a/9aef3ddb-9bb7-42c8-975b-b1917955a416.jpg?1783905000,Legendary Creature — Human Warrior Ally,Rafater
+Haliya- Guided by Light,3,2025,1.69,#ffffff,https://cards.scryfall.io/normal/front/6/f/6f7c63ae-5df3-410f-8643-b8c69133ca9d.jpg?1783905996,Legendary Creature — Human Soldier,Kieran Yanner
+Hallowed Burial,5,2016,0.46,#ffffff,https://cards.scryfall.io/normal/front/9/4/94389b94-1514-44d1-b19b-7be104db9bba.jpg?1783937333,Sorcery,Dave Kendall
+Hallowed Haunting,4,2021,10.91,#ffffff,https://cards.scryfall.io/normal/front/6/7/674c0a50-9c37-4c29-84d8-eb3e34f34d37.jpg?1783924918,Enchantment,David Auden Nash
+Hallowed Moonlight,2,2015,0.31,#ffffff,https://cards.scryfall.io/normal/front/9/4/94fd0c0f-4a6a-47cf-9f50-df0bbf19aae4.jpg?1783938362,Instant,Mike Bierek
+Hallowed Spiritkeeper,3,2021,0.5,#ffffff,https://cards.scryfall.io/normal/front/d/c/dc8037d5-79fa-47e3-9d3b-eb29643ecae7.jpg?1783924973,Creature — Avatar,Steve Prescott
+Halo Fountain,3,2022,7.95,#ffffff,https://cards.scryfall.io/normal/front/0/e/0ee79399-715c-4c46-9fa1-e76b1087f009.jpg?1783923158,Artifact,Anastasia Ovchinnikova
+Halvar- God of Battle // Sword of the Realms,4,2021,25.84,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact — Equipment,Lie Setiawan
+Hanged Executioner,3,2021,0.26,#ffffff,https://cards.scryfall.io/normal/front/7/6/7676deeb-b80d-49c9-b810-5ed0a68fa618.jpg?1783924973,Creature — Spirit,Johann Bodin
+Hanna's Custody,3,1997,1.27,#ffffff,https://cards.scryfall.io/normal/front/7/e/7ea44536-ef4e-4dcf-9c1a-c1122dd00cbb.jpg?1783946665,Enchantment,DiTerlizzi
+Hanweir Militia Captain // Westvale Cult Leader,2,2016,0.44,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Soldier // Creature — Human Cleric,David Palumbo
+Happily Ever After,3,2019,0.3,#ffffff,https://cards.scryfall.io/normal/front/d/3/d32d85d5-a6f0-4cc5-9fd6-6b329aae2e5b.jpg?1783932672,Enchantment,Matt Stewart
+Hardlight Containment,1,2025,0.25,#ffffff,https://cards.scryfall.io/normal/front/0/b/0b934241-4d6b-4b9c-99f1-c49cb387cf56.jpg?1783905995,Enchantment — Aura,Dominik Mayer
+Harmonious Archon,6,2019,0.34,#ffffff,https://cards.scryfall.io/normal/front/c/7/c7093834-9627-4da2-9322-c03bfd5b3a71.jpg?1783932673,Creature — Archon,Anastasia Ovchinnikova
+Harper Recruiter,3,2022,0.32,#ffffff,https://cards.scryfall.io/normal/front/6/b/6bb131fd-d96f-43e0-a40d-fa6394a4b75c.jpg?1783922513,Creature — Human Warrior,Ernanda Souza
+Harsh Judgment,4,2000,0.41,#ffffff,https://cards.scryfall.io/normal/front/3/4/34c78dee-ab45-4638-b89a-10686145b19a.jpg?1783945717,Enchantment,Carl Critchlow
+Harsh Mercy,3,2023,1.42,#ffffff,https://cards.scryfall.io/normal/front/b/1/b1448ffd-42af-475c-8883-1933508a8a6a.jpg?1783915450,Sorcery,John Matson
+Hatut Zeraze Strike Force,4,2026,0.43,#ffffff,https://cards.scryfall.io/normal/front/d/9/d96a9ecd-86a3-49ae-851c-ce93b0dca6af.jpg?1783903298,Creature — Human Spy Warrior,Toni Infante
+Haunted Library,2,2021,0.48,#ffffff,https://cards.scryfall.io/normal/front/b/0/b0193151-0f5f-457b-a6b2-08f66b53c9b2.jpg?1783925008,Enchantment,Justyna Dura
+Hawkeye- Bowslinger,3,2026,0.58,#ffffff,https://cards.scryfall.io/normal/front/e/c/ec6889e2-14ad-4193-9272-c1c758f61724.jpg?1783903084,Legendary Creature — Human Archer Hero,Nanna Marie Steffensen
+Haystack,2,2024,2.46,#ffffff,https://cards.scryfall.io/normal/front/9/2/92a70aa6-ac7d-4592-94b0-9ce862d71d50.jpg?1783910885,Artifact,Miklós Ligeti & AndWorld Design
+Hazduhr the Abbot,5,1995,0.59,#ffffff,https://cards.scryfall.io/normal/front/a/d/adfd416a-dddf-40e4-acf0-84057edb7a58.jpg?1783947303,Legendary Creature — Human Cleric,Dan Frazier
+Heartflame Duelist // Heartflame Slash,2,2023,0.31,#d78f42,https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1783915065,Creature — Human Knight // Instant — Adventure,Justyna Dura
+Heavenly Blademaster,6,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/5/3/53f34f41-bbd8-4424-88a3-b97a795b6daf.jpg?1783915721,Creature — Angel,Zack Stella
+Hedron-Field Purists,3,2010,0.35,#ffffff,https://cards.scryfall.io/normal/front/c/4/c48e9f90-4b13-4281-943c-126be4ff1ce0.jpg?1783942008,Creature — Human Cleric,Scott Chou
+Heidegger- Shinra Executive,4,2025,0.19,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e216baf-0e3c-4173-a852-5c5aeb3a9d79.jpg?1783906367,Legendary Creature — Human Soldier,Danciao
+Heliod- God of the Sun,4,2023,4.11,#ffffff,https://cards.scryfall.io/normal/front/b/8/b83e9693-4996-498c-95f7-884d40341298.jpg?1783915449,Legendary Enchantment Creature — God,Jaime Jones
+Heliod's Intervention,2,2024,5.13,#ffffff,https://cards.scryfall.io/normal/front/9/5/9519bb3a-bed3-48e8-93ae-9e9b2e7d646a.jpg?1783911947,Instant,Daarken
+Heliod- Sun-Crowned,3,2023,21.49,#ffffff,https://cards.scryfall.io/normal/front/3/2/3245ff74-1f9c-4518-a23f-1579f338f232.jpg?1783915722,Legendary Enchantment Creature — God,Lius Lasahido
+Heliod- the Radiant Dawn // Heliod- the Warped Eclipse,4,2023,2.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Enchantment Creature — God // Legendary Enchantment Creature — Phyrexian God,Victor Adame Minguez
+Helitrooper,2,2025,0.18,#ffffff,https://cards.scryfall.io/normal/front/2/0/2073f387-9cdd-4184-8704-e6031c934b6d.jpg?1783906367,Creature — Human Soldier,HAIKEI
+Helpful Hunter,2,2025,26.83,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a09344c-e869-4a8e-9be6-a29f1a5b6df6.jpg?1783907482,Creature — Cat,Chuck Grieb
+Herald of Amity,4,2026,0.23,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a36fe06-225f-44c6-b608-452344e3585a.jpg?1783903864,Creature — Griffin,Xabi Gaztelua
+Herald of Anafenza,1,2014,0.15,#ffffff,https://cards.scryfall.io/normal/front/e/8/e8bf6ed4-48f3-419f-bafd-d1ee4d798482.jpg?1783939095,Creature — Human Soldier,Aaron Miller
+Herald of Eternal Dawn,7,2024,1.04,#ffffff,https://cards.scryfall.io/normal/front/c/9/c9fdfebf-98e0-4718-bac3-6eee1cd0623d.jpg?1783909125,Creature — Angel,Martina Fačková
+Herald of Serra,4,1998,2.4,#ffffff,https://cards.scryfall.io/normal/front/2/2/22a2b882-d616-495e-99f6-196031235f93.jpg?1783946375,Creature — Angel,Matthew D. Wilson
+Herald of the Forgotten,8,2020,0.33,#ffffff,https://cards.scryfall.io/normal/front/c/3/c3dba1c4-ee9a-4ea6-bf66-f639d38711cd.jpg?1783931224,Creature — Cat Beast,Antonio José Manzanedo
+Herald of War,5,2021,3.46,#ffffff,https://cards.scryfall.io/normal/front/1/8/18f7c44c-a21f-4b61-8f08-122a75accb00.jpg?1783925350,Creature — Angel,Eric Deschamps
+Hercules- Olympian Hero,5,2026,0.48,#ffffff,https://cards.scryfall.io/normal/front/7/7/77be0e26-90db-41a5-97c2-43cf6ef87ab0.jpg?1783903299,Legendary Creature — Demigod Warrior Hero,Alex Horley-Orlandelli
+Heroes Remembered,9,2007,1.31,#ffffff,https://cards.scryfall.io/normal/front/9/9/9902b260-82cf-4b10-a353-321231824a3b.jpg?1783943170,Sorcery,Michael Phillippi
+Heroic Return,6,2026,0.24,#ffffff,https://cards.scryfall.io/normal/front/7/0/707e0b51-701b-4eb6-b721-19c21a3c4d90.jpg?1783903298,Instant,David Seeley
+Heroic Sacrifice,2,2026,0.72,#ffffff,https://cards.scryfall.io/normal/front/e/c/ec7bd155-1dd6-4fc3-870f-e0905f8c6d42.jpg?1783903298,Instant,Lie Setiawan
+Hero of Bladehold,4,2025,0.48,#ffffff,https://cards.scryfall.io/normal/front/8/c/8ca58965-1dfa-40ac-b6c8-f957167ff066.jpg?1783907125,Creature — Human Knight,Steven Belledin
+Hero of Bretagard,3,2021,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/4/4458c16c-b71d-481d-863b-f2e3b1320178.jpg?1783928340,Creature — Human Warrior,Heonhwa
+Hero of Goma Fada,5,2015,0.3,#ffffff,https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg?1783938218,Creature — Human Knight Ally,Lake Hurwitz
+Hero of Iroas,2,2014,0.79,#ffffff,https://cards.scryfall.io/normal/front/7/9/7917f2ee-f093-4ffb-83ed-a181b14b5957.jpg?1783939579,Creature — Human Soldier,Willian Murai
+Hero of Precinct One,2,2022,0.25,#ffffff,https://cards.scryfall.io/normal/front/4/5/4564f7b4-4fa3-40a3-88e8-2f1cfd15461c.jpg?1783921436,Creature — Human Warrior,Bram Sels
+Hidden Dragonslayer,2,2024,0.22,#ffffff,https://cards.scryfall.io/normal/front/b/2/b29a3e7c-4d19-4737-9b58-deb56de26118.jpg?1783913030,Creature — Human Warrior,Anastasia Ovchinnikova
+Hidden Retreat,3,1998,3.14,#ffffff,https://cards.scryfall.io/normal/front/5/b/5be86f1f-c85a-4396-aa16-a39fbf493c96.jpg?1783946574,Enchantment,Terese Nielsen
+High Noon,2,2024,6.05,#d78f42,https://cards.scryfall.io/normal/front/9/9/9995e0e6-7c9c-4fef-8fd2-8fb1622e6ec8.jpg?1783911857,Enchantment,Eduardo Francisco
+High Sentinels of Arashin,4,2023,0.21,#ffffff,https://cards.scryfall.io/normal/front/d/4/d46b34ed-88a4-4868-9ce3-b91901e600d3.jpg?1783917183,Creature — Bird Soldier,James Ryman
+Hikari- Twilight Guardian,5,2004,0.19,#ffffff,https://cards.scryfall.io/normal/front/e/2/e2dc7ba1-6194-45ba-97c5-ad14331cc3a6.jpg?1783944341,Legendary Creature — Spirit,Glen Angus
+Hildibrand Manderville // Gentleman's Rise,2,2025,0.21,#d78f42,https://cards.scryfall.io/normal/front/6/0/60aed76e-2265-471d-8e41-1d8605603b78.jpg?1783906347,Legendary Creature — Human Detective // Instant — Adventure,AKAGI
+Historian's Boon,4,2022,2.57,#ffffff,https://cards.scryfall.io/normal/front/0/d/0da48d1e-0dec-461a-9a1d-477408b297e6.jpg?1783921470,Enchantment,Irina Nordsol
+History of Benalia,3,2018,0.91,#ffffff,https://cards.scryfall.io/normal/front/d/1/d134385d-b01c-41c7-bb2d-30722b44dc5a.jpg?1783935041,Enchantment — Saga,Noah Bradley
+Hixus- Prison Warden,5,2015,0.31,#ffffff,https://cards.scryfall.io/normal/front/d/0/d0c21a35-4b70-4de4-93ff-c0ccabdc39e0.jpg?1783938361,Legendary Creature — Human Soldier,Chris Rallis
+Hokori- Dust Drinker,4,2005,1.62,#ffffff,https://cards.scryfall.io/normal/front/5/a/5a03f5d5-d5c3-4a7d-8d44-e60b498b4ed5.jpg?1783944216,Legendary Creature — Spirit,Darrell Riche
+Hold the Line,3,2014,0.33,#ffffff,https://cards.scryfall.io/normal/front/d/2/d20ee9c8-6d58-42fc-8b27-bfd0ea6d4374.jpg?1783939106,Instant,Ron Spears
+Holy Avenger,3,2021,0.74,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d64d158-3477-4530-9596-2d4e4eceb11a.jpg?1783926258,Artifact — Equipment,Milivoj Ćeran
+Honor of the Pure,2,2011,0.73,#ffffff,https://cards.scryfall.io/normal/front/6/5/650a6831-c352-4ca7-9f8f-43ea99a1cf33.jpg?1783941102,Enchantment,Greg Staples
+Honor the Fallen,2,1999,13.12,#ffffff,https://cards.scryfall.io/normal/front/7/0/70147617-10e0-413d-be0a-a888b9cb6b97.jpg?1783945980,Instant,Terese Nielsen
+Hoofprints of the Stag,2,2026,0.15,#ffffff,https://cards.scryfall.io/normal/front/a/f/af609bbd-2ed0-4a2b-b3e3-7120e86da9ce.jpg?1783911512,Kindred Enchantment — Elemental,Anthony S. Waters
+Hopeful Initiate,1,2025,0.34,#ffffff,https://cards.scryfall.io/normal/front/c/6/c655f9e8-ff99-48d0-83a9-ea6a853f17c6.jpg?1783908180,Creature — Human Warlock,Dan Murayama Scott
+Horn of Valhalla // Ysgard's Call,2,2022,1.04,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2419408-e907-4d62-b158-c97afc388c04.jpg?1783922810,Artifact — Equipment // Sorcery — Adventure,John Severin Brassell
+Hourglass of the Lost,3,2024,1.34,#ffffff,https://cards.scryfall.io/normal/front/1/5/15a5bb8f-cfc5-4afa-870d-a7a7117929b2.jpg?1783911426,Artifact,Lindsey Look
+Hour of Reckoning,7,2025,0.29,#ffffff,https://cards.scryfall.io/normal/front/1/4/14d60131-8715-477d-8a67-5f1f99a906a8.jpg?1783907128,Sorcery,Joseph Meehan
+Hour of Revelation,6,2020,1.6,#ffffff,https://cards.scryfall.io/normal/front/d/d/ddb53e90-f91e-4da9-ab70-5460958c6c99.jpg?1783929489,Sorcery,Raymond Swanland
+Huang Zhong- Shu General,4,1999,100.77,#ffffff,https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg?1783946131,Legendary Creature — Human Soldier,Quan Xuejun
+Hundred-Handed One,4,2016,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/8/489f192f-0d8a-468b-94f5-67a937e5028e.jpg?1783937332,Creature — Giant,Brad Rigney
+Hunted Lammasu,4,2021,0.35,#ffffff,https://cards.scryfall.io/normal/front/e/a/ea6daa57-1520-40a9-90c7-fa7283f4a687.jpg?1783927576,Creature — Lammasu,Mark Zug
+Hushbringer,2,2019,0.83,#ffffff,https://cards.scryfall.io/normal/front/6/6/663b3e6f-1099-4de8-a0a7-6f1919c38010.jpg?1783932672,Creature — Faerie,Bastien L. Deharme
+Hushwing Gryff,3,2016,0.38,#ffffff,https://cards.scryfall.io/normal/front/6/0/604b8ad4-b606-4be2-b3de-ad9f24b01eac.jpg?1783937077,Creature — Hippogriff,John Severin Brassell
+Hyperion- Supreme Hero,7,2026,12.47,#ffffff,https://cards.scryfall.io/normal/front/1/6/1604acc8-0d54-42bb-ac4b-399987a6b554.jpg?1783903083,Legendary Creature — Eternal Hero,Immanuela Crovius
+Ian Chesterton,3,2023,0.36,#ffffff,https://cards.scryfall.io/normal/front/8/b/8bce4bde-33af-4c91-903f-c46218664353.jpg?1783914679,Legendary Creature — Human Scientist,Kim Sokol
+Icatian Lieutenant,2,1994,0.89,#ffffff,https://cards.scryfall.io/normal/front/3/9/39fec59a-4ade-4c6f-ae7d-911fbe6da26d.jpg?1783947917,Creature — Human Soldier,Pete Venters
+Icatian Skirmishers,4,1994,0.81,#ffffff,https://cards.scryfall.io/normal/front/1/5/15f6d115-c02d-45a3-aa6d-402964df47dd.jpg?1783947915,Creature — Human Soldier,Heather Hudson
+Icatian Town,6,1999,0.62,#ffffff,https://cards.scryfall.io/normal/front/f/7/f7582903-57b0-42e6-991c-0f93ab9172d0.jpg?1783946210,Sorcery,Tom Wänerstrand
+Icingdeath- Frost Tyrant,4,2021,0.82,#ffffff,https://cards.scryfall.io/normal/front/2/6/26b0e68a-9d4e-42ea-8dac-c47cbed0c6ad.jpg?1783926531,Legendary Creature — Dragon,Matt Stewart
+Idolized,2,2024,1.88,#ffffff,https://cards.scryfall.io/normal/front/6/8/687133cb-3754-475c-9e21-b6a33aa58bb0.jpg?1783912417,Enchantment — Aura,Kim Sokol
+Idol of Endurance,3,2020,0.21,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d60e84e-be05-49da-9720-4225abe9d003.jpg?1783930739,Artifact,Kim Sokol
+Idyllic Tutor,3,2020,13.13,#ffffff,https://cards.scryfall.io/normal/front/f/0/f06edd53-f3ac-44b0-a087-5670ba8f0fa5.jpg?1783931595,Sorcery,Jaime Jones
+Ignite the Beacon,5,2019,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/e/4e11d6f9-0b80-4b19-ab96-23f80b66b409.jpg?1783933480,Instant,Slawomir Maniak
+Illustrious Wanderglyph,5,2023,18.27,#ffffff,https://cards.scryfall.io/normal/front/3/0/30e02cc7-8ea9-468b-ba61-a1e00fefea22.jpg?1783913934,Artifact Creature — Golem,Erikas Perl
+Immortal Obligation,2,2024,0.39,#ffffff,https://cards.scryfall.io/normal/front/b/d/bdadc60f-942f-47e2-b8fc-51deb3d0b86d.jpg?1783913052,Instant,Nino Vecia
+Immovable Rod,1,2021,0.39,#ffffff,https://cards.scryfall.io/normal/front/2/1/214c87be-7ce3-48a0-b2eb-26eff75636c9.jpg?1783926258,Artifact,Jakub Kasper
+Imperial Mask,5,2007,0.59,#ffffff,https://cards.scryfall.io/normal/front/b/b/bb02f692-80a9-4740-afde-cb4792d24774.jpg?1783943124,Enchantment,Christopher Moeller
+Imposing Sovereign,2,2013,0.35,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f672328-3361-498e-a9f4-2d8e69a8b072.jpg?1783939942,Creature — Human Noble,Scott M. Fischer
+I'm Rubber- You're Glue,2,1998,1.17,#ffffff,https://cards.scryfall.io/normal/front/5/9/5979237f-ff41-4e87-b2e4-d09b81eca2dc.jpg?1783946438,Enchantment,Claymore J. Flapdoodle
+Increasing Devotion,5,2020,0.35,#ffffff,https://cards.scryfall.io/normal/front/0/c/0c786c28-1085-4b3e-9164-5fa3adfa5010.jpg?1783931197,Sorcery,Daniel Ljunggren
+Indestructibility,4,2013,3.68,#ffffff,https://cards.scryfall.io/normal/front/e/0/e086a062-d39b-4e2a-bde0-f4d6d1797a5f.jpg?1783939942,Enchantment — Aura,Darrell Riche
+Indomitable Ancients,4,2025,0.41,#ffffff,https://cards.scryfall.io/normal/front/a/4/a4e20d78-8c01-40ed-bc69-89d4d5028552.jpg?1783907123,Creature — Treefolk Warrior,Pete Venters
+Indomitable Archangel,4,2022,0.49,#ffffff,https://cards.scryfall.io/normal/front/2/3/23f4b149-fad5-4ba2-a484-dd29d97d120d.jpg?1783923967,Creature — Angel,Allen Williams
+Infinite Authority,3,1994,11.91,#ffffff,https://cards.scryfall.io/normal/front/d/c/dc60077f-d577-4a6c-a78f-697317024c40.jpg?1783948085,Enchantment — Aura,Douglas Shuler
+Informed Inkwright,2,2026,0.32,#ffffff,https://cards.scryfall.io/normal/front/5/d/5defb2d1-d0fb-4e7f-a5c7-3df99fe675d6.jpg?1783903704,Creature — Human Wizard,Nia Kovalevski
+Inner Sanctum,3,1997,1.01,#ffffff,https://cards.scryfall.io/normal/front/2/2/2298faae-370e-4b87-bf32-d20c2282a928.jpg?1783946747,Enchantment,D. Alexander Gregory
+Intervention Pact,0,2007,4.77,#ffffff,https://cards.scryfall.io/normal/front/b/c/bca127ef-349e-4380-875d-49c14fa03b18.jpg?1783943128,Instant,Dave Kendall
+In the Trenches,3,2022,0.33,#ffffff,https://cards.scryfall.io/normal/front/7/1/71ff86e9-1ce6-43cc-8135-f2adb1b6c5a7.jpg?1783920131,Enchantment,Daarken
+Intrepid Adversary,2,2021,0.51,#ffffff,https://cards.scryfall.io/normal/front/7/7/773199f9-c83b-4a77-8342-9f1552ecf595.jpg?1783925657,Creature — Human Scout,Viktor Titov
+Intrepid Hero,3,2012,1.06,#ffffff,https://cards.scryfall.io/normal/front/4/3/43ec71e9-0024-4f8f-b499-541fb7607fcd.jpg?1783940516,Creature — Human Soldier,Greg Hildebrandt
+Invasion of Gobakhan // Lightshield Array,2,2023,0.54,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Enchantment,Andreas Zafiratos
+Invasion of Theros // Ephara- Ever-Sheltering,3,2023,0.64,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Battle — Siege // Legendary Enchantment Creature — God,Johan Grenier
+Invincible Hymn,8,2008,2.95,#ffffff,https://cards.scryfall.io/normal/front/7/1/712c64bc-ba0c-4bab-9329-54805f4efa8a.jpg?1783942581,Sorcery,Matt Stewart
+Invisible Force Field,2,2026,0.51,#ffffff,https://cards.scryfall.io/normal/front/7/b/7b05925b-ac8f-4ca5-9c9d-5e4e408c9f1d.jpg?1783903298,Instant,Erikas Perl
+Invisible Woman,3,2026,1.09,#d78f42,https://cards.scryfall.io/normal/front/d/8/d8e13ecb-98be-4d9b-86a2-24eaa98f7f0d.jpg?1783903304,Legendary Creature — Human Hero,Erikas Perl
+Invoke Justice,5,2022,0.25,#ffffff,https://cards.scryfall.io/normal/front/3/a/3a598ab6-3254-49fe-b69f-e7c759129599.jpg?1783923919,Sorcery,Kekai Kotaki
+Iona- Shield of Emeria,9,2015,13.29,#ffffff,https://cards.scryfall.io/normal/front/6/1/6197b59e-1652-496c-a038-e2eb88ecf017.jpg?1783938426,Legendary Creature — Angel,Jason Chan
+Ironsoul Enforcer,5,2022,0.79,#ffffff,https://cards.scryfall.io/normal/front/c/2/c2c0dfeb-2af0-4c91-bdfe-5270f64dff03.jpg?1783923999,Artifact Creature — Human Samurai,Antonio José Manzanedo
+Ironwill Forger,4,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/5/3/53398f76-7c8a-4009-8f28-9ce586e2c7e4.jpg?1783907184,Creature — Orc Artificer,Konstantin Porubov
+Isamaru- Hound of Konda,1,2020,1.71,#ffffff,https://cards.scryfall.io/normal/front/6/a/6afead32-3542-44c4-82d6-b6a81beb9f90.jpg?1783930470,Legendary Creature — Dog,Christopher Moeller
+Isolate,1,2018,0.11,#ffffff,https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg?1783934605,Instant,Victor Adame Minguez
+Ivory Mask,4,2005,0.62,#ffffff,https://cards.scryfall.io/normal/front/b/0/b02422f7-728b-481b-9eb1-34d17c696ce6.jpg?1783944102,Enchantment,Glen Angus
+Jabari's Influence,5,1996,1.21,#ffffff,https://cards.scryfall.io/normal/front/c/9/c9f764d7-4c18-40ef-8373-ef1e2a88007e.jpg?1783947120,Instant,Gerry Grace
+Jackdaw Savior,3,2024,0.42,#ffffff,https://cards.scryfall.io/normal/front/1/2/121af600-6143-450a-9f87-12ce4833f1ec.jpg?1783910860,Creature — Bird Cleric,Alessandra Pisano
+Jacked Rabbit,2,2024,3.4,#ffffff,https://cards.scryfall.io/normal/front/2/c/2c695df6-6bf2-4e6b-8500-e3116137ca27.jpg?1783910736,Creature — Rabbit Warrior,Scott Murphy
+Jackknight,2,2017,0.25,#ffffff,https://cards.scryfall.io/normal/front/3/d/3d84953b-c59c-45f8-aedd-e68bff7c7ce3.jpg?1783935460,Artifact Creature — Cyborg Knight,Ben Wootten
+Jailbreak,2,2022,0.33,#ffffff,https://cards.scryfall.io/normal/front/5/8/5884d98e-3e02-48ae-9904-4ebbf1e90f6d.jpg?1783923374,Sorcery,Tatiana Kirgetova
+Jareth- Leonine Titan,6,2018,0.53,#ffffff,https://cards.scryfall.io/normal/front/b/f/bf57d9ec-d161-4cb4-989b-72278bfdba4c.jpg?1783934771,Legendary Creature — Cat Giant,Daren Bader
+Jazal Goldmane,4,2023,0.28,#ffffff,https://cards.scryfall.io/normal/front/6/1/616d54a1-33f7-47c9-852f-4f3a07309f27.jpg?1783915721,Legendary Creature — Cat Warrior,Aaron Miller
+Jennifer Walters // The Sensational She-Hulk,2,2026,13.17,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Advisor Hero // Legendary Creature — Gamma Hero,Taurin Clarke
+Jet- Rebel Leader,4,2025,0.2,#ffffff,https://cards.scryfall.io/normal/front/7/9/79d4b68c-36b9-4597-83f8-a869c5cf4b93.jpg?1783904834,Legendary Creature — Human Rebel Ally,Keiuu
+Jeweled Spirit,5,2000,0.31,#ffffff,https://cards.scryfall.io/normal/front/b/0/b0d3e681-bd4b-41e9-8db4-083172f3caad.jpg?1783945797,Creature — Spirit,Christopher Moeller
+Jhovall Queen,6,1999,0.71,#ffffff,https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg?1783945979,Creature — Cat Rebel,Michael Sutfin
+Jo Grant,3,2023,0.24,#ffffff,https://cards.scryfall.io/normal/front/a/4/a4c73220-363e-44d7-b406-436246c02a75.jpg?1783914678,Legendary Creature — Human Soldier,Fajareka Setiawan
+Joined Researchers // Secret Rendezvous,2,2026,0.31,#ffffff,https://cards.scryfall.io/normal/front/1/e/1ebaafe0-3a9a-424c-8698-d26e7be45343.jpg?1783903702,Creature — Human Cleric Wizard // Sorcery,Ryan Pancoast
+Judgment of Alexander,3,2025,7.58,#ffffff,https://cards.scryfall.io/normal/front/2/3/2327bf49-348c-44e5-9a6b-97ef1c810079.jpg?1783904652,Instant,Erion Makuo
+Just Fate,3,1998,1.33,#ffffff,https://cards.scryfall.io/normal/front/a/6/a6e5e572-030d-4a41-89e6-e720b49bc131.jpg?1783946492,Instant,Bradley Williams
+Kabira Evangel,3,2009,4.21,#ffffff,https://cards.scryfall.io/normal/front/5/7/57f05d96-42d5-4e1d-a9c6-229a3f42dda9.jpg?1783942172,Creature — Human Cleric Ally,Eric Deschamps
+Kalemne's Captain,5,2020,0.24,#ffffff,https://cards.scryfall.io/normal/front/8/c/8c6fd0bf-25de-422b-b042-121460b01b17.jpg?1783931197,Creature — Giant Soldier,Tomasz Jedruszek
+Karmic Guide,5,2026,0.36,#ffffff,https://cards.scryfall.io/normal/front/b/2/b26d50dd-54a1-43ce-9884-3999f698d97b.jpg?1783903811,Creature — Angel Spirit,Allen Williams
+Karmic Justice,3,2015,1.66,#ffffff,https://cards.scryfall.io/normal/front/e/a/ea141e39-8124-4d72-a154-eb76e71be1dc.jpg?1783938102,Enchantment,Ray Lago
+Kataki- War's Wage,2,2013,1.65,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d84ac44-01d8-415e-af69-7c608ac8ae20.jpg?1783940005,Legendary Creature — Spirit,Matt Thompson
+Katerina of Myra's Marvels,4,2022,0.19,#ffffff,https://cards.scryfall.io/normal/front/1/9/191da6ec-22a5-4eab-a016-01cd588cce9f.jpg?1783920610,Legendary Creature — Human Performer,Gaboleps
+Katilda- Dawnhart Martyr // Katilda's Rising Dawn,3,2021,0.98,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Spirit Warlock // Legendary Enchantment — Aura,Manuel Castañón
+Kayla's Command,3,2022,0.23,#ffffff,https://cards.scryfall.io/normal/front/0/7/0737dbec-1646-41a0-adbf-706c9bd4fc7a.jpg?1783920132,Sorcery,Dominik Mayer
+Kayla's Reconstruction,3,2022,0.27,#ffffff,https://cards.scryfall.io/normal/front/2/b/2bb84e72-0231-461a-a230-d8afa6e54289.jpg?1783920129,Sorcery,Nicholas Elias
+Keeper of the Accord,4,2024,0.49,#ffffff,https://cards.scryfall.io/normal/front/0/8/08788504-17b9-47b1-b928-f395d0057eed.jpg?1783913029,Creature — Human Soldier,Denman Rooke
+Kellan- Daring Traveler // Journey On,2,2023,0.25,#d78f42,https://cards.scryfall.io/normal/front/0/1/01739030-c280-492b-a5c9-b3e9f6debc6d.jpg?1783913732,Legendary Creature — Human Faerie Scout // Sorcery — Adventure,Marta Nael
+Kemba- Kha Enduring,2,2023,0.3,#ffffff,https://cards.scryfall.io/normal/front/9/4/945d283d-4592-485f-808a-6e5a721f3cf7.jpg?1783918078,Legendary Creature — Cat Cleric,Zoltan Boros
+Kemba- Kha Regent,3,2020,0.28,#ffffff,https://cards.scryfall.io/normal/front/e/8/e8e92cf6-8382-44b5-9f14-c91e572685b9.jpg?1783930214,Legendary Creature — Cat Cleric,Todd Lockwood
+Kemba's Banner,4,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/5/e/5e50c148-9f30-4131-8ec1-85e9ba8cafbb.jpg?1783918163,Artifact — Equipment,Wisnu Tan
+Kenrith- the Returned King,5,2023,3.02,#d78f42,https://cards.scryfall.io/normal/front/0/e/0e259db1-14db-4314-998c-6a076a28d8cb.jpg?1783916113,Legendary Creature — Human Noble,Kieran Yanner
+Kentaro- the Smiling Cat,2,2005,2.16,#ffffff,https://cards.scryfall.io/normal/front/d/d/ddcea3b3-5852-4ae1-a952-7b392564cb9d.jpg?1783944214,Legendary Creature — Human Samurai,Donato Giancola
+Kinbinding,5,2026,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6e35fd5-de7e-40a8-a23c-00d07fd1ac56.jpg?1783904504,Enchantment,Caio Monteiro
+Kindred Boon,4,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/a/9/a9d21710-3006-45a0-9af2-275159bb5315.jpg?1783913895,Enchantment,Carlos Palma Cruchaga
+King Solomon's Frogs,4,2026,0.42,#ffffff,https://cards.scryfall.io/normal/front/6/9/6908808f-e47e-4acb-a405-41b8018a5729.jpg?1783903297,Legendary Artifact,Michele Giorgi
+King Suleiman,2,1993,161.1,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d3dce0f-2168-4f63-b2f9-156a11beeea7.jpg?1783948393,Creature — Human Noble,Mark Poole
+Kinjalli's Sunwing,3,2023,0.8,#ffffff,https://cards.scryfall.io/normal/front/0/4/04421508-b5ac-4466-9f77-dfef478d3cc2.jpg?1783913896,Creature — Dinosaur,Simon Dominic
+Kinsbaile Borderguard,3,2008,6.33,#ffffff,https://cards.scryfall.io/normal/front/8/2/82a2e219-9e84-4f54-88e2-3925e48c4827.jpg?1783942804,Creature — Kithkin Soldier,Christopher Moeller
+Kinsbaile Cavalier,4,2011,11.57,#ffffff,https://cards.scryfall.io/normal/front/b/c/bcda21e6-f423-4dd9-a4a3-bacfa83612d0.jpg?1783941347,Creature — Kithkin Knight,Wayne Reynolds
+Kinscaer Sentry,2,2026,0.41,#ffffff,https://cards.scryfall.io/normal/front/3/3/333bf101-14e8-4753-99bc-9174f42c4122.jpg?1783904507,Creature — Kithkin Soldier,Kev Fang
+Kirtar's Wrath,6,2021,0.21,#ffffff,https://cards.scryfall.io/normal/front/6/f/6f9a11d2-e422-430d-af2a-525fc4a2e2cc.jpg?1783924973,Sorcery,Kev Walker
+Kitsune Mystic // Autumn-Tail- Kitsune Sage,4,2004,0.93,#ffffff,https://cards.scryfall.io/normal/front/f/2/f2ddf1a3-e6fa-4dd0-b80d-1a585b51b934.jpg?1783944336,Creature — Fox Wizard // Legendary Creature — Fox Wizard,Jim Murray
+Kiyomaro- First to Stand,5,2005,0.44,#ffffff,https://cards.scryfall.io/normal/front/3/b/3b3351bb-5c4e-498b-b6c9-94f571baffd5.jpg?1783944169,Legendary Creature — Spirit,Kev Walker
+Kjeldoran Knight,2,1995,1.35,#ffffff,https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg?1783947523,Creature — Human Knight,Ron Spencer
+Kjeldoran Phalanx,6,1995,1.07,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg?1783947523,Creature — Human Soldier,Richard Kane Ferguson
+Kjeldoran Royal Guard,5,2007,0.21,#ffffff,https://cards.scryfall.io/normal/front/e/a/ea3d742a-52a1-45c8-961a-85b6ff120c44.jpg?1783943076,Creature — Human Soldier,Carl Critchlow
+Knight-Captain of Eos,5,2008,2.64,#ffffff,https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg?1783942580,Creature — Human Knight,Chris Rahn
+Knight-Errant of Eos,5,2023,0.31,#ffffff,https://cards.scryfall.io/normal/front/a/b/ab2ad652-2406-491a-9f22-23e974f943d7.jpg?1783917058,Creature — Human Knight,Kevin Sidharta
+Knight Exemplar,3,2023,4.16,#ffffff,https://cards.scryfall.io/normal/front/8/4/8400f1a7-ebf0-49b2-a51d-3b2056c05b61.jpg?1783917184,Creature — Human Knight,Jason Chan
+Knight of the White Orchid,2,2023,3.81,#ffffff,https://cards.scryfall.io/normal/front/f/3/f332cd21-46ed-4fff-9fd9-d5975bf0004d.jpg?1783917182,Creature — Human Knight,Mark Zug
+Knights of Thorn,4,1994,9.58,#ffffff,https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg?1783947948,Creature — Human Knight,Christopher Rush
+Konda- Lord of Eiganjo,7,2004,6.2,#ffffff,https://cards.scryfall.io/normal/front/5/e/5edab171-94b9-4e5e-ab61-bd8c6c8cfc38.jpg?1783944335,Legendary Creature — Human Samurai,John Bolton
+Kongming's Contraptions,4,1999,41.65,#ffffff,https://cards.scryfall.io/normal/front/6/7/6729eb0b-5655-4191-af14-4f7e4a8dded7.jpg?1783946130,Creature — Human Soldier,Jiaming
+Kor Spiritdancer,2,2026,0.39,#ffffff,https://cards.scryfall.io/normal/front/4/8/48da45bd-ed72-4239-af02-e848703a1d02.jpg?1783903807,Creature — Kor Wizard,Nils Hamm
+Kutzil's Flanker,3,2023,0.47,#ffffff,https://cards.scryfall.io/normal/front/d/1/d1201811-54ab-4c4e-b6e1-19b0d07e5ede.jpg?1783913810,Creature — Cat Warrior,Michele Giorgi
+Kyodai- Soul of Kamigawa,4,2022,0.43,#d78f42,https://cards.scryfall.io/normal/front/c/b/cbbfd21e-96f1-4e5b-8546-73bb5a887b98.jpg?1783923918,Legendary Creature — Dragon Spirit,Daniel Zrom
+Kytheon- Hero of Akros // Gideon- Battle-Forged,1,2015,1.51,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Soldier // Legendary Planeswalker — Gideon,Willian Murai
+Kytheon's Irregulars,4,2019,0.24,#ffffff,https://cards.scryfall.io/normal/front/b/8/b861a011-ec5a-471f-b2a3-d8af52af07b4.jpg?1783931666,Creature — Human Soldier,Mark Winters
+Lady of Laughter,5,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg?1783915041,Creature — Faerie Noble,Kai Carpenter
+Lae'zel's Acrobatics,4,2022,2.63,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d102241-4463-437f-b2bb-f574d9dbbd1e.jpg?1783922809,Instant,Tatiana Kirgetova
+Lae'zel- Vlaakith's Champion,3,2022,2.83,#ffffff,https://cards.scryfall.io/normal/front/1/a/1a93f587-ab72-42da-88c4-31af1c9cdf1b.jpg?1783922810,Legendary Creature — Gith Warrior,John Stanko
+Land Tax,1,2026,14.82,#ffffff,https://cards.scryfall.io/normal/front/c/7/c70d3706-9d28-49ac-8718-4a516413e727.jpg?1783903809,Enchantment,Chuck Lukacs
+Lantern Flare,2,2021,0.15,#d78f42,https://cards.scryfall.io/normal/front/d/f/dfd59300-7b5c-4263-a7fd-775c9fcb05ad.jpg?1783924916,Instant,Lie Setiawan
+Lantern Scout,3,2015,0.32,#ffffff,https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg?1783938218,Creature — Human Scout Ally,Steven Belledin
+Launch the Fleet,1,2014,0.5,#ffffff,https://cards.scryfall.io/normal/front/b/c/bc3e52c0-2f79-4537-8f1c-70b68836bac0.jpg?1783939456,Sorcery,Karl Kopinski
+Lavabrink Venturer,3,2020,0.17,#ffffff,https://cards.scryfall.io/normal/front/3/8/38c0d9d6-c9c7-4169-8106-400445643a1a.jpg?1783931089,Creature — Human Soldier,Zoltan Boros
+Layla Hassan,4,2024,0.34,#ffffff,https://cards.scryfall.io/normal/front/2/2/2278d97e-791a-4843-a385-65bac79bde7a.jpg?1783910987,Legendary Creature — Human Assassin,Michael MacRae
+Leader's Talent,2,2026,0.66,#ffffff,https://cards.scryfall.io/normal/front/4/c/4cbcb622-1aff-460f-b8fa-4502d991e0ad.jpg?1783904124,Enchantment — Class,Manuel Castañón
+Legion Angel,4,2020,0.3,#ffffff,https://cards.scryfall.io/normal/front/b/d/bda5609a-ab22-4f03-988b-8056c97fdc9e.jpg?1783929414,Creature — Angel Warrior,PINDURSKI
+Legion Loyalty,8,2025,0.33,#ffffff,https://cards.scryfall.io/normal/front/1/1/11681eae-f5bd-4e78-a980-5ab58db0d9f3.jpg?1783907122,Enchantment,Michal Ivan
+Legion's Landing // Adanto- the First Fort,1,2017,2.75,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Enchantment // Legendary Land,Svetlin Velinov
+Lena- Selfless Champion,6,2020,0.39,#ffffff,https://cards.scryfall.io/normal/front/d/a/da1fb1a6-7f64-45a6-9fc0-a325b7600afa.jpg?1783930469,Legendary Creature — Human Knight,Lucas Graciano
+Leonardo- Cutting Edge,2,2026,0.86,#ffffff,https://cards.scryfall.io/normal/front/7/4/74c11ee3-19d1-4ad5-a727-1d74c565d6a5.jpg?1783904124,Legendary Creature — Mutant Ninja Turtle,Chris Seaman
+Leonardo- Sewer Samurai,4,2026,1.4,#ffffff,https://cards.scryfall.io/normal/front/0/e/0e3a0a26-c163-4f31-bed8-1be52a35feea.jpg?1783904123,Legendary Creature — Mutant Ninja Turtle Samurai,Ryan Pancoast
+Leonardo's Technique,4,2026,0.35,#ffffff,https://cards.scryfall.io/normal/front/4/0/405e4057-e26c-4882-89a9-706868548c37.jpg?1783904123,Sorcery,Andreas Zafiratos
+Leonardo- the Balance,4,2026,2.52,#d78f42,https://cards.scryfall.io/normal/front/7/2/72e637db-7112-406f-809b-0eda248488b5.jpg?1783904176,Legendary Creature — Mutant Ninja Turtle,Inkognit
+Leonardo- Worldly Warrior,8,2026,0.69,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6913056-de4a-45ac-a731-b478bdad6754.jpg?1783904140,Legendary Creature — Mutant Ninja Turtle,Nathaniel Himawan
+Leonin Abunas,4,2020,3.11,#ffffff,https://cards.scryfall.io/normal/front/1/4/14397b59-ff0d-4838-92c3-9728bf6b0af5.jpg?1783930213,Creature — Cat Cleric,Carl Critchlow
+Leonin Arbiter,2,2022,0.55,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d0f827b-ebc3-45a4-8d12-c71a14478038.jpg?1783921934,Creature — Cat Cleric,Shelly Wan
+Leonin Lightscribe,2,2021,0.52,#ffffff,https://cards.scryfall.io/normal/front/2/a/2a465d7b-398c-444b-9eae-331ea2513f6d.jpg?1783927388,Creature — Cat Cleric,Steven Belledin
+Leonin Shikari,2,2017,5.52,#ffffff,https://cards.scryfall.io/normal/front/4/7/47db94ce-e9f3-4bc3-b05f-17fde1d91329.jpg?1783935927,Creature — Cat Soldier,Wayne England
+Leonin Warleader,4,2018,4.56,#ffffff,https://cards.scryfall.io/normal/front/b/3/b31b2e5e-6572-462a-9fa0-1b2e660099e3.jpg?1783934603,Creature — Cat Soldier,Jakub Kasper
+Leyline Binding,6,2022,0.49,#ffffff,https://cards.scryfall.io/normal/front/3/c/3c3ac3dd-35db-447f-8674-37b4680a1ef7.jpg?1783921363,Enchantment,Cristi Balanescu
+Leyline of Hope,4,2024,0.94,#ffffff,https://cards.scryfall.io/normal/front/4/0/40960e47-3065-485e-aede-29a62411034e.jpg?1783909508,Enchantment,Sergey Glushakov
+Leyline of Sanctity,4,2019,0.54,#ffffff,https://cards.scryfall.io/normal/front/b/e/be8b1acf-dd87-42ca-ad19-c27d21066030.jpg?1783933025,Enchantment,Noah Bradley
+Leyline of the Meek,4,2006,1.55,#ffffff,https://cards.scryfall.io/normal/front/e/f/efc58757-abcc-41c9-b4d2-e70e9f387cbb.jpg?1783943529,Enchantment,Mark Zug
+Liberated Livestock,6,2023,0.34,#ffffff,https://cards.scryfall.io/normal/front/f/2/f22f4c5a-fe42-4511-be96-78e0e807e704.jpg?1783914989,Creature — Cat Bird Ox,Kisung Koh
+Lieutenant Kirtar,3,2023,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/7/475ba0c3-237e-4349-85e9-c31b016f609b.jpg?1783918515,Legendary Creature — Bird Soldier,Paolo Parente
+Lifeblood,4,1994,21.64,#ffffff,https://cards.scryfall.io/normal/front/4/e/4ecb1362-9a67-4d4c-8d69-9ac2ebf4d0b0.jpg?1783948083,Enchantment,Mark Tedin
+Light from Within,4,2008,8.47,#ffffff,https://cards.scryfall.io/normal/front/6/a/6afda091-ed14-4bc5-8896-bdb7c95a499e.jpg?1783942694,Enchantment,Aleksi Briclot
+Lightmine Field,4,2010,5.82,#ffffff,https://cards.scryfall.io/normal/front/5/6/5602b52a-5904-4780-9192-72990d07c975.jpg?1783942007,Enchantment,Eric Deschamps
+Lightning Blow,2,1995,1.02,#ffffff,https://cards.scryfall.io/normal/front/d/1/d1a4ed99-f38c-4e0f-9ff2-2e1e9126e6ef.jpg?1783947521,Instant,Harold McNeill
+Light of Promise,3,2026,1.14,#ffffff,https://cards.scryfall.io/normal/front/f/7/f78673f6-8173-4d0e-ae50-539cad30aa5c.jpg?1783903324,Enchantment — Aura,David Lopez
+Light of Sanction,3,2005,0.41,#ffffff,https://cards.scryfall.io/normal/front/d/a/daff382a-980e-4f0c-b26c-70c8a43c66f1.jpg?1783943697,Enchantment,Michael Phillippi
+Light of the Legion,6,2018,0.26,#ffffff,https://cards.scryfall.io/normal/front/a/2/a2f1b831-ca55-4575-9dfa-c3163e3d789d.jpg?1783934197,Creature — Angel,Alex Konstad
+Light-Paws- Emperor's Voice,2,2022,3.86,#ffffff,https://cards.scryfall.io/normal/front/3/9/39555a72-a57b-45ee-9222-ce3b9e8de126.jpg?1783923918,Legendary Creature — Fox Advisor,Randy Vargas
+Lightstall Inquisitor,1,2025,0.33,#ffffff,https://cards.scryfall.io/normal/front/6/3/635245e9-c27f-4a51-a6f1-bae62e696542.jpg?1783905994,Creature — Angel Wizard,Arif Wijaya
+Lightwielder Paladin,5,2017,0.32,#ffffff,https://cards.scryfall.io/normal/front/b/6/b61a3ca4-f311-412a-927f-148e614846f6.jpg?1783936163,Creature — Human Knight,D. Alexander Gregory
+Limited Resources,1,1998,2.76,#ffffff,https://cards.scryfall.io/normal/front/2/0/20ae3609-a3cc-486c-94f6-b8f647adfb47.jpg?1783946531,Enchantment,Keith Parkinson
+Linden- the Steadfast Queen,3,2026,0.5,#ffffff,https://cards.scryfall.io/normal/front/e/0/e0bb07cd-9b74-4ba7-8089-27a565d74197.jpg?1783903955,Legendary Creature — Human Noble,Ryan Pancoast
+Lin Sivvi- Defiant Hero,3,2000,2.23,#ffffff,https://cards.scryfall.io/normal/front/e/5/e574e522-2632-4cd4-8545-c582ac3b641f.jpg?1783945846,Legendary Creature — Human Rebel,rk post
+Linvala- Keeper of Silence,4,2020,20.08,#ffffff,https://cards.scryfall.io/normal/front/d/d/dded98c3-17cb-4a43-a209-289ceb11df39.jpg?1783930467,Legendary Creature — Angel,Igor Kieryluk
+Linvala- the Preserver,6,2016,0.96,#ffffff,https://cards.scryfall.io/normal/front/e/f/ef0dbb08-d124-46da-bfb1-af7ef4a18179.jpg?1783937925,Legendary Creature — Angel,Magali Villeneuve
+Lion Sash,2,2022,2.41,#ffffff,https://cards.scryfall.io/normal/front/3/e/3e1766e9-2fa7-4446-a255-7beea1467ece.jpg?1783923917,Artifact Creature — Equipment Cat,Yongjae Choi
+Lita- Mechanical Engineer,3,2022,8.83,#ffffff,https://cards.scryfall.io/normal/front/f/3/f3a5a044-d474-43f4-95a9-e67808908e6c.jpg?1783919196,Legendary Artifact Creature — Artificer,Bartek Fedyczak
+Livio- Oathsworn Sentinel,2,2020,0.25,#ffffff,https://cards.scryfall.io/normal/front/0/2/02bce846-8049-4d5c-b0ad-8abd484e5a27.jpg?1783928881,Legendary Creature — Human Knight,Kekai Kotaki
+Localized Destruction,5,2024,0.41,#ffffff,https://cards.scryfall.io/normal/front/d/d/dd64fe7f-2c06-42f8-96ac-47e4c38dc149.jpg?1783911427,Sorcery,Olivier Bernard
+Look at Me- I'm R&D,3,2020,0.13,#ffffff,https://cards.scryfall.io/normal/front/a/a/aaee15d7-db3d-4aa2-ab04-b883ff41d12a.jpg?1783931351,Enchantment,
+Look at Me- I'm the DCI,7,2020,0.23,#ffffff,https://cards.scryfall.io/normal/front/4/f/4fa69802-c392-4004-9d58-ad1fc42de0bd.jpg?1783931350,Sorcery,Mark Rosewater
+Loran of the Third Path,3,2024,3.71,#ffffff,https://cards.scryfall.io/normal/front/9/e/9e83a0ef-4fea-45ba-86c0-130d6687f7fe.jpg?1783913028,Legendary Creature — Human Artificer,Steven Belledin
+Lord Jyscal Guado,2,2025,0.21,#ffffff,https://cards.scryfall.io/normal/front/1/3/134ef3cd-01ac-4d60-a277-df7ab7b8f88c.jpg?1783906367,Legendary Creature — Spirit Cleric,Takeuchi Moto
+Losheel- Clockwork Scholar,3,2021,2.77,#ffffff,https://cards.scryfall.io/normal/front/d/b/db1d67fe-bffe-45ad-af6a-cb131ddb1a12.jpg?1783927608,Legendary Creature — Elephant Artificer,Daniel Zrom
+Lossarnach Captain,4,2023,0.4,#ffffff,https://cards.scryfall.io/normal/front/0/8/08b78cd2-7c52-4dcd-b063-1ac5e96420d4.jpg?1783916034,Creature — Human Soldier,Justine Cruz
+Loxodon Gatekeeper,4,2005,1.17,#ffffff,https://cards.scryfall.io/normal/front/7/8/781476a1-73a9-4f43-9f71-d29c97ecc69a.jpg?1783943696,Creature — Elephant Soldier,Carl Critchlow
+Loxodon Lifechanter,6,2019,0.27,#ffffff,https://cards.scryfall.io/normal/front/1/9/19610e6d-61bf-4c79-bfb2-e855eb944d11.jpg?1783933025,Creature — Elephant Cleric,Nicholas Gregory
+Loxodon Peacekeeper,2,2003,0.33,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c9e7029-bea3-4a33-bd05-774e802616d4.jpg?1783944561,Creature — Elephant Soldier,Michael Sutfin
+Loxodon Punisher,4,2003,0.3,#ffffff,https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg?1783944561,Creature — Elephant Soldier,Terese Nielsen
+Loyal Retainers,3,2026,0.41,#ffffff,https://cards.scryfall.io/normal/front/3/0/3092e715-36cf-4b41-95c1-cf271646db39.jpg?1783903247,Creature — Human Advisor,Tyler Walpole
+Loyal Sentry,1,2010,0.35,#ffffff,https://cards.scryfall.io/normal/front/7/7/7736c041-d333-4748-8045-79d42aba6e05.jpg?1783941771,Creature — Human Soldier,Michael Sutfin
+Loyal Warhound,2,2021,0.51,#ffffff,https://cards.scryfall.io/normal/front/f/4/f408c5e4-e18d-4e4d-959a-f41df4c3019c.jpg?1783926530,Creature — Dog,Dmitry Burmak
+Lucy MacLean- Positively Armed,5,2026,4.9,#ffffff,https://cards.scryfall.io/normal/front/2/a/2a5150ee-d177-48f5-9c93-edfaa95922ab.jpg?1783904272,Legendary Creature — Human Survivor,Ryan Valle
+Lumbering Battlement,5,2019,0.34,#ffffff,https://cards.scryfall.io/normal/front/2/4/2469bc93-57ca-4077-bda2-160b4160adad.jpg?1783933721,Creature — Beast,Simon Dominic
+Lumen-Class Frigate,2,2025,0.35,#ffffff,https://cards.scryfall.io/normal/front/0/c/0cc59b5a-65fa-47cc-8ac7-b7c3f533a782.jpg?1783905992,Artifact — Spacecraft,Zezhou Chen
+Luminarch Ascension,2,2018,18.09,#ffffff,https://cards.scryfall.io/normal/front/b/3/b3770d86-4496-4c06-aab1-2917cfec100e.jpg?1783935193,Enchantment,Michael Komarck
+Luminarch Aspirant,2,2022,0.38,#ffffff,https://cards.scryfall.io/normal/front/d/c/dcd27fa3-f6b6-4137-9b6c-4cba7187664c.jpg?1783923289,Creature — Human Cleric,Mads Ahm
+Luminate Primordial,7,2013,0.35,#ffffff,https://cards.scryfall.io/normal/front/b/0/b0747b12-c75a-4fdf-a881-f2383a23ccdd.jpg?1783940142,Creature — Avatar,Stephan Martiniere
+Luminous Angel,7,2014,0.95,#ffffff,https://cards.scryfall.io/normal/front/c/3/c3ac419f-7630-48c7-9039-88ce28898b6d.jpg?1783938786,Creature — Angel,Jason Chan
+Luminous Broodmoth,4,2020,1.79,#ffffff,https://cards.scryfall.io/normal/front/b/b/bb65df55-d6a6-4a57-a903-e5eb17637982.jpg?1783931087,Creature — Insect,Lie Setiawan
+Lyra Dawnbringer,5,2026,0.46,#ffffff,https://cards.scryfall.io/normal/front/f/9/f9fa30b6-3a33-46fd-8b32-ac1cfa41500d.jpg?1783903956,Legendary Creature — Angel,Chris Rahn
+Mace of the Valiant,3,2019,0.31,#ffffff,https://cards.scryfall.io/normal/front/6/c/6c141ed6-02ee-49c4-98af-938ebcefb2f5.jpg?1783932553,Artifact — Equipment,Aaron Miller
+Machinist's Arsenal,5,2025,1.0,#ffffff,https://cards.scryfall.io/normal/front/f/f/ff976428-2145-4630-aab1-08870b90b2f0.jpg?1783906647,Artifact — Equipment,Thanh Tuấn
+Mageta the Lion,5,2000,1.65,#ffffff,https://cards.scryfall.io/normal/front/5/8/5861dffc-5afa-44a3-a3fa-9fd440093377.jpg?1783945797,Legendary Creature — Human Spellshaper,Brom
+Magus of the Balance,2,2022,0.24,#ffffff,https://cards.scryfall.io/normal/front/e/6/e63074e4-2c4c-411c-b320-c90d3a4a96d0.jpg?1783922489,Creature — Human Wizard,Kev Walker
+Magus of the Disk,4,2020,0.36,#ffffff,https://cards.scryfall.io/normal/front/7/0/70cdad7a-f041-4bbe-87ed-876ac6d0c31b.jpg?1783931197,Creature — Human Wizard,Jeremy Jarvis
+Magus of the Moat,4,2007,7.96,#ffffff,https://cards.scryfall.io/normal/front/2/0/20dcdda9-66a2-401f-9e1b-5603f771f56f.jpg?1783943127,Creature — Human Wizard,John Avon
+Magus of the Tabernacle,4,2007,1.96,#ffffff,https://cards.scryfall.io/normal/front/d/d/dd520f8c-93fb-4cf3-8dd5-d05abbd86c74.jpg?1783943169,Creature — Human Wizard,Randy Gallegos
+Main Event Horizon,5,2022,0.12,#ffffff,https://cards.scryfall.io/normal/front/3/1/315c4a63-2561-4c52-908f-7d1c08e1d9a7.jpg?1783920610,Sorcery,Mike Burns
+Major Teroh,4,2002,0.51,#ffffff,https://cards.scryfall.io/normal/front/3/2/3229ca5a-5340-48b8-bd46-b0b924c8faf7.jpg?1783945169,Legendary Creature — Bird Soldier,Daren Bader
+Mana Tithe,1,2021,1.56,#ffffff,https://cards.scryfall.io/normal/front/e/7/e7f32354-893d-4f0b-b555-e0757fb5443b.jpg?1783927442,Instant,Robbie Trevino
+Mandate of Peace,2,2019,1.62,#ffffff,https://cards.scryfall.io/normal/front/d/2/d243055f-892e-4042-9694-13d5e99e3550.jpg?1783932814,Instant,Chris Rallis
+Mangara of Corondor,3,2021,0.25,#ffffff,https://cards.scryfall.io/normal/front/d/b/db5686b7-4b7b-4127-9330-9282f36bd70b.jpg?1783927870,Legendary Creature — Human Wizard,Karl Kopinski
+Mangara- the Diplomat,4,2026,0.34,#ffffff,https://cards.scryfall.io/normal/front/4/9/49d0d7ec-4bee-47d3-91a6-43510be65402.jpg?1783903806,Legendary Creature — Human Cleric,Howard Lyon
+Mantle of the Ancients,5,2021,9.02,#ffffff,https://cards.scryfall.io/normal/front/8/6/867124fc-c8e4-4e0e-be41-b74a6bb34e86.jpg?1783926258,Enchantment — Aura,Denman Rooke
+Marble Titan,4,2005,1.63,#ffffff,https://cards.scryfall.io/normal/front/e/4/e4816f18-9f66-4539-9764-2f65f2826812.jpg?1783944099,Creature — Giant,Brom
+March of Otherworldly Light,1,2022,0.87,#ffffff,https://cards.scryfall.io/normal/front/5/5/553fb946-2706-475b-89f9-e4355ec9ea2b.jpg?1783923916,Instant,Nils Hamm
+March of Souls,5,2001,2.3,#ffffff,https://cards.scryfall.io/normal/front/f/0/f07dd0f1-b80b-4af0-ae76-907ec55ec7d5.jpg?1783945629,Sorcery,Marc Fishman
+March of the Canonized,2,2023,0.39,#ffffff,https://cards.scryfall.io/normal/front/5/4/547581d0-025a-435a-8016-ee7c6b890e53.jpg?1783913913,Enchantment,Dominik Mayer
+Mark of Asylum,2,2009,1.59,#ffffff,https://cards.scryfall.io/normal/front/d/9/d9801e68-9a03-491f-be23-f0b830c4a0c5.jpg?1783942492,Enchantment,Sal Villagran
+Marshal's Anthem,4,2024,0.25,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c84cbf6-cab0-4b53-ab60-470ade5c3654.jpg?1783911947,Enchantment,Matt Stewart
+Martial Coup,2,2026,0.22,#ffffff,https://cards.scryfall.io/normal/front/a/0/a0660e74-6973-41d7-a20b-8d71fed1495a.jpg?1783903247,Sorcery,Andreas Zafiratos
+Martial Law,4,2012,0.21,#ffffff,https://cards.scryfall.io/normal/front/2/1/21078b6f-a39d-4ec8-879e-ad10d97c3ff6.jpg?1783940374,Enchantment,Tyler Jacobson
+Martyr's Bond,6,2011,1.04,#ffffff,https://cards.scryfall.io/normal/front/2/f/2ff99e85-bfb7-4c8c-a8e1-3b0618ffe479.jpg?1783941251,Enchantment,Ryan Pancoast
+Masako the Humorless,3,2004,24.93,#ffffff,https://cards.scryfall.io/normal/front/d/6/d6b2507f-4035-47d5-8295-0a3773f187fb.jpg?1783944334,Legendary Creature — Human Advisor,Ben Thompson
+Mass Calcify,7,2014,3.34,#ffffff,https://cards.scryfall.io/normal/front/3/1/316a2d2f-ca94-463f-ada4-2b12bce6312f.jpg?1783939200,Sorcery,Brandon Kitkouski
+Master Apothecary,3,2001,0.83,#ffffff,https://cards.scryfall.io/normal/front/f/9/f9ff6624-ed0e-43d0-9519-112979b165f5.jpg?1783945276,Creature — Human Cleric,Terese Nielsen
+Master Healer,5,2005,0.25,#ffffff,https://cards.scryfall.io/normal/front/c/6/c6a4a15d-9f16-4aa1-adc0-5d4c85991062.jpg?1783944098,Creature — Human Cleric,Adam Rex
+Master of Ceremonies,4,2022,16.91,#ffffff,https://cards.scryfall.io/normal/front/d/1/d152cfa8-00b7-4aa0-855e-bbd57a5f4b23.jpg?1783923374,Creature — Rhino Druid,Milivoj Ćeran
+Master of Pearls,2,2024,0.15,#ffffff,https://cards.scryfall.io/normal/front/5/c/5c0267c9-e0a7-4c16-afc9-f05de9fccaba.jpg?1783913028,Creature — Human Monk,David Gaillet
+Master Trinketeer,3,2016,0.29,#ffffff,https://cards.scryfall.io/normal/front/c/d/cdb6beb3-1669-4e7b-9c76-65424673eb36.jpg?1783937230,Creature — Dwarf Artificer,Matt Stewart
+Mastery of the Unseen,2,2024,0.18,#ffffff,https://cards.scryfall.io/normal/front/b/2/b27f4217-881d-401d-860e-d3d8689ca1e4.jpg?1783913028,Enchantment,Daniel Ljunggren
+Matt Murdock- Justice Seeker,2,2026,2.46,#ffffff,https://cards.scryfall.io/normal/front/a/b/ab8e5c5d-e6a0-4666-930a-0a1f475d3c2e.jpg?1783903080,Legendary Creature — Human Advisor Hero,Gintas Galvanauskas
+Maul of the Skyclaves,3,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/3/2/3213c1f9-bff5-4629-a0b6-0c81ccf6c80d.jpg?1783917182,Artifact — Equipment,Joseph Meehan
+Mavinda- Students' Advocate,3,2021,0.66,#ffffff,https://cards.scryfall.io/normal/front/8/b/8b3d521f-31cd-4bd2-b6b6-771c79252789.jpg?1783927388,Legendary Creature — Bird Advisor,Wesley Burt
+Mavren Fein- Dusk Apostle,3,2023,0.36,#ffffff,https://cards.scryfall.io/normal/front/f/d/fdc3e998-760b-41ca-9f92-270aaa82f3fb.jpg?1783913894,Legendary Creature — Vampire Cleric,Daarken
+Mentor of the Meek,3,2024,0.17,#ffffff,https://cards.scryfall.io/normal/front/6/0/60790977-efd4-470a-823a-6929f84016e7.jpg?1783908939,Creature — Human Soldier,Jana Schirmer & Johannes Voss
+Mercenaries,4,1995,0.59,#ffffff,https://cards.scryfall.io/normal/front/7/b/7b28762d-1ab7-460e-b433-27f5fa858959.jpg?1783947522,Creature — Human Mercenary,Cornelius Brudi
+Mercenary Informer,3,2000,0.36,#ffffff,https://cards.scryfall.io/normal/front/9/8/98ee3f50-09d7-4960-8214-680a7299fa20.jpg?1783945797,Creature — Human Rebel Mercenary,Nelson DeCastro
+Merchant of Truth,4,2024,0.85,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f47e29e-54c5-4b1a-b9b9-d5e267a0203a.jpg?1783913051,Creature — Angel Detective,Carissa Susilo
+Mesa Enchantress,3,2024,1.06,#ffffff,https://cards.scryfall.io/normal/front/c/4/c4f9e9fc-8b89-40ee-9b20-10e4a23e6333.jpg?1783909643,Creature — Human Druid,Eelis Kyttanen
+Methods of the Mighty,4,2026,0.33,#ffffff,https://cards.scryfall.io/normal/front/f/3/f3699f46-6173-47e1-97b2-a7632224fb6c.jpg?1783903298,Instant,David Seeley
+Metropolis Reformer,3,2023,2.36,#ffffff,https://cards.scryfall.io/normal/front/a/6/a61a3ba1-af6c-4ddc-aa82-34bfc30867d0.jpg?1783916528,Creature — Angel Cleric,Ryan Pancoast
+Michiko Konda- Truth Seeker,4,2005,8.71,#ffffff,https://cards.scryfall.io/normal/front/9/9/99c56bf0-ad9f-4419-902c-f3a3880c716c.jpg?1783944168,Legendary Creature — Human Advisor,Christopher Moeller
+Midnight Angel Armor,5,2026,0.24,#ffffff,https://cards.scryfall.io/normal/front/5/b/5b5b87ba-c6cc-4f25-a5c9-22464a41de65.jpg?1783903298,Artifact — Equipment,Mateus Manhanini
+Mikaeus- the Lunarch,1,2023,0.79,#ffffff,https://cards.scryfall.io/normal/front/f/b/fb885d30-c6e5-494a-bc01-3d5085b8e262.jpg?1783917181,Legendary Creature — Human Cleric,Steven Belledin
+Mila- Crafty Companion // Lukka- Wayward Bonder,3,2021,2.15,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Fox // Legendary Planeswalker — Lukka,Kieran Yanner
+Militant Angel,5,2018,1.4,#ffffff,https://cards.scryfall.io/normal/front/7/6/762fa38f-a760-4e84-bdd5-c14cbc21db72.jpg?1783933994,Creature — Angel,Victor Adame Minguez
+Militia's Pride,2,2007,6.66,#ffffff,https://cards.scryfall.io/normal/front/5/3/53c8cde1-e447-422e-aed0-2571a77d3d29.jpg?1783942912,Kindred Enchantment — Kithkin,Larry MacDougall
+Minwu- White Mage,5,2025,0.31,#ffffff,https://cards.scryfall.io/normal/front/6/8/6822144f-f0eb-4e10-a217-52cad36d2973.jpg?1783906647,Legendary Creature — Human Cleric,Josu Hernaiz
+Mirran Crusader,3,2015,0.35,#ffffff,https://cards.scryfall.io/normal/front/f/7/f7c34f5d-0430-4036-a633-1a68a0d2fc65.jpg?1783938428,Creature — Human Knight,Eric Deschamps
+Mirror Entity,3,2024,1.73,#ffffff,https://cards.scryfall.io/normal/front/f/2/f2a3107d-bb96-45c6-97ac-b6c6b84cbad4.jpg?1783911947,Creature — Shapeshifter,Zoltan Boros & Gabor Szikszai
+Mirror-Sigil Sergeant,6,2009,1.35,#ffffff,https://cards.scryfall.io/normal/front/e/9/e94b3eec-7420-45fa-8750-7f01028836d3.jpg?1783942492,Creature — Rhino Soldier,Chris Rahn
+Mite Overseer,4,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/a/5/a55a5edb-edf3-4f6c-90b8-1780b1e73997.jpg?1783917920,Creature — Phyrexian Soldier,Néstor Ossandón Leal
+Mobilization,3,2014,0.71,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc25a245-4d47-45fe-82ae-4e0ecd4ed34e.jpg?1783938857,Enchantment,Carl Critchlow
+Momo- Friendly Flier,1,2025,0.31,#ffffff,https://cards.scryfall.io/normal/front/c/4/c472ef84-a632-4ad7-853c-60588a7a4b12.jpg?1783904997,Legendary Creature — Lemur Bat Ally,Brandon L. Hunt
+Monastery Mentor,3,2025,0.53,#ffffff,https://cards.scryfall.io/normal/front/2/3/2343e69d-f30e-4826-953c-fbf31c6079e6.jpg?1783907121,Creature — Human Monk,Magali Villeneuve
+Mondrak- Glory Dominus,4,2023,44.1,#ffffff,https://cards.scryfall.io/normal/front/8/2/8296a455-21d5-498e-9029-2bdf0da855a8.jpg?1783918077,Legendary Creature — Phyrexian Horror,Jason A. Engle
+Monica Rambeau // Photon- Living Light,3,2026,1.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Hero // Legendary Creature — Elemental Hero,Xabi Gaztelua & Marta Nael
+Monk Gyatso,4,2025,6.78,#ffffff,https://cards.scryfall.io/normal/front/e/2/e27ed185-eb2b-42dd-b48e-3c8d4456268b.jpg?1783904834,Legendary Creature — Human Monk,Masateru Ikeda
+Moogles' Valor,5,2025,0.74,#ffffff,https://cards.scryfall.io/normal/front/c/a/caa838a7-60a9-4791-af5b-194f7574c4c8.jpg?1783906647,Instant,Kotakan
+Moonshaker Cavalry,8,2026,5.62,#ffffff,https://cards.scryfall.io/normal/front/c/a/ca90d382-7e13-4637-a624-2a1b82abe56c.jpg?1783903824,Creature — Spirit Knight,Diana Franco
+Moorland Rescuer,6,2021,0.35,#ffffff,https://cards.scryfall.io/normal/front/0/c/0c293b8c-3ebc-4d14-b0a6-5e41d966cba1.jpg?1783925382,Creature — Human Knight,Justyna Dura
+Morningtide,2,2002,0.44,#ffffff,https://cards.scryfall.io/normal/front/a/6/a62e17a7-3602-45af-bdb6-fa5f2a9f1155.jpg?1783945169,Sorcery,Tony Szczudlo
+Morningtide's Light,4,2026,1.31,#ffffff,https://cards.scryfall.io/normal/front/1/8/181ee045-5650-479a-8c03-015b38fdcd63.jpg?1783904502,Sorcery,Mark Poole
+Mother of Runes,1,2016,12.48,#ffffff,https://cards.scryfall.io/normal/front/f/d/fdf2354e-1232-452e-b89b-78ac8be206f7.jpg?1783937629,Creature — Human Cleric,Terese Nielsen
+Munda's Vanguard,5,2016,0.31,#ffffff,https://cards.scryfall.io/normal/front/0/d/0dfb21b1-95a5-446d-afc6-aede81ee5a0d.jpg?1783937924,Creature — Kor Knight Ally,Steve Prescott
+Murmuration,5,2024,0.37,#ffffff,https://cards.scryfall.io/normal/front/5/6/561c9c4e-942e-40e8-b5f2-ac709a502f18.jpg?1783910736,Enchantment,Xabi Gaztelua
+Myojin of Blooming Dawn,8,2022,0.35,#ffffff,https://cards.scryfall.io/normal/front/a/f/afd718b5-040b-4bb7-9f0c-b72373d786d4.jpg?1783923987,Legendary Creature — Spirit,Yigit Koroglu
+Myojin of Cleansing Fire,8,2004,3.07,#ffffff,https://cards.scryfall.io/normal/front/a/0/a0570ba0-2877-46f6-acea-6913f8915d6d.jpg?1783944334,Legendary Creature — Spirit,Kev Walker
+Myrel- Shield of Argive,4,2022,17.77,#ffffff,https://cards.scryfall.io/normal/front/e/6/e632ed57-bb00-4493-adef-7b4805edd7ea.jpg?1783920129,Legendary Creature — Human Soldier,Ryan Pancoast
+Mysterious Limousine,5,2022,0.23,#ffffff,https://cards.scryfall.io/normal/front/a/5/a58cb742-0ba7-4795-9772-25d4db0bc4ce.jpg?1783923155,Artifact — Vehicle,Dan Murayama Scott
+Mystic Barrier,5,2013,2.39,#ffffff,https://cards.scryfall.io/normal/front/f/f/ffb70bd4-e876-4242-b5b4-bb7493710f0f.jpg?1783939689,Enchantment,Matt Stewart
+Mystic Crusader,3,2001,0.4,#ffffff,https://cards.scryfall.io/normal/front/2/7/27ce1baf-8a89-4884-b0f7-19311bfc8c4c.jpg?1783945275,Creature — Human Nomad Mystic,Kev Walker
+Mythos of Snapdax,4,2020,0.35,#d78f42,https://cards.scryfall.io/normal/front/2/7/2712a1a3-dd28-44c8-a661-5bcf68d3acaa.jpg?1783931085,Sorcery,Seb McKinnon
+Myth Realized,1,2015,0.29,#ffffff,https://cards.scryfall.io/normal/front/3/7/37bd9f67-32a7-4022-bb53-5bfc671520c7.jpg?1783938617,Enchantment,Jason Rainville
+Nadaar- Selfless Paladin,3,2021,0.36,#ffffff,https://cards.scryfall.io/normal/front/8/7/878a0d8c-11c1-4c65-9051-78e036ac496f.jpg?1783926528,Legendary Creature — Dragon Knight,Aaron Miller
+Nahiri- the Lithomancer,5,2023,0.85,#ffffff,https://cards.scryfall.io/normal/front/b/0/b074e60a-6f9b-4679-9617-261e2e15e1e8.jpg?1783915716,Legendary Planeswalker — Nahiri,Eric Deschamps
+Near-Death Experience,5,2010,0.55,#ffffff,https://cards.scryfall.io/normal/front/7/7/77d61706-f9c1-4590-8057-7aa7fa199e6d.jpg?1783942004,Enchantment,Dan Murayama Scott
+Nesting Dovehawk,4,2023,20.71,#ffffff,https://cards.scryfall.io/normal/front/c/5/c58ff93f-7135-40af-92ce-358da48694dc.jpg?1783917290,Creature — Bird,Alessandra Pisano
+Nevermore,3,2011,0.77,#ffffff,https://cards.scryfall.io/normal/front/6/7/67b610fe-36ee-4d58-8ed4-04e7a12587b2.jpg?1783940989,Enchantment,Jason A. Engle
+Nick Fury- Agent of S.H.I.E.L.D.,1,2026,0.35,#d78f42,https://cards.scryfall.io/normal/front/3/a/3aa6fc02-ef76-426b-accd-6c0ef88b2a5e.jpg?1783902971,Legendary Creature — Human Spy Hero,Marco Turini
+Nick Fury- Spymaster,5,2026,0.36,#ffffff,https://cards.scryfall.io/normal/front/1/6/169b6c86-60f2-462b-877f-481354ef2d20.jpg?1783903081,Legendary Creature — Human Spy Hero,Michael MacRae
+Nils- Discipline Enforcer,3,2026,0.26,#ffffff,https://cards.scryfall.io/normal/front/c/3/c34cff04-01b0-4849-85bf-9e0b034be0e6.jpg?1783903804,Legendary Creature — Human Cleric,Magali Villeneuve
+Nine Lives,3,2020,0.69,#ffffff,https://cards.scryfall.io/normal/front/e/7/e70b7a73-484e-48f1-944c-3d38866cdc20.jpg?1783930737,Enchantment,Paul Scott Canavan
+Noble Heritage,2,2022,0.41,#ffffff,https://cards.scryfall.io/normal/front/3/e/3e49fd5a-6893-4a06-b835-4bf611c9ada1.jpg?1783922806,Legendary Enchantment — Background,Dallas Williams
+Noble Purpose,5,2003,0.67,#ffffff,https://cards.scryfall.io/normal/front/b/d/bd35c327-1998-4331-9280-1617638c1031.jpg?1783944836,Enchantment,Kev Walker
+Nomad Mythmaker,3,2007,5.0,#ffffff,https://cards.scryfall.io/normal/front/0/4/0468f109-8020-4a74-8ffd-bba771362f76.jpg?1783943076,Creature — Human Nomad Cleric,Darrell Riche
+Nomads' Assembly,6,2014,0.69,#ffffff,https://cards.scryfall.io/normal/front/0/0/00afdd58-a6e3-490c-8ff5-3d761fcd3885.jpg?1783938857,Sorcery,Erica Yang
+Norn's Annex,5,2023,5.64,#ffffff,https://cards.scryfall.io/normal/front/d/2/d25bbe18-709c-4ed3-a047-5578ecfaaba7.jpg?1783915448,Artifact,James Paick
+Norn's Choirmaster,5,2023,16.45,#ffffff,https://cards.scryfall.io/normal/front/1/d/1da10c9f-4c9f-4eee-8480-665c453215d4.jpg?1783918163,Creature — Phyrexian Angel,Jason A. Engle
+Norn's Decree,3,2023,8.93,#ffffff,https://cards.scryfall.io/normal/front/7/6/76f28aa2-1c18-4d58-a3f9-6cd5b49280d8.jpg?1783918161,Enchantment,Néstor Ossandón Leal
+Norn's Wellspring,2,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/e/e/eeebc0ab-89fb-47d5-a20f-8f1fe5e3c149.jpg?1783918076,Artifact,Jonas De Ro
+Northern Paladin,4,2001,1.95,#ffffff,https://cards.scryfall.io/normal/front/5/e/5ed1fb50-b7c3-43e9-a0ef-a33135a12300.jpg?1783945579,Creature — Human Knight,Carl Critchlow
+No Witnesses,4,2024,0.17,#ffffff,https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg?1783912920,Sorcery,Michele Giorgi
+Null Chamber,4,1996,1.51,#ffffff,https://cards.scryfall.io/normal/front/8/1/814f8976-6612-438f-a04a-8edb63edb1e7.jpg?1783947118,World Enchantment,Douglas Shuler
+Nykthos Paragon,6,2021,0.84,#ffffff,https://cards.scryfall.io/normal/front/2/9/2963205e-b181-44d1-809f-6577e29fa812.jpg?1783926889,Enchantment Creature — Human Soldier,Martina Pilcerova
+Oath of Gideon,3,2023,0.27,#ffffff,https://cards.scryfall.io/normal/front/b/8/b8a3f02b-9408-46a5-8d25-f5cec553d600.jpg?1783915447,Legendary Enchantment,Wesley Burt
+Oath of Lieges,2,1998,4.26,#ffffff,https://cards.scryfall.io/normal/front/4/7/470a2092-eeda-4557-8cee-ac401b61a225.jpg?1783946530,Enchantment,Mark Zug
+Oblation,3,2021,0.53,#ffffff,https://cards.scryfall.io/normal/front/d/c/dcfdea72-4736-4442-987b-173f6885528a.jpg?1783927576,Instant,Doug Chaffee
+Ocelot Pride,1,2024,40.98,#ffffff,https://cards.scryfall.io/normal/front/8/9/89cf6f57-230f-497e-a14e-ad1e8737fd42.jpg?1783911298,Creature — Cat,Chris Seaman
+Oddly Uneven,5,2017,0.24,#ffffff,https://cards.scryfall.io/normal/front/8/3/830d5f87-1c8b-414a-a91e-4805f5bdca54.jpg?1783935458,Sorcery,Ben Wootten
+Odric- Lunarch Marshal,4,2025,1.09,#ffffff,https://cards.scryfall.io/normal/front/1/d/1db600b2-9b8b-4c21-8d8b-8033ec680a35.jpg?1783908176,Legendary Creature — Human Soldier,Chase Stone
+Odric- Master Tactician,4,2023,0.4,#ffffff,https://cards.scryfall.io/normal/front/1/3/13bfcec9-a789-41f1-aa3d-4e4cdd7555b2.jpg?1783915716,Legendary Creature — Human Soldier,Michael Komarck
+Of Herbs and Stewed Rabbit,3,2023,0.41,#ffffff,https://cards.scryfall.io/normal/front/c/5/c58623cb-8b49-470c-9622-dd6e09d47599.jpg?1783916034,Enchantment — Saga,Dan Murayama Scott
+Ojer Taq- Deepest Foundation // Temple of Civilization,6,2023,27.75,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Land,Cristi Balanescu
+Ojutai Exemplars,4,2015,0.44,#ffffff,https://cards.scryfall.io/normal/front/d/1/d1205482-2f9d-463e-893f-18998aaf09c6.jpg?1783938615,Creature — Human Monk,Willian Murai
+Oketra's Last Mercy,3,2017,0.31,#ffffff,https://cards.scryfall.io/normal/front/c/4/c4d3bf26-6003-4699-a26e-b3b5bcd3e8dc.jpg?1783936059,Sorcery,Howard Lyon
+Oketra the True,4,2017,5.13,#ffffff,https://cards.scryfall.io/normal/front/f/2/f2cc79cf-d4db-4236-b3e2-fd12662b2a74.jpg?1783936537,Legendary Creature — God,Chase Stone
+Oltec Matterweaver,3,2024,2.01,#ffffff,https://cards.scryfall.io/normal/front/f/4/f4f2a818-9fd1-41db-967e-7d2c9b4e4c2f.jpg?1783912005,Creature — Human Artificer,Villarrte
+Onakke Oathkeeper,2,2023,2.03,#ffffff,https://cards.scryfall.io/normal/front/5/5/55d0caac-50c0-434e-af77-9ebd2a466415.jpg?1783915485,Creature — Ogre Spirit,Arash Radkia
+Once More with Feeling,4,1998,1.08,#ffffff,https://cards.scryfall.io/normal/front/b/a/ba42881b-9275-4b54-a17f-dec87d21a270.jpg?1783946436,Sorcery,Terese Nielsen
+Ondu Inversion // Ondu Skyruins,8,2020,1.39,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Sorcery // Land,James Paick
+Ondu Spiritdancer,5,2024,12.77,#ffffff,https://cards.scryfall.io/normal/front/e/e/ee1c6432-54d7-4b57-a554-f7194d74e03c.jpg?1783909632,Creature — Kor Cleric,Tran Nguyen
+One Last Job,3,2024,0.17,#ffffff,https://cards.scryfall.io/normal/front/7/1/71bfbfae-e7eb-4f80-81c6-9ab6a1bbd39d.jpg?1783911855,Sorcery,Caroline Gariba
+On Thin Ice,1,2019,0.89,#ffffff,https://cards.scryfall.io/normal/front/b/7/b7d4f6b0-ea17-4374-a80c-ba4dd207e9d6.jpg?1783933158,Snow Enchantment — Aura,Lucas Graciano
+On Wings of Gold,4,2025,0.83,#ffffff,https://cards.scryfall.io/normal/front/d/5/d5e247d3-8542-4e6c-b256-5ae216eeceb0.jpg?1783907753,Enchantment,Danny Schwartz
+Opal Archangel,5,1998,1.96,#ffffff,https://cards.scryfall.io/normal/front/a/7/a75fca33-fa06-4385-866c-5d463ae6aaf6.jpg?1783946372,Enchantment,Jeff Miracola
+Opal Avenger,3,1999,0.39,#ffffff,https://cards.scryfall.io/normal/front/f/9/f9337bbe-e092-469d-8122-77f92e233306.jpg?1783946251,Enchantment,Edward P. Beard, Jr.
+Opalescence,4,1999,39.27,#ffffff,https://cards.scryfall.io/normal/front/3/c/3c0071fb-afa5-47b5-b266-2b10a4f5a98a.jpg?1783946084,Enchantment,John Avon
+Opal-Eye- Konda's Yojimbo,3,2005,3.75,#ffffff,https://cards.scryfall.io/normal/front/e/0/e08d5618-4fe0-4ae5-af16-696467aae02d.jpg?1783944212,Legendary Creature — Fox Samurai,Greg Staples
+Opal Guardian,3,2006,0.19,#ffffff,https://cards.scryfall.io/normal/front/9/0/905ad286-e70b-46cd-87fd-eec13ed2d43b.jpg?1783943252,Enchantment,Christopher Rush
+Opal Titan,4,1998,0.46,#ffffff,https://cards.scryfall.io/normal/front/3/7/379f1f01-88c6-4cc2-9049-078aa6980582.jpg?1783946373,Enchantment,Paolo Parente
+Open the Armory,2,2025,3.93,#ffffff,https://cards.scryfall.io/normal/front/f/8/f84b14a2-2d71-456c-b6e7-12cc2493ed7b.jpg?1783906087,Sorcery,Mike Burns
+Open the Vaults,6,2020,0.71,#ffffff,https://cards.scryfall.io/normal/front/e/5/e5c5a822-0f5e-4b5f-b969-b27324e4543f.jpg?1783930213,Sorcery,Brian Despain
+Oracle en-Vec,2,1997,0.62,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc538730-c46c-4e5f-bc1f-0efb7765086d.jpg?1783946664,Creature — Human Wizard,Dan Frazier
+Oracle's Attendants,4,2005,0.13,#ffffff,https://cards.scryfall.io/normal/front/1/1/11a180a4-bffc-4f4f-ae34-3afa4a565960.jpg?1783944096,Creature — Human Soldier,Dany Orizio
+Order of Whiteclay,3,2022,0.36,#ffffff,https://cards.scryfall.io/normal/front/0/c/0caaa62f-4959-4321-a2d5-dc255f1e5eaf.jpg?1783922483,Creature — Kithkin Cleric,Steven Belledin
+Organic Extinction,10,2025,0.36,#ffffff,https://cards.scryfall.io/normal/front/d/a/daaa7b7e-76fc-47a0-a58d-1169be1aa335.jpg?1783906046,Sorcery,Cristi Balanescu
+Origin of Spider-Man,2,2025,0.42,#ffffff,https://cards.scryfall.io/normal/front/a/1/a10a7da7-d9cb-495a-9c9f-205d355c390d.jpg?1783905363,Enchantment — Saga,Bill Sienkiewicz
+Origin of the Avengers,2,2026,0.31,#ffffff,https://cards.scryfall.io/normal/front/9/b/9b0701e8-e365-425a-b897-92f4df9edcb8.jpg?1784182931,Enchantment — Saga,Serena Malyon
+Orim's Chant,1,2024,5.22,#ffffff,https://cards.scryfall.io/normal/front/e/e/ee241079-1e5a-4224-b9cb-4fd3e0da687c.jpg?1783911218,Instant,Kev Walker
+Oriss- Samite Guardian,3,2007,0.88,#ffffff,https://cards.scryfall.io/normal/front/7/a/7a9a3aeb-a316-4b1e-927b-36c3f999f2c3.jpg?1783943123,Legendary Creature — Human Cleric,Michael Komarck
+Oswald Fiddlebender,2,2021,2.52,#ffffff,https://cards.scryfall.io/normal/front/b/b/bba1650f-eddf-49a9-820e-489cb8d5b6fa.jpg?1783926527,Legendary Creature — Gnome Artificer,Steven Belledin
+Otherworldly Escort,4,2024,0.16,#ffffff,https://cards.scryfall.io/normal/front/b/5/b50bfde2-6c2d-403e-ab47-c932bcb2116d.jpg?1783913052,Creature — Human Detective,Artur Treffner
+Out of Time,3,2021,0.26,#ffffff,https://cards.scryfall.io/normal/front/0/5/053d6b3b-72d4-4a55-a79e-0a601aecf108.jpg?1783926888,Enchantment,Tobias Kwan
+Overencumbered,2,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/4/7/47058eaa-348d-4bbb-8df5-b931eba067f3.jpg?1783912418,Enchantment — Aura,Elizabeth Peiró
+Overlord of the Mistmoors,7,2024,1.96,#ffffff,https://cards.scryfall.io/normal/front/6/b/6bcafc2e-cef6-412d-8c5d-1658c3337292.jpg?1783909507,Enchantment Creature — Avatar Horror,Steven Belledin
+Overseer of Vault 76,3,2024,0.27,#ffffff,https://cards.scryfall.io/normal/front/3/5/35848917-d658-4c3b-b675-4f0185f76dc4.jpg?1783912418,Legendary Creature — Human Advisor,Kieran Yanner
+Overwhelming Splendor,8,2017,6.74,#ffffff,https://cards.scryfall.io/normal/front/8/6/867b32d2-e396-411d-ac02-1af4106dd3d2.jpg?1783936059,Enchantment — Aura Curse,Richard Wright
+Ox Drover,4,2023,0.38,#ffffff,https://cards.scryfall.io/normal/front/b/4/b479be78-da22-41f0-937e-348dc0c7511e.jpg?1783914989,Creature — Human Peasant,Filipe Pagliuso
+Oyobi- Who Split the Heavens,7,2021,0.3,#ffffff,https://cards.scryfall.io/normal/front/8/f/8f279602-024a-44b6-9a36-465c16363cb5.jpg?1783924971,Legendary Creature — Spirit,Christopher Moeller
+Pack Leader,2,2020,0.5,#ffffff,https://cards.scryfall.io/normal/front/a/8/a8b94bc1-68d1-41dc-914c-a33ecb9aeb49.jpg?1783930738,Creature — Dog,Rudy Siswanto
+Paladin Class,1,2021,0.41,#ffffff,https://cards.scryfall.io/normal/front/5/b/5bf81fb1-7992-4ae9-b1a8-80c31579a2bf.jpg?1783926526,Enchantment — Class,Campbell White
+Paladin of Atonement,2,2018,0.25,#ffffff,https://cards.scryfall.io/normal/front/d/0/d0ad263e-7ff0-459b-b04b-1d03b09c48aa.jpg?1783935335,Creature — Vampire Knight,Lius Lasahido
+Paliano Vanguard,2,2016,0.12,#ffffff,https://cards.scryfall.io/normal/front/2/b/2b120f2d-2585-4827-a8c5-d6ecdc8108e5.jpg?1783937364,Creature — Human Soldier,Chris Rallis
+Palisade Giant,6,2012,0.28,#ffffff,https://cards.scryfall.io/normal/front/f/d/fdfd37ca-e4c9-4674-a75f-15d8ebcce72b.jpg?1783940375,Creature — Giant Soldier,Greg Staples
+Pang Tong- "Young Phoenix",3,1999,13.75,#ffffff,https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg?1783946129,Legendary Creature — Human Advisor,Li Tie
+Parhelion II,8,2022,1.07,#ffffff,https://cards.scryfall.io/normal/front/8/7/871279e6-9a59-470e-8acc-fd5fe4fda5b3.jpg?1783923965,Legendary Artifact — Vehicle,Adam Paquette
+Pariah,3,2016,2.51,#ffffff,https://cards.scryfall.io/normal/front/5/1/51b2136c-392c-436d-9263-b3236adc4a10.jpg?1783937331,Enchantment — Aura,Jon J Muth
+Path of Bravery,3,2020,0.3,#ffffff,https://cards.scryfall.io/normal/front/6/d/6d389a05-2e1a-471d-a865-1c3b68a03e01.jpg?1783930465,Enchantment,Chris Rahn
+Path of the Ghosthunter,2,2023,0.26,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a33b3de-a666-4ae0-9c82-c12d7887d7a1.jpg?1783917288,Sorcery,Eli Minaya
+Path to Exile,1,2026,7.68,#ffffff,https://cards.scryfall.io/normal/front/e/2/e2e30b25-b710-4566-8b0f-56f6e390a446.jpg?1783903322,Instant,Klaus Janson & Mike Zeck
+Patrolling Peacemaker,3,2025,0.9,#ffffff,https://cards.scryfall.io/normal/front/1/e/1e06d6be-c2a3-4c73-a916-89674c0ddfed.jpg?1783906067,Artifact Creature — Robot Soldier,Michal Ivan
+Patron of the Kitsune,6,2005,1.63,#ffffff,https://cards.scryfall.io/normal/front/1/0/102ee72e-5fb8-4059-9dfa-98004e222c27.jpg?1783944211,Legendary Creature — Spirit,Ben Thompson
+Peacekeeper,3,1997,10.51,#ffffff,https://cards.scryfall.io/normal/front/5/9/592a5683-5f2f-4933-9fc3-5f7773f72f93.jpg?1783946746,Creature — Human,Donato Giancola
+Pearl Dragon,6,1999,0.62,#ffffff,https://cards.scryfall.io/normal/front/3/e/3efee309-2eba-4702-9361-0f75043922bb.jpg?1783946208,Creature — Dragon,Ian Miller
+Pearl-Ear- Imperial Advisor,3,2026,0.21,#ffffff,https://cards.scryfall.io/normal/front/7/e/7e8d6bc1-4609-4802-a4b6-7e75fdae186c.jpg?1783903804,Legendary Creature — Fox Advisor,Fajareka Setiawan
+Pegasus Refuge,4,1997,0.43,#ffffff,https://cards.scryfall.io/normal/front/a/2/a2bce334-0ae6-4a7d-85db-99ee205ce546.jpg?1783946662,Enchantment,Kev Walker
+Pentarch Paladin,5,2006,0.44,#ffffff,https://cards.scryfall.io/normal/front/c/e/ced01039-e19f-466b-bbc6-9bcb8d3ae845.jpg?1783943252,Creature — Human Knight,Jim Murray
+Perch Protection,6,2024,3.49,#ffffff,https://cards.scryfall.io/normal/front/1/f/1f81d6ea-9a76-43b9-b030-d40c5cfbeefe.jpg?1783910735,Instant,Edgar Sánchez Hidalgo
+Peri Brown,4,2023,0.29,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2f81beb-4565-4cfe-80a2-456f3d44f461.jpg?1783914676,Legendary Creature — Human,Wangjie Li
+Perilous Snare,3,2025,0.36,#ffffff,https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg?1783907916,Artifact,Chris Seaman
+Personal Sanctuary,3,2011,0.32,#ffffff,https://cards.scryfall.io/normal/front/5/6/56f10d57-687d-4ee3-8226-bae525d56e9e.jpg?1783941099,Enchantment,Howard Lyon
+Peter Parker // Amazing Spider-Man,2,2025,3.7,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Human Scientist Hero // Legendary Creature — Spider Human Hero,Thanh Tuấn
+Phelia- Exuberant Shepherd,2,2024,4.57,#ffffff,https://cards.scryfall.io/normal/front/5/5/55707746-da6e-46e5-a5ca-7ac843fdc38e.jpg?1783911298,Legendary Creature — Dog,Rudy Siswanto
+Phyrexian Rebirth,6,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/5/5/5516854d-ace3-4e02-a2d1-f780c3b15e37.jpg?1783917180,Sorcery,Scott Chou
+Phyrexian Unlife,3,2011,1.08,#ffffff,https://cards.scryfall.io/normal/front/b/4/b4a1e16a-39f0-47ab-aba8-73e82ba9ab18.jpg?1783941325,Enchantment,Jason Chan
+Phyrexian Vindicator,4,2023,5.63,#ffffff,https://cards.scryfall.io/normal/front/e/1/e18780ce-add4-4346-8028-4bc3b4099d71.jpg?1783918075,Creature — Phyrexian Horror,Denys Tsiperko
+Pianna- Nomad Captain,3,2001,0.56,#ffffff,https://cards.scryfall.io/normal/front/0/8/0812edfa-3a53-48e8-ba35-6922a1f3aa90.jpg?1783945274,Legendary Creature — Human Nomad,D. Alexander Gregory
+Pinnacle Starcage,3,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/b/1/b1f40c4c-a955-4d9c-8225-251fa4159124.jpg?1783905992,Artifact,Leon Tukker
+Planar Birth,2,1998,3.85,#ffffff,https://cards.scryfall.io/normal/front/c/7/c7cacdff-aa83-4644-b2f0-ce8c89dddfbf.jpg?1783946371,Sorcery,Adam Rex
+Planar Cleansing,6,2019,0.33,#ffffff,https://cards.scryfall.io/normal/front/5/e/5eddac86-947e-48c1-9f02-4634a7918c98.jpg?1783933021,Sorcery,Michael Komarck
+Planar Collapse,2,1999,0.99,#ffffff,https://cards.scryfall.io/normal/front/e/e/ee22cf3c-51b0-4790-ab13-985cbe900c3b.jpg?1783946249,Enchantment,Mark Zug
+Planar Guide,1,2003,1.14,#ffffff,https://cards.scryfall.io/normal/front/7/0/7087cb1e-f2e2-4b75-bacf-bc4153e398e3.jpg?1783944927,Creature — Human Cleric,Eric Peterson
+Planar Outburst,5,2022,0.35,#ffffff,https://cards.scryfall.io/normal/front/3/d/3d45dfee-810e-4359-96ad-8d423ab86178.jpg?1783923288,Sorcery,Vincent Proce
+Planeswalker's Mirth,3,2001,0.37,#ffffff,https://cards.scryfall.io/normal/front/0/2/0205d094-c846-4aa0-ade8-2a52c57b11da.jpg?1783945629,Enchantment,John Matson
+Plargg- Dean of Chaos // Augusta- Dean of Order,2,2021,0.35,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Orc Shaman // Legendary Creature — Human Cleric,Bryan Sola
+Play of the Game,8,2018,0.54,#ffffff,https://cards.scryfall.io/normal/front/8/5/85b09595-0d81-4cc0-872f-9a6fb539298b.jpg?1783934870,Sorcery,Jung Park
+Plea for Guidance,6,2014,0.67,#ffffff,https://cards.scryfall.io/normal/front/1/d/1d1d6d76-f399-475a-b5cd-544bd7c6d967.jpg?1783939576,Sorcery,Terese Nielsen
+Pollen-Shield Hare // Hare Raising,2,2023,0.33,#d78f42,https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1783915063,Creature — Rabbit // Sorcery — Adventure,Olena Richards
+Porphyry Nodes,1,2021,0.27,#ffffff,https://cards.scryfall.io/normal/front/d/f/dfe6f333-ccb4-44ea-be59-bba6335acf99.jpg?1783927870,Enchantment,Alan Pollack
+Possessed Nomad,4,2002,0.31,#d78f42,https://cards.scryfall.io/normal/front/5/d/5d9dfae5-63f6-401a-9dec-afe838190824.jpg?1783945168,Creature — Human Nomad Horror,Eric Peterson
+Practiced Offense,3,2026,1.09,#ffffff,https://cards.scryfall.io/normal/front/7/9/79c7cf94-c0a1-432d-90d7-7f0599c2e7a8.jpg?1783903699,Sorcery,Raluca Marinescu
+Precinct Captain,2,2017,0.29,#ffffff,https://cards.scryfall.io/normal/front/f/e/fef6faa4-520c-4823-bfdf-715cec7fcd4b.jpg?1783936161,Creature — Human Soldier,Steve Prescott
+Preeminent Captain,3,2014,0.73,#ffffff,https://cards.scryfall.io/normal/front/3/2/32faaece-2775-4ab5-8376-d9f68959d5ac.jpg?1783939200,Creature — Kithkin Soldier,Greg Staples
+Prehistoric Pet,1,2026,0.27,#ffffff,https://cards.scryfall.io/normal/front/1/4/148e6acd-a96a-4bea-8cfe-a129cd8d1003.jpg?1783904122,Creature — Dinosaur Ninja,Jakob Eirich
+Preston- the Vanisher,4,2022,33.76,#ffffff,https://cards.scryfall.io/normal/front/9/5/952cb0b3-a6b7-4279-8833-3d8890b2d005.jpg?1783919194,Legendary Creature — Rabbit Wizard,Christina Kraus
+Pre-War Formalwear,3,2026,2.51,#ffffff,https://cards.scryfall.io/normal/front/d/b/db08975d-ae6e-43b2-8170-79f12149ad83.jpg?1783904272,Artifact — Equipment,Pauline Voss
+Priest of the Blessed Graf,3,2021,0.37,#ffffff,https://cards.scryfall.io/normal/front/5/b/5b3947c1-f497-4407-ae29-287a490cceee.jpg?1783925007,Creature — Human Cleric,Irina Nordsol
+Priest of the Crossing,4,2025,0.23,#ffffff,https://cards.scryfall.io/normal/front/f/0/f0740a86-84eb-4720-b4d7-c5f5e561ddc7.jpg?1783907754,Creature — Zombie Bird Cleric,Edgar Sánchez Hidalgo
+Priest of the Wakening Sun,1,2017,0.29,#ffffff,https://cards.scryfall.io/normal/front/0/5/051dc73e-f04a-4901-b0ed-3b33c33ac72f.jpg?1783935795,Creature — Human Cleric,Bastien L. Deharme
+Pristine Angel,6,2019,0.38,#ffffff,https://cards.scryfall.io/normal/front/2/f/2fbd3a6b-831d-4876-9f84-861cab788747.jpg?1783932787,Creature — Angel,Scott M. Fischer
+Proclamation of Rebirth,3,2006,0.57,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc799c97-3df1-4194-b220-6cf862ce3810.jpg?1783943444,Sorcery,William Simpson
+Profound Journey,7,2015,0.25,#ffffff,https://cards.scryfall.io/normal/front/f/d/fd2dcfe8-ced4-44f2-8268-68035a4d4d58.jpg?1783938614,Sorcery,Tomasz Jedruszek
+Progenitor Exarch,1,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/f/8/f86f7d03-ce71-498d-9dc5-2bd853ac0eae.jpg?1783917051,Creature — Phyrexian Cat Cleric,Marie Magny
+Promise of Bunrei,3,2021,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/4/a40e9071-7b27-4070-bc3a-c095c2128953.jpg?1783924969,Enchantment,Stephen Tappin
+Promise of Tomorrow,3,2020,0.3,#ffffff,https://cards.scryfall.io/normal/front/0/c/0ccffa9d-8896-4364-bc5c-37592d2714f9.jpg?1783928878,Enchantment,Seb McKinnon
+Proper Burial,4,2006,3.05,#ffffff,https://cards.scryfall.io/normal/front/a/e/ae8a4756-d82b-4c6d-b652-5c3722d3edec.jpg?1783943443,Enchantment,Luca Zontini
+Protection Magic,2,2025,0.38,#ffffff,https://cards.scryfall.io/normal/front/9/1/917e9267-010d-450c-ab98-6f861250c437.jpg?1783906366,Instant,Mikio Masuda
+Protector of the Crown,6,2016,2.05,#ffffff,https://cards.scryfall.io/normal/front/2/4/24447332-4bc5-420d-972c-6d472669cfa3.jpg?1783937364,Creature — Giant Soldier,Johannes Voss
+Protector of the Wastes,6,2025,0.25,#ffffff,https://cards.scryfall.io/normal/front/f/d/fd68208b-761f-4aa0-bc8e-59977d784211.jpg?1783907184,Creature — Dragon,Zezhou Chen
+Providence,7,2016,0.21,#ffffff,https://cards.scryfall.io/normal/front/2/e/2e5edd8d-8e10-4414-a326-95a672dfcff7.jpg?1783937512,Sorcery,Zack Stella
+Prowl- Stoic Strategist // Prowl- Pursuit Vehicle,4,2022,1.18,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact Creature — Robot // Legendary Artifact — Vehicle,Volta Creation
+Pulmonic Sliver,5,2021,1.87,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc4eb560-97a7-4f5f-bf12-1f9e1be63095.jpg?1783927866,Creature — Sliver,Jeff Easley
+Pulsemage Advocate,3,2002,1.77,#ffffff,https://cards.scryfall.io/normal/front/0/d/0dce0e8f-9ad6-42b6-af61-c883613efc97.jpg?1783945133,Creature — Human Cleric,Jeff Easley
+Pulse of the Fields,3,2004,0.57,#ffffff,https://cards.scryfall.io/normal/front/b/d/bdedff5d-4c5d-4120-9d9a-4bb5b0b2d2f2.jpg?1783944452,Instant,Paolo Parente
+Pure Intentions,1,2005,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/2/b231d818-df57-4e2d-9603-babe0c2c4568.jpg?1783944167,Instant — Arcane,Randy Gallegos
+Purelace,1,1995,0.44,#ffffff,https://cards.scryfall.io/normal/front/5/7/5736fcc7-fa95-4ef4-b821-392ec00e03bf.jpg?1783947867,Instant,Sandra Everingham
+Pure Reflection,3,2000,0.47,#ffffff,https://cards.scryfall.io/normal/front/b/b/bbff85a6-a51b-424e-a86b-da52c9b3a9da.jpg?1783945715,Enchantment,Scott M. Fischer
+Puresteel Paladin,2,2023,2.38,#ffffff,https://cards.scryfall.io/normal/front/d/8/d8f8a324-006d-4cb8-9816-620a603b4229.jpg?1783915714,Creature — Human Knight,Jason Chan
+Purify,5,2001,0.4,#ffffff,https://cards.scryfall.io/normal/front/0/c/0cfb77ea-6776-4bb4-886d-9a60f56e1fa7.jpg?1783945577,Sorcery,Doug Chaffee
+Purity,6,2007,2.5,#ffffff,https://cards.scryfall.io/normal/front/1/5/154a335d-188d-49c3-af6d-c8e702b4b3ba.jpg?1783942909,Creature — Elemental Incarnation,Warren Mahy
+Pursuit of Knowledge,4,1998,0.66,#ffffff,https://cards.scryfall.io/normal/front/e/a/eaa577b1-2604-4065-a973-166521682a86.jpg?1783946575,Enchantment,DiTerlizzi
+Quantum Entanglement,2,2026,4.57,#ffffff,https://cards.scryfall.io/normal/front/5/4/546e6506-e711-49d7-b9ad-e7791ec4264a.jpg?1783903079,Enchantment,Ioannis Fiore
+Quarantine Field,2,2015,0.31,#ffffff,https://cards.scryfall.io/normal/front/3/0/30c525ab-08d5-4d29-aef1-01b0c75ee8d9.jpg?1783938216,Enchantment,Daarken
+Queen Mother Ramonda,5,2026,0.29,#ffffff,https://cards.scryfall.io/normal/front/6/b/6b971f0b-42de-46bc-8e26-51eb5be447ec.jpg?1783903294,Legendary Creature — Human Noble,Michael Machira
+Rabble Rousing,5,2022,1.26,#ffffff,https://cards.scryfall.io/normal/front/2/0/206c8529-56df-4ed9-97bc-6c9b5e2a04c4.jpg?1783923156,Enchantment,Néstor Ossandón Leal
+Radiant- Archangel,5,1999,7.65,#ffffff,https://cards.scryfall.io/normal/front/9/9/99509da7-3e11-4c38-804b-286ce572f36e.jpg?1783946249,Legendary Creature — Angel,Michael Sutfin
+Radiant Destiny,3,2023,0.32,#ffffff,https://cards.scryfall.io/normal/front/d/1/d1d03bfb-c3bf-4837-b4df-e6339997dedb.jpg?1783913893,Enchantment,Emrah Elmasli
+Radiant Purge,2,2015,0.26,#ffffff,https://cards.scryfall.io/normal/front/c/3/c34d94f4-c504-4cf1-9bc7-d318fbee54d7.jpg?1783938614,Instant,Igor Kieryluk
+Radiant Solar,6,2021,3.42,#ffffff,https://cards.scryfall.io/normal/front/f/a/fa0e443a-c479-40ab-9702-8beca3e5ab95.jpg?1783926257,Creature — Angel,Alexander Mokhov
+Raise the Past,4,2024,0.48,#ffffff,https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg?1783909124,Sorcery,Nathaniel Himawan
+Raksha Golden Cub,7,2017,0.61,#ffffff,https://cards.scryfall.io/normal/front/8/7/8736fd50-312e-47e2-8337-997c2acf48d9.jpg?1783935925,Legendary Creature — Cat Soldier,Pete Venters
+Rally the Ancestors,2,2015,0.36,#ffffff,https://cards.scryfall.io/normal/front/6/d/6d9efacb-9d7c-41f4-9b11-59df1be50e11.jpg?1783938710,Instant,Nils Hamm
+Rally the Ranks,2,2021,0.42,#ffffff,https://cards.scryfall.io/normal/front/0/3/03595195-3be2-4d18-b5c0-43b2dcc1c0f5.jpg?1783928282,Enchantment,Lie Setiawan
+Rammas Echor- Ancient Shield,4,2023,11.05,#ffffff,https://cards.scryfall.io/normal/front/5/5/558c1fcc-cb01-4031-ada5-4e39d65aee27.jpg?1783914195,Legendary Artifact,Matt Stewart
+Ramosian Sky Marshal,5,1999,0.42,#ffffff,https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg?1783945976,Creature — Human Rebel,Matt Cavotta
+Ranger-Captain of Eos,3,2019,38.08,#ffffff,https://cards.scryfall.io/normal/front/a/f/af3928b4-813a-4120-8799-de34235d60ac.jpg?1783933158,Creature — Human Soldier Ranger,Ryan Pancoast
+Ranger of Eos,4,2017,1.58,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c3ba78b-c66a-4a93-abc6-18b63779eda3.jpg?1783936677,Creature — Human Soldier Ranger,Ryan Pancoast
+Rapid Fire,4,1994,11.71,#ffffff,https://cards.scryfall.io/normal/front/e/2/e26e7c9c-e6de-47f4-8394-7e853408f84c.jpg?1783948082,Instant,Justin Hampton
+Rappelling Scouts,4,1999,0.35,#ffffff,https://cards.scryfall.io/normal/front/1/1/113b8366-e6d0-423e-af4b-52c1e08ed446.jpg?1783945975,Creature — Human Rebel Scout,Nelson DeCastro
+Rashel- Fist of Torm,4,2025,15.13,#ffffff,https://cards.scryfall.io/normal/front/1/2/12401fc7-3332-48e5-b38a-efaae29b3ee1.jpg?1783906767,Legendary Creature — Human Knight,Chuck Lukacs
+Rashida Scalebane,5,1996,3.34,#ffffff,https://cards.scryfall.io/normal/front/e/b/ebb48053-da60-477a-b1eb-a9ab9ea682af.jpg?1783947119,Legendary Creature — Human Soldier,Randy Gallegos
+Ratchet- Field Medic // Ratchet- Rescue Racer,3,2022,3.61,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact Creature — Robot // Legendary Artifact — Vehicle,Volta Creation
+Ravnica at War,4,2019,0.59,#ffffff,https://cards.scryfall.io/normal/front/e/0/e0f83824-43c6-4101-88fd-9109958b23e2.jpg?1783933477,Sorcery,Adam Paquette
+Razorfield Ripper,3,2024,0.3,#ffffff,https://cards.scryfall.io/normal/front/2/d/2dc5aa4f-90c0-4a14-8a26-33780c7366c8.jpg?1783911427,Artifact Creature — Equipment Rhino,Samuel Perin
+Realm-Cloaked Giant // Cast Off,7,2021,0.27,#ffffff,https://cards.scryfall.io/normal/front/d/6/d6fc6ed9-740a-4726-8f2c-5d662636f687.jpg?1783926231,Creature — Giant // Sorcery — Adventure,Adam Paquette
+Reborn Hero,3,2002,0.31,#ffffff,https://cards.scryfall.io/normal/front/b/4/b4acbc7f-c86e-4285-a66d-d7b03fe44377.jpg?1783945168,Creature — Human Soldier,Gary Ruddell
+Reciprocate,1,2005,3.76,#ffffff,https://cards.scryfall.io/normal/front/3/f/3f55274a-54f1-4ab2-90ae-8634073baf5f.jpg?1783944219,Instant,Jim Murray
+Reconnaissance,1,2024,34.04,#ffffff,https://cards.scryfall.io/normal/front/2/1/214828eb-434c-47ed-b4af-faaa6c784fb4.jpg?1783913068,Enchantment,Josh Newton & Scott Okumura
+Recruiter of the Guard,3,2024,5.82,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e4c6ba1-1abc-478f-9b7c-97e9e3c92fb0.jpg?1783911218,Creature — Human Soldier,Eric Wilkerson
+Recruitment Officer,1,2022,0.37,#ffffff,https://cards.scryfall.io/normal/front/2/9/29c63c32-ec2d-49fa-9c81-ab9e1abc8494.jpg?1783923551,Creature — Human Soldier,Zoltan Boros
+Redemption Arc,3,2026,0.25,#ffffff,https://cards.scryfall.io/normal/front/4/9/49326de1-d3b0-4f2b-95bc-5f2878e14a89.jpg?1783903803,Enchantment — Aura,Dominik Mayer
+Redemption Choir,4,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/9/8/981dcacb-24a3-43bb-bb64-2b227f31dc3e.jpg?1783913912,Creature — Vampire Cleric,Michele Giorgi
+Redress Fate,8,2024,0.59,#ffffff,https://cards.scryfall.io/normal/front/1/9/19f56096-f692-4719-af38-6a4955f2b65c.jpg?1783909662,Sorcery,Julie Dillon
+Regal Bunnicorn,2,2023,0.72,#ffffff,https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg?1783915128,Creature — Rabbit Unicorn,Ilse Gort
+Regal Caracal,5,2024,0.42,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6310a82-73db-40cb-ae64-6f07f869024c.jpg?1783908938,Creature — Cat,Filip Burburan
+Regal Sliver,4,2023,1.4,#ffffff,https://cards.scryfall.io/normal/front/9/b/9b081723-41a1-4139-88ee-01c0238e50c3.jpg?1783915485,Creature — Sliver,Victor Adame Minguez
+Regna's Sanction,4,2018,0.42,#ffffff,https://cards.scryfall.io/normal/front/3/e/3ea0c6c5-f782-40bf-a0c9-ee7e97963146.jpg?1783934869,Sorcery,Bayard Wu
+Regna- the Redeemer,6,2018,1.84,#ffffff,https://cards.scryfall.io/normal/front/0/c/0c2bf475-9845-40ed-9f55-669325fb6183.jpg?1783934878,Legendary Creature — Angel,Randy Vargas
+Reidane- God of the Worthy // Valkmira- Protector's Shield,3,2021,0.45,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — God // Legendary Artifact,Jason Rainville
+Release to Memory,4,2022,0.47,#ffffff,https://cards.scryfall.io/normal/front/b/4/b45c4bbf-2c61-4d49-96c8-34a0fb0d6d02.jpg?1783923996,Instant,Alayna Danner
+Relic Seeker,2,2020,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/e/ae71b0a7-90c6-48cd-808c-c6c430dcba9c.jpg?1783928727,Creature — Human Soldier,Volkan Baǵa
+Reluctant Role Model,2,2024,0.35,#ffffff,https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg?1783909505,Creature — Human Survivor,Chris Rallis
+Remembrance,4,1998,9.45,#ffffff,https://cards.scryfall.io/normal/front/5/5/556d334e-3ac9-45b0-98d2-aff49ada0f75.jpg?1783946370,Enchantment,Val Mayerik
+Remorseful Cleric,2,2026,0.27,#ffffff,https://cards.scryfall.io/normal/front/6/6/665a1bd1-db82-4db9-af7d-af161d31a696.jpg?1783903803,Creature — Spirit Cleric,Grzegorz Rutkowski
+Renewed Solidarity,3,2025,4.1,#ffffff,https://cards.scryfall.io/normal/front/9/a/9a72b230-dbb0-4d38-ba7a-fb0bd03b6c47.jpg?1783907752,Enchantment,Julie Dillon
+Renounce the Guilds,2,2013,0.22,#ffffff,https://cards.scryfall.io/normal/front/b/c/bc9acc14-24e0-4c03-a09a-2afee351f2cc.jpg?1783940045,Instant,Daarken
+Rent Is Due,1,2025,0.19,#ffffff,https://cards.scryfall.io/normal/front/b/3/b3f8d221-081f-49f5-a501-07e5eb21a840.jpg?1783905362,Enchantment,Gal Or
+Repentant Blacksmith,2,1993,43.74,#ffffff,https://cards.scryfall.io/normal/front/6/1/61fc30b6-1355-425b-a86f-18f59f83141c.jpg?1783948391,Creature — Human,Drew Tucker
+Replenish,4,1999,225.81,#ffffff,https://cards.scryfall.io/normal/front/7/f/7fd2fe13-bbc0-42b7-bc42-3b51910ce118.jpg?1783946084,Sorcery,Jim Nelson
+Requiem Angel,6,2014,0.88,#ffffff,https://cards.scryfall.io/normal/front/a/d/ad135475-d1f6-4e78-a536-6bf61204c739.jpg?1783938856,Creature — Angel,Eric Deschamps
+Rescue Retriever,5,2022,0.4,#ffffff,https://cards.scryfall.io/normal/front/5/9/598def2c-003c-4aa4-ac7c-44ffd9639fdc.jpg?1783919996,Creature — Dog Soldier,Jesper Ejsing
+Resolute Archangel,7,2014,0.96,#ffffff,https://cards.scryfall.io/normal/front/e/3/e37b31b8-d868-4dff-9ab0-723ce41ee7e4.jpg?1783939198,Creature — Angel,Anthony Palumbo
+Resourceful Defense,3,2025,0.35,#ffffff,https://cards.scryfall.io/normal/front/7/8/78743ab3-0289-4799-b139-a37964532b92.jpg?1783906046,Enchantment,Francis Tneh
+Resplendent Angel,3,2023,8.77,#ffffff,https://cards.scryfall.io/normal/front/5/9/59adbd35-9959-4a0f-babf-46ea3c15f018.jpg?1783913805,Creature — Angel,Victor Adame Minguez
+Resplendent Marshal,3,2021,0.96,#ffffff,https://cards.scryfall.io/normal/front/5/e/5e849bec-2ee6-4c83-83e6-bf9f5543e414.jpg?1783928279,Creature — Angel Warrior,Ryan Pancoast
+Rest in Peace,2,2024,0.97,#ffffff,https://cards.scryfall.io/normal/front/d/1/d108c2b1-236e-4b8d-8445-d9749ccc4fea.jpg?1783912003,Enchantment,Grady Frederick
+Restoration Angel,4,2025,0.38,#ffffff,https://cards.scryfall.io/normal/front/f/1/f17f85d3-58e5-4128-90c5-98b524256af8.jpg?1783908175,Creature — Angel,Johannes Voss
+Restoration Seminar,7,2026,3.65,#ffffff,https://cards.scryfall.io/normal/front/9/e/9ebc4ecf-2fa2-4ab8-afde-3b91cf5eadb6.jpg?1783903699,Sorcery — Lesson,Josu Hernaiz
+Restore Balance,0,2021,0.62,#ffffff,https://cards.scryfall.io/normal/front/0/f/0febc7fe-4172-4285-9804-a62ce4506c39.jpg?1783927872,Sorcery,Mark Poole
+Resurgent Belief,0,2021,1.0,#ffffff,https://cards.scryfall.io/normal/front/0/1/01880c6f-be00-48b5-913f-ec6c80ced184.jpg?1783926887,Sorcery,Cliff Childs
+Retaliate,4,2004,0.6,#ffffff,https://cards.scryfall.io/normal/front/5/8/58acdda6-6754-46f2-ad68-f1580b8ab0dd.jpg?1783944409,Instant,Vance Kovacs
+Retether,4,2007,19.77,#ffffff,https://cards.scryfall.io/normal/front/0/f/0faa005e-c753-4484-bf64-349350d59094.jpg?1783943169,Sorcery,Dan Murayama Scott
+Retribution of the Meek,3,1997,8.59,#ffffff,https://cards.scryfall.io/normal/front/8/6/860b8633-1bfc-426a-8666-5e6a584d4525.jpg?1783947003,Sorcery,Nathalie Hertz
+Return to the Ranks,2,2014,0.83,#ffffff,https://cards.scryfall.io/normal/front/9/f/9fccce64-abac-4b90-bbe5-dbba8434b3b4.jpg?1783939198,Sorcery,Michael Komarck
+Reunion of the House,7,2025,0.26,#ffffff,https://cards.scryfall.io/normal/front/7/1/71e4a360-89dd-4f25-9b85-75d0b131e208.jpg?1783907183,Sorcery,Quintin Gleim
+Reveillark,5,2022,0.76,#ffffff,https://cards.scryfall.io/normal/front/5/3/53b4dcd6-b1b6-4f1c-9264-e58bdc87399b.jpg?1783921930,Creature — Elemental,Jim Murray
+Reverence,4,2005,6.85,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d5e65e1-be52-4023-81cc-ee4948444195.jpg?1783944168,Enchantment,Ittoku
+Reverent Mantra,4,1999,21.38,#ffffff,https://cards.scryfall.io/normal/front/4/8/48364e19-a3ea-4980-925f-7918e57315f1.jpg?1783945974,Instant,Rebecca Guay
+Reverse Damage,3,2005,0.38,#ffffff,https://cards.scryfall.io/normal/front/5/f/5f938c52-c7f6-41a4-b480-632b43b60b67.jpg?1783944091,Instant,Thomas Gianni
+Reverse the Sands,8,2016,0.87,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6d56ce1-fb5d-47c6-961d-65b544a48b32.jpg?1783937075,Sorcery,Jeremy Jarvis
+Revivify,3,2021,1.89,#ffffff,https://cards.scryfall.io/normal/front/6/d/6d21fb27-e821-4ce1-8f34-fc5d6c69d779.jpg?1783926256,Instant,Caio Monteiro
+Reya Dawnbringer,9,2018,4.12,#ffffff,https://cards.scryfall.io/normal/front/4/4/44b45bdd-829a-4fc1-ad37-17c2bd57fac8.jpg?1783933857,Legendary Creature — Angel,Matthew D. Wilson
+Rhoda- Geist Avenger,4,2021,0.38,#ffffff,https://cards.scryfall.io/normal/front/c/4/c434e774-c908-46b9-ba18-52e1efe092de.jpg?1783925007,Legendary Creature — Human Soldier,Randy Vargas
+Rhox Faithmender,4,2025,1.92,#ffffff,https://cards.scryfall.io/normal/front/c/7/c79a8938-aae6-42ff-888c-2783e11a8d4f.jpg?1783907119,Creature — Rhino Monk,Wesley Burt
+Rhys- the Evermore,2,2026,0.27,#ffffff,https://cards.scryfall.io/normal/front/a/7/a7072412-4aa2-40ef-a267-bd717551a42b.jpg?1783904499,Legendary Creature — Elf Warrior,Kai Carpenter
+Riders of Gavony,4,2021,0.31,#ffffff,https://cards.scryfall.io/normal/front/3/5/3586c558-fb74-41ba-9ce0-0269154a9205.jpg?1783925350,Creature — Human Knight,Volkan Baǵa
+Righteous Confluence,5,2023,0.36,#ffffff,https://cards.scryfall.io/normal/front/8/9/89c2faf6-e65b-4962-82d4-0294912c2ddb.jpg?1783915714,Sorcery,Kieran Yanner
+Righteousness,1,2007,0.33,#ffffff,https://cards.scryfall.io/normal/front/b/d/bda6c9d5-113f-44f1-bfaf-c40001ba9f60.jpg?1783943073,Instant,Wayne England
+Righteous Valkyrie,3,2021,4.71,#ffffff,https://cards.scryfall.io/normal/front/0/2/02fb5f9f-8750-4eb5-a03a-6dacc60e0b90.jpg?1783928279,Creature — Angel Cleric,Chris Rahn
+Rinoa- Angel Wing,3,2025,8.51,#ffffff,https://cards.scryfall.io/normal/front/7/6/76a9b08e-53f7-48d7-a024-3e2bf2318391.jpg?1783904654,Legendary Creature — Human Rebel Warlock,Lius Lasahido
+Roar of Reclamation,7,2004,0.6,#ffffff,https://cards.scryfall.io/normal/front/d/5/d560e242-44ef-4162-8589-965897e4cdad.jpg?1783944409,Sorcery,Justin Sweet
+Robaran Mercenaries,4,2022,0.31,#ffffff,https://cards.scryfall.io/normal/front/3/2/32e9a83f-be4b-4116-8e0d-61c159286ae0.jpg?1783921470,Creature — Human Mercenary,Chuck Lukacs
+Robe of Stars,2,2021,14.29,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2992175-5499-4a83-9ff2-03c7c34819c3.jpg?1783926256,Artifact — Equipment,Olena Richards
+Rolling Stones,2,2003,1.64,#ffffff,https://cards.scryfall.io/normal/front/0/d/0dcb50bf-7e77-4b8e-a030-e575d0418a00.jpg?1783944830,Enchantment,Don Hazeltine
+Romana II,4,2023,0.26,#ffffff,https://cards.scryfall.io/normal/front/4/c/4ccc3ebd-34e1-421c-87b4-0be905954289.jpg?1783914677,Legendary Creature — Time Lord Scientist,Tyukina Tatiana
+Rosa- Resolute White Mage,4,2025,3.9,#ffffff,https://cards.scryfall.io/normal/front/c/4/c44e0ad6-9f44-4e4c-8c3b-3ee99409a740.jpg?1783906436,Legendary Creature — Human Noble Cleric,Christian Angel
+Rout,5,2021,0.42,#ffffff,https://cards.scryfall.io/normal/front/1/5/15ce585a-67fc-4e7a-92ff-a27292179dfa.jpg?1783927572,Sorcery,Igor Kieryluk
+Royal Talon Fighter Jet,2,2026,1.89,#ffffff,https://cards.scryfall.io/normal/front/e/9/e94da91d-6c76-4909-91e3-2f8d97398654.jpg?1783903295,Artifact — Vehicle,Sean Vo
+Rule of Law,3,2003,1.49,#ffffff,https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg?1783944559,Enchantment,Scott M. Fischer
+Rules Lawyer,5,2017,0.35,#ffffff,https://cards.scryfall.io/normal/front/6/c/6c02c575-5685-44f5-8b47-89d888529d1b.jpg?1783935454,Artifact Creature — Cyborg Advisor,Sean Murray
+Runed Halo,2,2020,0.27,#ffffff,https://cards.scryfall.io/normal/front/6/1/61296b2d-4e5c-419a-8775-4e6af902c7b1.jpg?1783930736,Enchantment,Steve Prescott
+Runeforge Champion,3,2021,0.27,#ffffff,https://cards.scryfall.io/normal/front/4/3/4368b087-05a0-4a88-ab43-0cd16446239b.jpg?1783928277,Creature — Dwarf Warrior,Andrey Kuzinskiy
+Rune of Protection: Lands,2,1998,0.5,#ffffff,https://cards.scryfall.io/normal/front/4/e/4e874700-8002-41e7-8861-b4ce29ba6d9e.jpg?1783946369,Enchantment,Scott M. Fischer
+Rune-Tail- Kitsune Ascendant // Rune-Tail's Essence,3,2005,4.84,#ffffff,https://cards.scryfall.io/normal/front/4/2/42ba0e13-d20f-47f9-9c86-2b0b13c39ada.jpg?1783944168,Legendary Creature — Fox Monk // Legendary Enchantment,Randy Gallegos
+Sacred Ground,2,2005,0.62,#ffffff,https://cards.scryfall.io/normal/front/d/7/d72dc68a-d6f9-4a18-8282-0f104999591f.jpg?1783944090,Enchantment,Gary Ruddell
+Sacred Guide,1,1997,0.5,#ffffff,https://cards.scryfall.io/normal/front/7/f/7f10c37d-d25a-47d6-83b0-dbe0a9cfc938.jpg?1783946662,Creature — Human Cleric,Zina Saunders
+Sacred Mesa,3,2014,0.29,#ffffff,https://cards.scryfall.io/normal/front/3/7/377b2bc1-c710-439d-96d2-beef72ae80a7.jpg?1783938856,Enchantment,Robbie Trevino
+Safeguard,5,1997,0.36,#ffffff,https://cards.scryfall.io/normal/front/2/c/2c8e174c-7abb-4a93-aa1d-8c2a2e815ba6.jpg?1783946662,Enchantment,Thomas M. Baxa
+Sage of the Skies,3,2025,0.49,#ffffff,https://cards.scryfall.io/normal/front/6/a/6ade6918-6d1d-448d-ab56-93996051e9a9.jpg?1783907412,Creature — Human Monk,Justyna Dura
+Sally Pride- Lioness Leader,5,2026,0.42,#ffffff,https://cards.scryfall.io/normal/front/b/c/bcd8ee6b-7142-4548-8b7a-691a36411851.jpg?1783904122,Legendary Creature — Cat Mutant Rebel,Andrea Tentori Montalto
+Salvation Colossus,8,2024,0.56,#ffffff,https://cards.scryfall.io/normal/front/3/8/3842803c-2d51-4ee0-88c3-800e2948d32c.jpg?1783911426,Artifact Creature — Construct,José Parodi
+Salvation Engine,5,2025,2.87,#ffffff,https://cards.scryfall.io/normal/front/3/4/34ed1bf2-0f3c-4528-b570-e5bdcd7ffda9.jpg?1783907915,Artifact — Vehicle,Ben Wootten
+Salvation Swan,4,2024,0.31,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2656160-d319-4530-a6e5-c418596c3f12.jpg?1783910856,Creature — Bird Cleric,Christina Kraus
+Samite Elder,3,2001,0.65,#ffffff,https://cards.scryfall.io/normal/front/b/3/b3c5dccc-2a48-4dcc-a796-fa6fdc11a14e.jpg?1783945628,Creature — Human Cleric,Terese Nielsen
+Samite Sanctuary,3,2000,0.28,#ffffff,https://cards.scryfall.io/normal/front/0/2/022ebeba-b61a-497a-a698-e75b130c468c.jpg?1783945795,Enchantment,Ben Thompson
+Sanctifier en-Vec,2,2021,0.31,#ffffff,https://cards.scryfall.io/normal/front/f/8/f8c3cca4-23c0-4c14-ab56-51ba011f5974.jpg?1783926886,Creature — Human Cleric,Michael C. Hayes
+Sanctifier of Souls,4,2016,0.15,#ffffff,https://cards.scryfall.io/normal/front/8/d/8d839c5a-dc35-4eaa-9cf0-b6e002815726.jpg?1783937511,Creature — Human Cleric,Jesper Ejsing
+Sanctuary Warden,6,2022,1.36,#ffffff,https://cards.scryfall.io/normal/front/4/d/4dfdab77-d7c3-4e6a-bb4b-55153bd2fd4d.jpg?1783923151,Creature — Angel Soldier,Johannes Voss
+Sanctum Prelate,3,2016,1.5,#ffffff,https://cards.scryfall.io/normal/front/1/d/1d95a7dd-2803-4164-8979-d7e8e8085ca2.jpg?1783937362,Creature — Human Cleric,Winona Nelson
+Sand Scout,2,2024,5.54,#ffffff,https://cards.scryfall.io/normal/front/e/6/e63ba7e6-87a9-49ef-bddc-60543edfd726.jpg?1783911971,Creature — Human Scout,Olena Richards
+Sanguine Evangelist,3,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/2/6/269ddd84-fdc4-4c94-b183-32ecec56967c.jpg?1783913806,Creature — Vampire Cleric,Zezhou Chen
+Sanguine Sacrament,2,2017,0.31,#ffffff,https://cards.scryfall.io/normal/front/f/9/f9fae153-d86a-42b5-9c1c-6dbd56118ecb.jpg?1783935792,Instant,Bastien L. Deharme
+Sanwell- Avenger Ace,2,2022,0.29,#ffffff,https://cards.scryfall.io/normal/front/7/0/70cb4359-8e57-4d1a-bf1f-c188555376ce.jpg?1783919724,Legendary Creature — Human Pilot,Josu Hernaiz
+Saradoc- Master of Buckland,4,2023,0.36,#ffffff,https://cards.scryfall.io/normal/front/a/6/a65a1fb5-cc2c-4556-b109-05c3d966ded9.jpg?1783916220,Legendary Creature — Halfling Citizen,Sean Vo
+Savannah Lions,1,2005,0.78,#ffffff,https://cards.scryfall.io/normal/front/d/b/db9f9f3c-d024-4529-bffb-c7a5a3085e58.jpg?1783944085,Creature — Cat,Carl Critchlow
+Savior of Ollenbock,3,2021,0.33,#ffffff,https://cards.scryfall.io/normal/front/b/a/ba77e83b-1846-4c42-bea0-2e304429fbe0.jpg?1783924908,Creature — Human Soldier,Aaron J. Riley
+Scalelord Reckoner,5,2017,7.51,#ffffff,https://cards.scryfall.io/normal/front/c/9/c91c3606-d037-4b97-a7b6-ab1ed09bc976.jpg?1783935950,Creature — Dragon,Even Amundsen
+Scepter of Dominance,3,2009,0.56,#ffffff,https://cards.scryfall.io/normal/front/8/8/888bc7ca-f9fa-4da4-b466-b9dc273d5319.jpg?1783942490,Artifact,Howard Lyon
+Scholar of New Horizons,2,2022,1.37,#ffffff,https://cards.scryfall.io/normal/front/e/8/e83e50d0-7851-4608-8cfd-63c54d1a7544.jpg?1783919722,Creature — Human Scout,Randy Vargas
+Scholarship Sponsor,4,2021,0.39,#ffffff,https://cards.scryfall.io/normal/front/e/d/ed238d90-72b5-44c4-bea7-20f71788088f.jpg?1783927605,Creature — Human Advisor,Tomas Duchek
+Scion of Vitu-Ghazi,5,2013,0.19,#ffffff,https://cards.scryfall.io/normal/front/3/c/3cd20865-0a9a-4a72-92f9-77c8d6384b46.jpg?1783940044,Creature — Elemental,Willian Murai
+Scourglass,5,2008,3.86,#ffffff,https://cards.scryfall.io/normal/front/b/8/b8993b57-3060-45ca-80ed-3366784ec61d.jpg?1783942579,Artifact,Matt Cavotta
+Scout's Warning,1,2007,3.46,#ffffff,https://cards.scryfall.io/normal/front/e/6/e6639e3d-b0c4-4c08-83d5-f3fc58fac9b2.jpg?1783943127,Instant,Zoltan Boros & Gabor Szikszai
+Sculpted Sunburst,5,2022,0.22,#ffffff,https://cards.scryfall.io/normal/front/2/d/2d16d8fe-a770-4bbd-bf20-447c0165de5a.jpg?1783922803,Sorcery,Evyn Fong
+Séance,4,2017,0.3,#ffffff,https://cards.scryfall.io/normal/front/2/e/2e376bdf-076c-471a-9408-b36fc5b8405b.jpg?1783936675,Enchantment,David Rapoza
+Search for Dagger,2,2025,4.19,#ffffff,https://cards.scryfall.io/normal/front/9/a/9adaef20-1d82-4941-b4bb-a037cf3d63db.jpg?1783904653,Enchantment,Erion Makuo
+Search for Glory,3,2021,0.9,#ffffff,https://cards.scryfall.io/normal/front/b/6/b65c215d-562d-4c7c-bc9f-b1d741050158.jpg?1783928277,Snow Sorcery,Kieran Yanner
+Search the Premises,4,2024,0.32,#ffffff,https://cards.scryfall.io/normal/front/0/8/08877e2c-79ac-4a4d-a7dd-60652c5eb5f6.jpg?1783913026,Enchantment,Matt Stewart
+Seasoned Dungeoneer,4,2022,6.81,#ffffff,https://cards.scryfall.io/normal/front/7/f/7fee3f76-20a8-4621-84fb-ddf79c955532.jpg?1783922514,Creature — Human Warrior,John Stanko
+Season of the Burrow,5,2024,2.53,#ffffff,https://cards.scryfall.io/normal/front/3/3/33bf9c60-4e58-48a4-8e53-abef7ab3b671.jpg?1783910856,Sorcery,Serena Malyon
+Second Sunrise,3,2003,3.0,#ffffff,https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg?1783944558,Instant,Greg Staples
+Secret Arcade // Dusty Parlor,8,2024,1.58,#ffffff,https://cards.scryfall.io/normal/front/f/e/fe050c16-9be5-42ef-988f-0531a8bb2352.jpg?1783909661,Enchantment — Room // Enchantment — Room,Arthur Yuan
+Secret Rendezvous,3,2026,2.6,#ffffff,https://cards.scryfall.io/normal/front/1/8/187f9ede-0f30-4f37-bf4a-dc78cbf81c9e.jpg?1783903501,Sorcery,Dwarf Fortress
+Secure the Wastes,1,2023,4.64,#ffffff,https://cards.scryfall.io/normal/front/b/c/bca35012-ecfa-475f-b405-d3143ce99eef.jpg?1783917179,Instant,Scott Murphy
+Securitron Squadron,2,2024,2.55,#ffffff,https://cards.scryfall.io/normal/front/b/6/b689a206-aec3-4a31-95cf-3d4b840db04c.jpg?1783912416,Artifact Creature — Robot,Jonas De Ro
+Security Detail,4,1999,0.3,#ffffff,https://cards.scryfall.io/normal/front/5/b/5b89d34b-1a67-4f5c-a731-54b56c5233ff.jpg?1783945974,Enchantment,Val Mayerik
+Seht's Tiger,4,2017,0.48,#ffffff,https://cards.scryfall.io/normal/front/5/9/5970a4c8-0e1f-42cc-bd8e-7ba3946c6e41.jpg?1783935924,Creature — Cat,Thomas Gianni
+Selfless Exorcist,5,2002,0.21,#ffffff,https://cards.scryfall.io/normal/front/c/9/c9b1c300-aec3-4512-9902-309615e86c73.jpg?1783945133,Creature — Human Cleric,Christopher Moeller
+Selfless Glyphweaver // Deadly Vanity,3,2021,0.33,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Cleric // Sorcery,Johannes Voss
+Selfless Savior,1,2023,3.31,#ffffff,https://cards.scryfall.io/normal/front/2/7/276b4316-e5f2-40a4-8d7a-a7d7059ebfad.jpg?1783916637,Creature — Dog,Randy Vargas
+Selfless Spirit,2,2026,0.35,#ffffff,https://cards.scryfall.io/normal/front/9/c/9cd16dac-3bf9-4a71-a906-0cfbf98cdca5.jpg?1783903802,Creature — Spirit Cleric,Seb McKinnon
+Selfless Squire,4,2024,0.38,#ffffff,https://cards.scryfall.io/normal/front/8/b/8b8f4489-3d07-4e57-9b94-afa52fa984f8.jpg?1783913025,Creature — Human Soldier,Tony Foti
+Semester's End,4,2023,0.95,#ffffff,https://cards.scryfall.io/normal/front/d/b/db2bb091-ac6d-4c99-bdf6-70ffb6291ef0.jpg?1783915447,Instant,Alayna Danner
+Sensei Golden-Tail,2,2004,1.83,#ffffff,https://cards.scryfall.io/normal/front/b/9/b93dd897-3fb5-48b1-bdff-9383ce1feb21.jpg?1783944332,Legendary Creature — Fox Samurai,Stephen Tappin
+Sentry Bot,5,2024,0.29,#ffffff,https://cards.scryfall.io/normal/front/b/1/b16b0143-3511-4f79-bdb1-1ff7af55f051.jpg?1783912415,Artifact Creature — Robot,Anthony Devine
+Senu- Keen-Eyed Protector,2,2024,0.85,#ffffff,https://cards.scryfall.io/normal/front/5/6/5671a03d-0858-41e7-976c-60825c29af04.jpg?1783910987,Legendary Creature — Bird Scout,Michael MacRae
+Sephara- Sky's Blade,7,2023,3.37,#ffffff,https://cards.scryfall.io/normal/front/7/2/729ee848-6c27-4202-b2bc-605f45209468.jpg?1783915714,Legendary Creature — Angel,Livia Prima
+Seraphic Greatsword,2,2020,0.86,#ffffff,https://cards.scryfall.io/normal/front/f/f/ff9b6e59-8e95-413d-825e-f1dc8874eaa9.jpg?1783928873,Artifact — Equipment,Craig J Spearing
+Seraph of the Sword,4,2013,0.38,#ffffff,https://cards.scryfall.io/normal/front/d/9/d9789cac-5774-4f72-82c3-18f11f9d4a62.jpg?1783939941,Creature — Angel,Jaime Jones
+Serene Master,2,2013,0.68,#ffffff,https://cards.scryfall.io/normal/front/0/6/06223a09-a32c-4c60-86a1-f8f7bf5a7cdd.jpg?1783939689,Creature — Human Monk,Mark Zug
+Serene Sleuth,2,2024,0.15,#ffffff,https://cards.scryfall.io/normal/front/6/1/61e691ff-ab3e-42ae-b160-54b53f5f961e.jpg?1783913050,Creature — Human Detective,Fay Dalton
+Serenity,2,1999,3.1,#ffffff,https://cards.scryfall.io/normal/front/3/b/3b37593d-13e7-4489-84bc-7074032b6f05.jpg?1783946206,Enchantment,Cliff Nielsen
+Serra Angel,5,2009,0.23,#ffffff,https://cards.scryfall.io/normal/front/2/7/27c4f032-0a26-4d21-906f-dd80310a14b8.jpg?1783942457,Creature — Angel,Greg Staples
+Serra Ascendant,1,2017,31.09,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a22ee47-fc56-436d-8570-88fbff421027.jpg?1783935554,Creature — Human Monk,Howard Lyon
+Serra Avatar,7,2023,0.54,#ffffff,https://cards.scryfall.io/normal/front/5/0/5041dcfd-c1af-448c-91f7-75fd1d34e93e.jpg?1783918508,Creature — Avatar,Victor Adame Minguez
+Serra Avenger,2,2021,0.55,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e5627de-fda7-4e39-a6ec-1e895bc353ed.jpg?1783927862,Creature — Angel,Scott M. Fischer
+Serra Aviary,4,1995,1.11,#ffffff,https://cards.scryfall.io/normal/front/6/8/688a8de2-0167-4b35-a38d-3574034a892c.jpg?1783947301,World Enchantment,Nicola Leonard
+Serra Paragon,4,2026,0.51,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e77a410-a053-4349-950c-d59e76b17923.jpg?1783903802,Creature — Angel,Heonhwa
+Serra Redeemer,5,2024,0.24,#ffffff,https://cards.scryfall.io/normal/front/2/3/230b9aef-bd9c-4332-ace4-b5b065bac6d8.jpg?1783910742,Creature — Angel Soldier,Joshua Raphael
+Serra's Emissary,7,2021,7.12,#ffffff,https://cards.scryfall.io/normal/front/b/6/b6534049-3045-4546-b1e8-e5b1b0df5f56.jpg?1783926884,Creature — Angel,Nils Hamm
+Serra's Guardian,6,2019,0.42,#ffffff,https://cards.scryfall.io/normal/front/8/4/84784231-2675-4b5b-929f-a796c091a77c.jpg?1783932913,Creature — Angel,Magali Villeneuve
+Serra's Liturgy,4,1998,0.62,#ffffff,https://cards.scryfall.io/normal/front/b/8/b84be3ef-a820-41e3-b66a-09303dad32dd.jpg?1783946368,Enchantment,rk post
+Serra the Benevolent,4,2019,7.75,#ffffff,https://cards.scryfall.io/normal/front/8/8/88bf4af9-4b14-43e7-9d50-0e6a895cece1.jpg?1783933156,Legendary Planeswalker — Serra,Magali Villeneuve
+Settle the Wreckage,4,2017,2.65,#ffffff,https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg?1783935791,Instant,Dimitar Marinski
+Sevinne's Reclamation,3,2026,0.63,#ffffff,https://cards.scryfall.io/normal/front/8/d/8deab1ef-4219-4767-a3c4-b61250d0ebe0.jpg?1783903800,Sorcery,Zoltan Boros
+Shahrazad,2,1993,456.74,#ffffff,https://cards.scryfall.io/normal/front/0/0/0014def3-4063-4929-ac51-76aef1bb2a68.jpg?1783948393,Sorcery,Kaja Foglio
+Shaile- Dean of Radiance // Embrose- Dean of Shadow,2,2021,0.38,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Bird Cleric // Legendary Creature — Human Warlock,Yongjae Choi
+Shalai- Voice of Plenty,4,2025,0.92,#d78f42,https://cards.scryfall.io/normal/front/5/3/53876046-cdb8-4157-96cd-7832d3ad2549.jpg?1783907119,Legendary Creature — Angel,Victor Adame Minguez
+Shared Triumph,2,2002,3.82,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d07ebe6-76cf-4345-b59b-9954496c44d0.jpg?1783945091,Enchantment,Mark Brill
+Shatter the Sky,4,2026,0.21,#ffffff,https://cards.scryfall.io/normal/front/e/7/e79f7e98-2f80-444b-8ca2-d529472ba798.jpg?1783911512,Sorcery,Bayard Wu
+Shelter,2,2024,4.47,#ffffff,https://cards.scryfall.io/normal/front/d/c/dccbf4c7-ea2c-413b-8226-6aaa46a44661.jpg?1783911496,Instant,Mandy Jurgens
+Sheltered by Ghosts,2,2026,20.6,#ffffff,https://cards.scryfall.io/normal/front/d/a/da7c29a0-5512-4188-acbc-af5f9194f264.jpg?1783903404,Enchantment — Aura,SimzArt
+Sheltering Prayers,1,2000,0.28,#ffffff,https://cards.scryfall.io/normal/front/a/3/a30803e6-7f0e-4832-b121-b18480c6465c.jpg?1783945795,Enchantment,Nelson DeCastro
+Shielded by Faith,3,2026,0.38,#ffffff,https://cards.scryfall.io/normal/front/6/8/681149f2-0802-4ab7-9521-3b3c7281f55d.jpg?1783903799,Enchantment — Aura,David Palumbo
+Shining Shoal,2,2005,1.88,#ffffff,https://cards.scryfall.io/normal/front/7/8/78ca16f8-336a-444b-9f78-e97a3f20a3bc.jpg?1783944211,Instant — Arcane,Ben Thompson
+Sidar Jabari,4,1996,0.74,#ffffff,https://cards.scryfall.io/normal/front/7/4/743f0d06-cd14-49f3-ad3c-0d419a0c30bc.jpg?1783947116,Legendary Creature — Human Knight,Gerry Grace
+Siege Veteran,3,2022,0.36,#ffffff,https://cards.scryfall.io/normal/front/f/5/f57e2a32-6e52-4f6e-96ec-55f5b7ba77e0.jpg?1783920123,Creature — Human Soldier,Darren Tan
+Sierra- Nuka's Biggest Fan,4,2024,0.34,#ffffff,https://cards.scryfall.io/normal/front/6/4/641dd97c-6577-4cab-8672-56f870477961.jpg?1783912415,Legendary Creature — Human Citizen,Anna Podedworna
+Sigarda's Aid,1,2020,18.21,#ffffff,https://cards.scryfall.io/normal/front/5/3/531da950-dc96-4050-94a8-e01b73ddd965.jpg?1783928726,Enchantment,Howard Lyon
+Sigarda's Splendor,4,2021,0.53,#ffffff,https://cards.scryfall.io/normal/front/b/b/bb22626d-84ef-40d1-a4f2-771b45198eaa.jpg?1783925652,Enchantment,Howard Lyon
+Sigarda's Summons,6,2021,0.36,#ffffff,https://cards.scryfall.io/normal/front/a/2/a27f647a-d48e-4f53-ae5b-64c76f4fc745.jpg?1783924908,Enchantment,Néstor Ossandón Leal
+Sigarda's Vanguard,5,2021,0.96,#ffffff,https://cards.scryfall.io/normal/front/d/8/d81da23b-b0c1-4e28-ab87-2aaac9b12bb3.jpg?1783925382,Creature — Angel,Martina Fačková
+Sigardian Savior,5,2021,0.36,#ffffff,https://cards.scryfall.io/normal/front/b/1/b1a2b41a-34b0-428e-80ec-3ffd601093a2.jpg?1783925651,Creature — Angel,David Rapoza
+Sigil of the Empty Throne,5,2024,0.49,#ffffff,https://cards.scryfall.io/normal/front/6/8/6875be24-1515-488f-a899-929c8e480dfd.jpg?1783909633,Enchantment,Cyril Van Der Haegen
+Sigil of the New Dawn,4,2002,0.28,#ffffff,https://cards.scryfall.io/normal/front/c/a/ca1babca-b285-4b00-8b46-ed946c9a027f.jpg?1783945091,Enchantment,Tony Szczudlo
+Sigrid- God-Favored,3,2021,0.31,#ffffff,https://cards.scryfall.io/normal/front/a/e/aeec3c1e-e612-4700-888e-300912932552.jpg?1783928275,Legendary Creature — Human Warrior,Johannes Voss
+Silence,1,2013,10.59,#ffffff,https://cards.scryfall.io/normal/front/1/c/1c2b13b1-31f0-4676-88a7-53f3a190e9a2.jpg?1783939940,Instant,Wayne Reynolds
+Silent Sentinel,7,2018,0.3,#ffffff,https://cards.scryfall.io/normal/front/7/3/73798b01-fcbc-4dc0-9fde-6a618da185f2.jpg?1783934317,Creature — Archon,Slawomir Maniak
+Silverblade Paladin,3,2014,0.79,#ffffff,https://cards.scryfall.io/normal/front/7/9/79c43502-5b82-43b6-a62d-162b49667f39.jpg?1783938855,Creature — Human Knight,Jason Chan
+Silverquill Lecturer,5,2024,0.4,#ffffff,https://cards.scryfall.io/normal/front/5/3/5360b208-76c0-4757-a78f-723662b3353f.jpg?1783911425,Creature — Kor Wizard,Ryan Pancoast
+Silver Seraph,8,2002,0.95,#ffffff,https://cards.scryfall.io/normal/front/1/4/1465ca9e-a997-4b8c-9677-6c7961f67eba.jpg?1783945133,Creature — Angel,Matthew D. Wilson
+Silverwing Squadron,6,2023,0.38,#ffffff,https://cards.scryfall.io/normal/front/4/f/4f674d39-e437-4efb-843b-30b18b567e98.jpg?1783917177,Creature — Human Knight,Johannes Voss
+Single Combat,5,2019,0.5,#ffffff,https://cards.scryfall.io/normal/front/c/e/ce0e7c6a-e628-4327-a16f-2062c5a662df.jpg?1783933474,Sorcery,Livia Prima
+Sisay- Weatherlight Captain,3,2019,2.64,#d78f42,https://cards.scryfall.io/normal/front/5/a/5a293c45-1e73-4527-be2f-2dcd5c47b610.jpg?1783933156,Legendary Creature — Human Soldier,Anna Steinbauer
+Sivvi's Valor,3,2000,0.36,#ffffff,https://cards.scryfall.io/normal/front/9/d/9d15f7b5-5070-4742-a05c-623822d874fb.jpg?1783945840,Instant,Jeff Miracola
+Skrelv- Defector Mite,1,2023,3.26,#ffffff,https://cards.scryfall.io/normal/front/6/0/60b565da-a49b-479c-b0c4-8ff3dd20cc0b.jpg?1783918072,Legendary Artifact Creature — Phyrexian Mite,Brian Valeza
+Skrelv's Hive,2,2023,2.13,#ffffff,https://cards.scryfall.io/normal/front/f/f/ffbd77ec-fc81-41d5-934f-c3dd844cb053.jpg?1783918072,Enchantment,Heonhwa
+Skybind,5,2014,0.37,#ffffff,https://cards.scryfall.io/normal/front/9/1/91e3117a-0955-47fc-81c0-7a662c8c487f.jpg?1783939455,Enchantment,Igor Kieryluk
+Skyboon Evangelist,5,2022,0.39,#ffffff,https://cards.scryfall.io/normal/front/a/7/a776f162-5ac4-444a-8254-ff6915932358.jpg?1783923374,Creature — Bird Advisor,Rudy Siswanto
+Skyclave Apparition,3,2026,0.26,#ffffff,https://cards.scryfall.io/normal/front/e/6/e671de25-c47c-48a1-919b-6aa30dab142f.jpg?1783903800,Creature — Kor Spirit,Donato Giancola
+Skyhunter Strike Force,3,2024,4.98,#ffffff,https://cards.scryfall.io/normal/front/d/7/d77b0ae2-e26a-4536-8f19-ed15328c039c.jpg?1783913120,Creature — Cat Knight,Slawomir Maniak
+Skyknight Squire,2,2024,0.31,#ffffff,https://cards.scryfall.io/normal/front/f/c/fcfe4e62-c153-47b8-8e09-cedaf91f53d8.jpg?1783909123,Creature — Cat Scout,Alexander Mokhov
+Skyseer's Chariot,2,2025,0.11,#ffffff,https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg?1783907914,Artifact — Vehicle,Carl Critchlow
+Slash the Ranks,5,2020,0.83,#ffffff,https://cards.scryfall.io/normal/front/0/9/0913a5e8-7f77-44f2-a7cf-c8c0d6270a86.jpg?1783928872,Sorcery,Svetlin Velinov
+Slaughter the Strong,3,2018,0.4,#ffffff,https://cards.scryfall.io/normal/front/4/2/4217ab21-181e-4c32-97c3-d8bd441287e0.jpg?1783935331,Sorcery,Randy Vargas
+Slip On the Ring,2,2023,10.51,#ffffff,https://cards.scryfall.io/normal/front/6/d/6d4eccc6-26a3-48d3-bb15-522ba51327e0.jpg?1783915182,Instant,Bakshi Productions
+Slumbering Walker,5,2026,0.21,#ffffff,https://cards.scryfall.io/normal/front/8/1/81e82915-e734-4754-829f-f5da6a7c550d.jpg?1783904499,Creature — Giant Warrior,Jakub Kasper
+Smile at Death,5,2025,2.82,#ffffff,https://cards.scryfall.io/normal/front/a/e/ae2da18f-0d7d-446c-b463-8bf170ed95da.jpg?1783907405,Enchantment,Olivier Bernard
+Smothering Tithe,4,2023,63.2,#ffffff,https://cards.scryfall.io/normal/front/8/6/861b5889-0183-4bee-afeb-a4b2aa700a8e.jpg?1783915712,Enchantment,Mark Behm
+Smuggler's Share,3,2024,10.01,#ffffff,https://cards.scryfall.io/normal/front/f/1/f1ced678-5cfd-49ff-9420-6ee52d5edf5a.jpg?1783913024,Enchantment,Aaron Miller
+Soaring Lightbringer,5,2024,0.7,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc7895bf-a5fe-45bd-bc57-c4abe0703900.jpg?1783909663,Enchantment Creature — Bird Glimmer,Michele Giorgi
+Sokka's Charge,4,2025,7.51,#ffffff,https://cards.scryfall.io/normal/front/a/9/a9dd7fc2-1eab-4f73-a4e8-6d7551c73a3e.jpg?1783904839,Enchantment,Fahmi Fauzi
+Sokka- Swordmaster,3,2025,1.08,#ffffff,https://cards.scryfall.io/normal/front/2/f/2fcfb238-121c-46b8-a4a9-1b45b4dbb4a0.jpg?1783904833,Legendary Creature — Human Warrior Ally,Jason Kiantoro
+Solaflora- Intergalactic Icon,5,2022,0.14,#ffffff,https://cards.scryfall.io/normal/front/1/a/1a97764c-0d47-4cca-8a02-2b9aade662e1.jpg?1783920606,Legendary Creature — Human Guest,Aaron J. Riley
+Solar Tide,6,2003,0.78,#ffffff,https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg?1783944559,Sorcery,Dave Dorman
+SOLDIER Military Program,3,2025,0.21,#ffffff,https://cards.scryfall.io/normal/front/d/d/dddad2c2-bd19-42bd-aad6-bbf23ccef269.jpg?1783906364,Enchantment,Yoshio Sugiura
+Soldier of the Pantheon,1,2013,0.26,#ffffff,https://cards.scryfall.io/normal/front/5/c/5cfc0f46-4df4-4ae3-bfe6-391916eb590f.jpg?1783939806,Creature — Human Soldier,Eric Deschamps
+Solemnity,3,2017,9.78,#ffffff,https://cards.scryfall.io/normal/front/0/a/0a71fb62-acbd-49f5-842f-0fc9fa48afea.jpg?1783936059,Enchantment,Greg Opalinski
+Solemn Recruit,3,2022,0.18,#ffffff,https://cards.scryfall.io/normal/front/4/b/4b93ee66-bc1d-42ad-8839-d77ab5992f14.jpg?1783922482,Creature — Dwarf Warrior,Eric Deschamps
+Solitary Confinement,3,2021,0.51,#ffffff,https://cards.scryfall.io/normal/front/b/9/b9031a7f-8821-443c-9c9d-552fb25b2101.jpg?1783926790,Enchantment,Scott M. Fischer
+Solitude,5,2021,33.51,#ffffff,https://cards.scryfall.io/normal/front/4/7/47a6234f-309f-4e03-9263-66da48b57153.jpg?1783926885,Creature — Elemental Incarnation,Evan Shipard
+Soltari Champion,3,1998,2.5,#ffffff,https://cards.scryfall.io/normal/front/a/1/a112edf3-c976-426c-a407-e86255586e41.jpg?1783946572,Creature — Soltari Soldier,Adam Rex
+Soltari Emissary,2,1997,0.56,#ffffff,https://cards.scryfall.io/normal/front/a/1/a18751d3-052b-4ae5-ba07-16f00a1af40e.jpg?1783946661,Creature — Soltari Soldier,Adam Rex
+Songbirds' Blessing,4,2026,0.49,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d1e229a-ed04-4d8d-90a9-5a451ca81470.jpg?1783903799,Enchantment — Aura,Eelis Kyttanen
+Song of the Worldsoul,6,2019,4.95,#ffffff,https://cards.scryfall.io/normal/front/b/b/bb73ec0d-f582-4f74-9b5c-180fe3aedcf6.jpg?1783932817,Enchantment,Torstein Nordstrand
+Soraya the Falconer,3,1995,2.17,#ffffff,https://cards.scryfall.io/normal/front/1/9/19fb3ce2-a660-4829-9af4-330cfd612f06.jpg?1783947300,Legendary Creature — Human,Dennis Detwiller
+Soul Echo,2,1996,1.36,#ffffff,https://cards.scryfall.io/normal/front/c/b/cb6f9427-ef5c-49fd-81e1-ddf130d69da0.jpg?1783947116,Enchantment,Ron Spencer
+Soulfire Grand Master,2,2015,1.13,#d78f42,https://cards.scryfall.io/normal/front/f/c/fc3a4e7d-6667-4c2f-b6b4-484f401b0455.jpg?1783938709,Creature — Human Monk,Johannes Voss
+Soul of Eternity,7,2020,0.36,#ffffff,https://cards.scryfall.io/normal/front/0/8/08241f94-8b5e-4f9b-8120-8175e3256e35.jpg?1783928870,Creature — Avatar,Yigit Koroglu
+Soul of Theros,6,2014,0.32,#ffffff,https://cards.scryfall.io/normal/front/6/3/63e391d3-cf19-4f73-9d39-22587e0f3c0d.jpg?1783939197,Creature — Avatar,Zack Stella
+Soul Partition,2,2022,0.64,#ffffff,https://cards.scryfall.io/normal/front/2/8/28bb8ec0-9729-4aa1-8ce4-a3a5598b0d70.jpg?1783920121,Instant,Kekai Kotaki
+Soulscour,10,2004,0.41,#ffffff,https://cards.scryfall.io/normal/front/6/b/6b431711-ac9d-4f05-af66-44f1ca5fabf1.jpg?1783944452,Sorcery,Kev Walker
+Soul Sculptor,3,1998,0.85,#ffffff,https://cards.scryfall.io/normal/front/f/e/fe6ef073-1c83-47a4-b19d-86fb8bed5db9.jpg?1783946365,Creature — Human,Ciruelo
+Soul Warden,1,2024,6.84,#ffffff,https://cards.scryfall.io/normal/front/b/c/bc9df8ac-0214-4d8a-a401-667f8c34e63e.jpg?1783909282,Creature — Human Cleric,Joshua Cairos
+Southern Paladin,4,2001,0.61,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2fa1570-3103-494c-8316-8f0bf484f22d.jpg?1783945567,Creature — Human Knight,Greg Staples
+South Pole Voyager,2,2025,0.34,#ffffff,https://cards.scryfall.io/normal/front/4/b/4b5ad895-be8d-476b-91ca-22fad7a3cc58.jpg?1783904994,Creature — Human Scout Ally,Tition
+Space Marine Devastator,4,2022,1.43,#ffffff,https://cards.scryfall.io/normal/front/4/a/4a821438-2b60-421e-9fd2-3ce3ec958eb7.jpg?1783920945,Creature — Astartes Warrior,Games Workshop
+Spark Rupture,3,2023,0.17,#ffffff,https://cards.scryfall.io/normal/front/a/0/a027a75f-4faf-4e96-9035-d1f622b9b607.jpg?1783916528,Enchantment,Viko Menezes
+Sparring Regimen,3,2021,0.29,#ffffff,https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg?1783927388,Enchantment,Tomasz Jedruszek
+Speaker of the Heavens,1,2020,0.55,#ffffff,https://cards.scryfall.io/normal/front/1/f/1f44b96a-8498-414a-a4ac-54c80dfa9f23.jpg?1783930732,Creature — Human Cleric,Randy Vargas
+Spear of Heliod,3,2013,1.16,#ffffff,https://cards.scryfall.io/normal/front/3/4/34ef01da-d311-4d4f-9f7b-328e7bb17db4.jpg?1783939806,Legendary Enchantment Artifact,Yeong-Hao Han
+Spectacular Pileup,5,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/2/a24a6309-0e69-45f0-a9ff-44d4997e7e4d.jpg?1783907914,Sorcery,Zezhou Chen
+Spectacular Spider-Man,2,2025,73.69,#ffffff,https://cards.scryfall.io/normal/front/3/f/3f1b7b3e-3449-4c8f-8eb7-aacc62d9eadd.jpg?1783905142,Legendary Creature — Spider Human Hero,Julian Totino Tedesco
+Spectral Guardian,4,1996,0.72,#ffffff,https://cards.scryfall.io/normal/front/2/a/2a0bea61-8fd2-4802-90b4-651bebbe9638.jpg?1783947115,Creature — Spirit,Mike Dringenberg
+Spectral Lynx,2,2001,0.46,#d78f42,https://cards.scryfall.io/normal/front/1/3/13099abe-721e-42b4-9666-9e6b5f1d75c9.jpg?1783945355,Creature — Cat Spirit,Heather Hudson
+Spectra Ward,5,2014,2.88,#ffffff,https://cards.scryfall.io/normal/front/6/9/69c1b7a2-a4ff-485c-9fe5-04c88e5e8886.jpg?1783939198,Enchantment — Aura,Ryan Alexander Lee
+Spellbook Vendor,2,2023,0.46,#ffffff,https://cards.scryfall.io/normal/front/4/c/4ceac5b5-05eb-4f00-9477-3db490be24dd.jpg?1783915127,Creature — Human Peasant,Scott Murphy
+Spelltithe Enforcer,5,2006,11.27,#ffffff,https://cards.scryfall.io/normal/front/0/d/0dd5682a-ca93-4b5f-af21-e1ff4439361b.jpg?1783943524,Creature — Elephant Wizard,Greg Staples
+Sphere of Safety,5,2025,14.23,#ffffff,https://cards.scryfall.io/normal/front/0/6/06d72ef4-b7a8-4879-b5e2-91d688d4df85.jpg?1783905159,Enchantment,Evyn Fong
+Sphinx's Decree,2,2018,0.25,#ffffff,https://cards.scryfall.io/normal/front/5/0/5058a729-9739-4548-b420-deebbc0950b7.jpg?1783935331,Sorcery,Daarken
+Spider-Man- Peter Parker,5,2025,10.13,#ffffff,https://cards.scryfall.io/normal/front/4/1/415bf221-215b-4c9f-b995-8d31ca95adc0.jpg?1783905373,Legendary Creature — Spider Human Hero,Paolo Rivera
+Spirit Bonds,2,2014,0.43,#ffffff,https://cards.scryfall.io/normal/front/a/a/aa2a3aaa-e78a-48cc-b7d3-7f65e467054c.jpg?1783939197,Enchantment,Willian Murai
+Spirited Companion,2,2025,17.77,#ffffff,https://cards.scryfall.io/normal/front/8/5/85c9b363-4883-4ce9-96cc-c786ab3f618a.jpg?1783907482,Enchantment Creature — Dog,Mariah Tekulve
+Spirit Mantle,2,2026,1.0,#ffffff,https://cards.scryfall.io/normal/front/e/e/ee9fa595-d7ee-47ab-a116-f4d75bb3b1bb.jpg?1783904271,Enchantment — Aura,Billy Christian
+Spirit of Resistance,3,2000,21.17,#ffffff,https://cards.scryfall.io/normal/front/5/f/5fb66439-df73-4a01-a8d4-6f2334297fdf.jpg?1783945711,Enchantment,John Avon
+Spirit of the Hearth,6,2017,0.37,#ffffff,https://cards.scryfall.io/normal/front/9/3/93fb7e08-ff15-49b9-bed8-0faadfa8338f.jpg?1783935923,Creature — Cat Spirit,Jason Chan
+Spirit of the Labyrinth,2,2014,0.68,#ffffff,https://cards.scryfall.io/normal/front/f/4/f44e5128-e146-4e46-b313-a40d82719d1d.jpg?1783939575,Enchantment Creature — Spirit,Jason Chan
+Spiritual Asylum,4,2000,0.67,#ffffff,https://cards.scryfall.io/normal/front/e/5/e5eea354-2d92-4b57-aec7-25260ab7a70f.jpg?1783945839,Enchantment,Matt Cavotta
+Spiritual Focus,2,1999,6.46,#ffffff,https://cards.scryfall.io/normal/front/8/5/8521ae08-eb46-45ff-8fc4-62d8b07cfac2.jpg?1783945973,Enchantment,Andrew Goldhawk
+Spiritual Guardian,5,1997,2.59,#ffffff,https://cards.scryfall.io/normal/front/0/d/0dbea02f-9124-4e1a-8693-d988a0a3adae.jpg?1783946847,Creature — Spirit,Terese Nielsen
+Spiritual Sanctuary,4,1994,19.1,#ffffff,https://cards.scryfall.io/normal/front/6/5/654dd1e0-a91d-44ee-af20-c025bf360c3f.jpg?1783948080,Enchantment,Amy Weber
+Splinter- Aging Champion,3,2026,1.29,#ffffff,https://cards.scryfall.io/normal/front/9/a/9a9cd2d2-74ba-497a-828c-ba22fbb9f2b1.jpg?1783904140,Legendary Creature — Mutant Ninja Rat,Thomas Chamberlain-Keen
+Splinter & Leo- Father & Son,3,2026,0.79,#ffffff,https://cards.scryfall.io/normal/front/a/8/a8959c36-068f-48fa-ab6a-9dd24ba985ce.jpg?1783904140,Legendary Creature — Mutant Ninja Rat Turtle,Eilene Cherie
+Split Up,3,2024,1.78,#ffffff,https://cards.scryfall.io/normal/front/1/b/1bb9a5b1-48d2-453e-8991-c788bc63e482.jpg?1783909503,Sorcery,Dominik Mayer
+Squad Commander,4,2022,0.23,#ffffff,https://cards.scryfall.io/normal/front/5/3/5390bbf3-9906-46a9-81d3-60e23eb89ca1.jpg?1783922484,Creature — Kor Warrior,Ekaterina Burmak
+Sram- Senior Edificer,2,2026,0.71,#ffffff,https://cards.scryfall.io/normal/front/8/f/8fbd18ce-0ac3-4b52-9cd0-0af7e0244207.jpg?1783903797,Legendary Creature — Dwarf Advisor,Chris Rahn
+Sram's Expertise,4,2017,0.61,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c6d47b0-4c19-4c19-9e21-54cd87a5e34d.jpg?1783936776,Sorcery,Kieran Yanner
+Staff of the Storyteller,2,2026,0.47,#ffffff,https://cards.scryfall.io/normal/front/6/7/67083aca-b077-4b12-8218-876e22476f85.jpg?1783903823,Artifact,Lorenzo Mastroianni
+Stalking Leonin,3,2024,0.26,#ffffff,https://cards.scryfall.io/normal/front/9/5/954c0bca-c613-4915-9811-128d3c64ba62.jpg?1783913022,Creature — Cat Archer,Zoltan Boros
+Stalwart Pathlighter,3,2021,0.34,#ffffff,https://cards.scryfall.io/normal/front/a/5/a5bf9336-80d6-4751-9630-1d28e24cc0cf.jpg?1783925382,Creature — Human Soldier,Sidharth Chaturvedi
+Starfall Invocation,5,2024,1.66,#ffffff,https://cards.scryfall.io/normal/front/2/a/2aea38e6-ec58-4091-b27c-2761bdd12b13.jpg?1783910855,Sorcery,Rob Rey
+Starfield Mystic,2,2026,0.22,#ffffff,https://cards.scryfall.io/normal/front/e/8/e8f2fcb4-8d06-49ac-9c70-9c54d77c6d86.jpg?1783903798,Creature — Human Cleric,Eric Deschamps
+Starfield of Nyx,5,2023,13.87,#ffffff,https://cards.scryfall.io/normal/front/b/f/bfe4e1cb-ceee-46aa-96d1-f3f26516cd77.jpg?1783915445,Enchantment,Tyler Jacobson
+Starlight Spectacular,4,2022,0.8,#ffffff,https://cards.scryfall.io/normal/front/d/e/de25090e-dd32-4267-a661-da3083d1737a.jpg?1783920606,Enchantment,Marco Bucci
+Starnheim Unleashed,4,2021,1.44,#ffffff,https://cards.scryfall.io/normal/front/e/a/ea660d42-a441-48d8-98c1-00933cde94a4.jpg?1783928275,Sorcery,Johannes Voss
+Staying Power,3,2020,0.15,#ffffff,https://cards.scryfall.io/normal/front/f/c/fcc13f28-6d2e-4589-b475-3c18d0eea2de.jpg?1783931347,Enchantment,Richard Sardinha
+Steelburr Champion,3,2024,0.34,#ffffff,https://cards.scryfall.io/normal/front/7/3/73b1f962-22b7-4394-9796-24f7b0f8a42f.jpg?1783910734,Creature — Mouse Soldier,Josiah "Jo" Cameron
+Steel-Plume Marshal,5,2020,0.36,#ffffff,https://cards.scryfall.io/normal/front/d/d/ddbcb165-0a60-493a-8cbb-ba8b36c527da.jpg?1783930509,Creature — Bird Soldier,Cristi Balanescu
+Steelshaper Apprentice,4,2004,0.69,#ffffff,https://cards.scryfall.io/normal/front/a/4/a4793de1-4d5d-4538-b48f-db5d31757bcc.jpg?1783944451,Creature — Human Soldier,Greg Hildebrandt
+Steelshaper's Gift,1,2023,9.39,#ffffff,https://cards.scryfall.io/normal/front/5/5/55d61383-b739-4422-a76c-d8cbca13c5b2.jpg?1783915711,Sorcery,Greg Hildebrandt
+Stern Marshal,3,1997,0.72,#ffffff,https://cards.scryfall.io/normal/front/1/8/18fbfbc0-c55b-4e56-a3d2-5d09571c36c8.jpg?1783946846,Creature — Human Soldier,D. Alexander Gregory
+Stick Together,5,2022,0.35,#ffffff,https://cards.scryfall.io/normal/front/8/d/8d77a57a-e30b-46d7-acb8-1d164c7dff78.jpg?1783922510,Sorcery,Dave Greco
+Stiltzkin- Moogle Merchant,1,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/0/6/06a972a4-0c1b-4f12-a5a5-fdea47c4cd35.jpg?1783906644,Legendary Creature — Moogle,Hendry Iwanaga
+Stirring Hopesinger,3,2026,0.33,#ffffff,https://cards.scryfall.io/normal/front/2/1/21375667-b318-47f8-a482-9c8c2b5b14c0.jpg?1783903698,Creature — Bird Bard,Cristi Balanescu
+Stoic Farmer,4,2021,0.33,#ffffff,https://cards.scryfall.io/normal/front/f/5/f53f39e9-f07e-444f-8420-4545e56253e5.jpg?1783928340,Creature — Dwarf Peasant,Svetlin Velinov
+Stoneforge Mystic,2,2020,31.62,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d3473d0-b46f-41f5-ac1e-ba217f7747d4.jpg?1783930209,Creature — Kor Artificer,Mike Bierek
+Stone Haven Outfitter,2,2016,0.36,#ffffff,https://cards.scryfall.io/normal/front/e/1/e1b98e63-f23d-432a-86ae-f88bdad2f648.jpg?1783937922,Creature — Kor Artificer Ally,Jason Rainville
+Stonehewer Giant,5,2020,8.46,#ffffff,https://cards.scryfall.io/normal/front/0/e/0efda05d-01ea-4478-b075-00a31d7037f8.jpg?1783930208,Creature — Giant Warrior,Steve Prescott
+Stony Silence,2,2017,2.04,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e7faede-f794-4bda-9d64-21390ba19266.jpg?1783936674,Enchantment,Mark Poole
+Storm Herd,10,2021,1.03,#ffffff,https://cards.scryfall.io/normal/front/2/3/2345331c-a14f-4b4b-a9a4-88c5beb48242.jpg?1783928328,Sorcery,Jim Nelson
+Storm of Souls,6,2021,0.3,#ffffff,https://cards.scryfall.io/normal/front/3/0/30cb1c3f-19d4-47d3-960e-f2de828e6feb.jpg?1783925007,Sorcery,Liiga Smilshkalne
+Story Circle,3,2007,1.01,#ffffff,https://cards.scryfall.io/normal/front/6/1/6194fab1-c185-4df5-8900-37d28ffae545.jpg?1783943069,Enchantment,Aleksi Briclot
+Strict Proctor,2,2021,0.32,#ffffff,https://cards.scryfall.io/normal/front/9/5/95f1e36a-6838-49de-b7dc-697cbcd1e892.jpg?1783927383,Creature — Spirit Cleric,Jokubas Uogintas
+Student of Warfare,1,2010,0.8,#ffffff,https://cards.scryfall.io/normal/front/9/f/9f4df9be-324b-458a-9379-ab4aa437a6d2.jpg?1783942002,Creature — Human Knight,Volkan Baǵa
+Sublime Archangel,4,2018,3.02,#ffffff,https://cards.scryfall.io/normal/front/9/5/95e53129-c49b-4bb8-a816-629fc87e58bb.jpg?1783933854,Creature — Angel,Cynthia Sheppard
+Sublime Exhalation,7,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/4/a/4a8f810f-844b-4ebd-b28c-46432cf0203d.jpg?1783915710,Sorcery,Lake Hurwitz
+Sudden Disappearance,6,2012,0.29,#ffffff,https://cards.scryfall.io/normal/front/a/5/a51b792c-b987-49b6-9cc6-80d613c7d065.jpg?1783940849,Sorcery,Cliff Childs
+Sudden Salvation,4,2021,0.15,#ffffff,https://cards.scryfall.io/normal/front/d/e/ded1c959-454c-4336-8eb5-0160c49d895d.jpg?1783925004,Instant,Cristi Balanescu
+Suki- Courageous Rescuer,3,2025,0.28,#ffffff,https://cards.scryfall.io/normal/front/3/3/33b97433-e16c-422e-a0ca-f6b1e98d8681.jpg?1783904995,Legendary Creature — Human Warrior Ally,Tky
+Suki- Kyoshi Captain,3,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/9/7/97f713ae-c70a-401c-ad10-323f1d7b8f47.jpg?1783904832,Legendary Creature — Human Warrior Ally,Shiren
+Summoner's Sending,2,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/8/1/8150be1a-4bac-4c67-9165-9d6fc04a69cc.jpg?1783906365,Enchantment,Yumi Yaoshida
+Summon: Good King Mog XII,5,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/c/1/c14098d6-28ae-492f-8ffc-7d115d83ce6a.jpg?1783906365,Enchantment Creature — Saga Moogle,Andrea Radeck
+Summon: Ixion,3,2025,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/c/acb35dcb-0bee-4deb-88bf-ffa1f110c67b.jpg?1783906365,Enchantment Creature — Saga Unicorn,Ben Wootten
+Summon: Knights of Round,8,2025,12.5,#ffffff,https://cards.scryfall.io/normal/front/4/4/44d23652-077e-4c1f-b640-b284685db911.jpg?1783906644,Enchantment Creature — Saga Knight,Takayama Toshiaki
+Summon: Yojimbo,4,2025,1.19,#ffffff,https://cards.scryfall.io/normal/front/c/d/cdbc2d28-ea35-47c6-af7e-07924e9d5794.jpg?1783906365,Enchantment Creature — Saga Samurai,Benjamin Ee
+Sunblast Angel,6,2021,0.63,#ffffff,https://cards.scryfall.io/normal/front/6/8/680f7d5c-d518-4ebb-92d5-e835cd9eafe0.jpg?1783926229,Creature — Angel,Jason Chan
+Suncleanser,2,2018,0.36,#ffffff,https://cards.scryfall.io/normal/front/3/6/3644df41-b690-4581-ac7d-c85cec75411f.jpg?1783934596,Creature — Human Cleric,Mark Zug
+Sunfall,5,2023,0.67,#ffffff,https://cards.scryfall.io/normal/front/3/2/32e29c7d-ed4b-4eff-b3c2-d99e5b63ef8d.jpg?1783917046,Sorcery,Kasia 'Kafis' Zielińska
+Sungold Sentinel,2,2021,0.29,#ffffff,https://cards.scryfall.io/normal/front/e/7/e7e1afd0-49d4-4657-ab75-98b0bfbfb245.jpg?1783925650,Creature — Human Soldier,Marta Nael
+Sunscape Master,4,2000,0.37,#d78f42,https://cards.scryfall.io/normal/front/e/b/ebb7203d-529d-45d2-8e03-cd342c153f38.jpg?1783945711,Creature — Human Wizard,Alan Rabinowitz
+Sunscorch Regent,5,2023,0.76,#ffffff,https://cards.scryfall.io/normal/front/d/a/da6b530c-5a56-4dc1-8d36-6ed8d2c158a9.jpg?1783917176,Creature — Dragon,Matt Stewart
+Sunscour,7,2006,3.27,#ffffff,https://cards.scryfall.io/normal/front/4/4/44c726db-a30a-4e76-9fbf-ec6d5cd7a1ba.jpg?1783943367,Sorcery,Jim Murray
+Sunstar Chaplain,2,2025,0.21,#ffffff,https://cards.scryfall.io/normal/front/8/3/83719626-3ff8-4566-9911-88212e753c69.jpg?1783905987,Creature — Human Cleric,Valera Lutfullina
+Sunstrike Legionnaire,2,2003,1.19,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f5d519a-9f11-4b10-97ad-edccfda639bb.jpg?1783944926,Creature — Human Soldier,Mark Zug
+Sun Titan,6,2026,0.3,#ffffff,https://cards.scryfall.io/normal/front/3/d/3d6eacf2-f6c7-4ede-b5a5-7463602699ae.jpg?1783903797,Creature — Giant,Todd Lockwood
+Sunweb,4,2003,0.34,#ffffff,https://cards.scryfall.io/normal/front/7/2/7261bcea-27e0-417f-b3bf-7089c1e8bf1e.jpg?1783944821,Creature — Wall,Greg Staples
+Super-Soldier Serum,2,2026,0.97,#ffffff,https://cards.scryfall.io/normal/front/8/4/845b0be1-4f85-4a8c-8205-dc85c8cf9a61.jpg?1783902965,Enchantment — Aura,Rafater
+Surprise Party,3,2022,0.1,#ffffff,https://cards.scryfall.io/normal/front/3/3/33dcfb90-8720-4a85-ab5b-169668871bb2.jpg?1783920605,Enchantment,Sean Murray
+Swift Reconfiguration,1,2022,3.69,#ffffff,https://cards.scryfall.io/normal/front/9/7/975dcfab-0281-4fee-92aa-021ea6c524c7.jpg?1783923997,Enchantment — Aura,Nicholas Gregory
+Sworn Defender,4,1996,0.8,#ffffff,https://cards.scryfall.io/normal/front/3/2/328e6ceb-30f7-415e-93b4-7075af0fed89.jpg?1783947198,Creature — Human Knight,D. Alexander Gregory
+Sygg- Wanderwine Wisdom // Sygg- Wanderbrine Shield,2,2026,0.27,#d78f42,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Merfolk Wizard // Legendary Creature — Merfolk Rogue,Justin Gerard
+Sylvia Brightspear,3,2018,2.04,#ffffff,https://cards.scryfall.io/normal/front/a/b/ab2b349a-1555-4aaa-8302-28667404e630.jpg?1783934878,Legendary Creature — Human Knight,Carmen Sinek
+Syr Cadian- Knight Owl,5,2020,0.21,#d78f42,https://cards.scryfall.io/normal/front/a/e/ae0b109c-eaf3-49ab-a61c-853e8ca239fc.jpg?1783931349,Legendary Creature — Bird Knight,Andrea Radeck
+Takeno- Samurai General,6,2004,0.77,#ffffff,https://cards.scryfall.io/normal/front/d/0/d038df46-4a30-4125-be0e-8781b16b523e.jpg?1783944332,Legendary Creature — Human Samurai,Matt Cavotta
+Tale of Momo,3,2025,0.27,#ffffff,https://cards.scryfall.io/normal/front/3/3/334d02cb-3a9c-4f1b-b6da-5ac4b1bef471.jpg?1783904833,Sorcery,Tetsuko
+Talus Paladin,4,2010,1.62,#ffffff,https://cards.scryfall.io/normal/front/4/f/4f5212f4-f04c-4ca3-b254-654bb263829b.jpg?1783942064,Creature — Human Knight Ally,Svetlin Velinov
+Taranika- Akroan Veteran,3,2020,0.3,#ffffff,https://cards.scryfall.io/normal/front/a/8/a8edd707-5ba3-4978-9a0b-efd0cda367c1.jpg?1783931589,Legendary Creature — Human Soldier,Eric Deschamps
+Tariff,2,1999,0.51,#ffffff,https://cards.scryfall.io/normal/front/6/1/61094858-b8a8-425f-9c96-fac4fc6ecae8.jpg?1783946205,Sorcery,Kev Walker
+Tataru Taru,2,2025,8.39,#ffffff,https://cards.scryfall.io/normal/front/9/3/93176e85-2343-43a8-8578-69699b464b86.jpg?1783906365,Legendary Creature — Dwarf Advisor,Livia Prima
+Tazri- Beacon of Unity,5,2020,0.32,#d78f42,https://cards.scryfall.io/normal/front/d/4/d4b79138-5728-4541-9ea5-dce1a5ae7e6a.jpg?1783929405,Legendary Creature — Human Warrior,Chris Rahn
+Tazri- Stalwart Survivor,3,2023,0.23,#d78f42,https://cards.scryfall.io/normal/front/2/2/227d0d7d-544b-4736-914d-10d5d752eb42.jpg?1783916528,Legendary Creature — Human Warrior,Manuel Castañón
+Teferi's Protection,3,2022,53.55,#ffffff,https://cards.scryfall.io/normal/front/4/8/483fa1cb-1e35-44f2-a143-98c0f107f5ca.jpg?1783921926,Instant,Chase Stone
+Tegan Jovanka,3,2023,0.32,#ffffff,https://cards.scryfall.io/normal/front/3/6/361769b3-7e10-4e0f-b623-c00e2144463d.jpg?1783914675,Legendary Creature — Human,Aurore Folny
+Teleportation Circle,4,2021,9.26,#ffffff,https://cards.scryfall.io/normal/front/9/0/90140bc0-4a9c-4422-b07c-3400c7ccde56.jpg?1783926523,Enchantment,Chris Cold
+Tempered Steel,3,2020,2.13,#ffffff,https://cards.scryfall.io/normal/front/9/5/956cc7b5-b120-4a98-9509-03047d8acd4a.jpg?1783930206,Enchantment,Wayne Reynolds
+Tempest Technique,4,2025,0.35,#ffffff,https://cards.scryfall.io/normal/front/5/d/5d5ee7cc-4854-4b52-ba9b-64d5a401fca1.jpg?1783907183,Enchantment — Aura,Nino Vecia
+Temple Altisaur,5,2023,0.56,#ffffff,https://cards.scryfall.io/normal/front/8/3/83c1ba83-c394-4ff1-b2ba-56907403162a.jpg?1783913893,Creature — Dinosaur,Daarken
+Temporary Lockdown,3,2022,0.3,#ffffff,https://cards.scryfall.io/normal/front/8/2/82b3088f-7b49-45e9-b447-129a597ceb75.jpg?1783921358,Enchantment,Bryan Sola
+Temporary Truce,2,1997,6.86,#ffffff,https://cards.scryfall.io/normal/front/5/f/5f6ee294-7dbb-4872-81d1-c69c7337cf9f.jpg?1783946845,Sorcery,Mike Raabe
+Tempt with Bunnies,3,2024,3.89,#ffffff,https://cards.scryfall.io/normal/front/9/0/90cc0369-dc9b-4e75-8e3c-ec0783fa13a9.jpg?1783910734,Sorcery,Ben Wootten
+Tempt with Glory,6,2017,0.34,#ffffff,https://cards.scryfall.io/normal/front/9/0/90e17fdd-c14f-413d-8119-d18cc8e58670.jpg?1783936301,Sorcery,Michael Komarck
+Tenth District Hero,2,2024,0.17,#ffffff,https://cards.scryfall.io/normal/front/7/c/7c65a79e-f28a-4f30-95a4-1ea55fd84564.jpg?1783912919,Creature — Human,Kai Carpenter
+Tenuous Truce,2,2022,0.41,#ffffff,https://cards.scryfall.io/normal/front/f/5/f511555a-09aa-41f8-b240-c21f911a57b4.jpg?1783923346,Enchantment — Aura,Kari Christensen
+Terminus,6,2024,0.33,#ffffff,https://cards.scryfall.io/normal/front/4/c/4c53c684-37f9-4b95-88be-a42b9600c47c.jpg?1783909643,Sorcery,Jarel Threat
+Terra Eternal,3,2010,7.46,#ffffff,https://cards.scryfall.io/normal/front/9/b/9bad0759-4132-42b5-9a26-0fcf321a60e0.jpg?1783942063,Enchantment,Daniel Ljunggren
+Teshar- Ancestor's Apostle,4,2022,0.33,#ffffff,https://cards.scryfall.io/normal/front/0/e/0ec9ef7c-88de-4346-a8f9-44beda59fa68.jpg?1783921433,Legendary Creature — Bird Cleric,Even Amundsen
+Test of Endurance,4,2023,7.82,#ffffff,https://cards.scryfall.io/normal/front/7/6/76841945-8ff1-4c2d-895e-d1e2cf468cff.jpg?1783918502,Enchantment,Denman Rooke
+Tethered Griffin,1,1999,1.17,#ffffff,https://cards.scryfall.io/normal/front/2/b/2bed19fa-e497-48de-8459-030e60fdc9a8.jpg?1783946081,Creature — Griffin,Matthew D. Wilson
+Teyo- Geometric Tactician,3,2023,9.58,#ffffff,https://cards.scryfall.io/normal/front/c/6/c66fa93a-6888-4297-b22e-7d69fd25c0d7.jpg?1783915485,Legendary Planeswalker — Teyo,Kieran Yanner
+Thalia- Guardian of Thraben,2,2021,0.48,#ffffff,https://cards.scryfall.io/normal/front/c/9/c9f8b8fb-1cd8-450e-a1fe-892e7a323479.jpg?1783924909,Legendary Creature — Human Soldier,Magali Villeneuve
+Thalia- Heretic Cathar,3,2025,2.39,#ffffff,https://cards.scryfall.io/normal/front/c/0/c062937f-d519-4206-99b0-cbea01b85a0d.jpg?1783908172,Legendary Creature — Human Soldier,Magali Villeneuve
+Thalia's Geistcaller,3,2019,0.24,#ffffff,https://cards.scryfall.io/normal/front/4/5/4531482d-9238-40de-957e-61beb5700330.jpg?1783932814,Creature — Human Cleric,Sean Sevestre
+Thalia's Lancers,5,2016,0.48,#ffffff,https://cards.scryfall.io/normal/front/9/9/9930d08d-5965-4c16-a84d-43c8ccf2ad0b.jpg?1783937507,Creature — Human Knight,David Palumbo
+Thalia's Lieutenant,2,2020,1.35,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c2000ef-3e6b-4f44-8bd6-ed8119336d5a.jpg?1783931193,Creature — Human Soldier,Johannes Voss
+Thancred Waters,5,2025,0.16,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc74ea74-05cf-4a33-84df-94ec34e816fe.jpg?1783906364,Legendary Creature — Human Warrior,Wisnu Tan
+The Battle of Bywater,3,2023,3.03,#ffffff,https://cards.scryfall.io/normal/front/9/b/9bae7a4d-9117-43c5-a048-80a0ddadc034.jpg?1783916337,Sorcery,Tomas Duchek
+The Book of Exalted Deeds,3,2021,8.23,#ffffff,https://cards.scryfall.io/normal/front/a/1/a1899bb1-dd8e-4437-8ea3-4ad637eabf2b.jpg?1783926538,Legendary Artifact — Book,Daniel Ljunggren
+The Caves of Androzani,4,2023,0.21,#ffffff,https://cards.scryfall.io/normal/front/7/b/7b260c0a-b9dc-4a4f-83ee-5a7fbd9b3f67.jpg?1783914682,Enchantment — Saga,Néstor Ossandón Leal
+The Cheese Stands Alone,6,1998,10.63,#ffffff,https://cards.scryfall.io/normal/front/d/0/d01a114f-3349-4a62-bfad-0dc33b78a53f.jpg?1783946437,Enchantment,Randy Elliott
+The Circle of Loyalty,6,2022,0.79,#ffffff,https://cards.scryfall.io/normal/front/8/1/81910ade-a742-4ed7-ab15-bca95850f8b5.jpg?1783921437,Legendary Artifact,Bastien L. Deharme
+The Destined White Mage,3,2025,10.91,#ffffff,https://cards.scryfall.io/normal/front/8/b/8b52f14c-e6b9-4ad0-8515-6644b201e2ea.jpg?1783904657,Legendary Creature — Human Cleric,David Rapoza
+The Eternal Wanderer,6,2023,1.91,#ffffff,https://cards.scryfall.io/normal/front/9/0/905f0dd4-0197-45f8-8e7f-396d6dcef600.jpg?1783918081,Legendary Planeswalker,Alix Branwyn
+The Gaffer,3,2023,6.96,#ffffff,https://cards.scryfall.io/normal/front/8/6/863ed552-dc6d-4910-b188-3cefc3ebf0ed.jpg?1783916035,Legendary Creature — Halfling Peasant,Tomas Duchek
+The Girl in the Fireplace,3,2023,0.29,#ffffff,https://cards.scryfall.io/normal/front/1/e/1e3a5da4-0d8e-4db1-b827-ddfeb5ce0f1d.jpg?1783914679,Enchantment — Saga,Torgeir Fjereide
+The Legend of Yangchen // Avatar Yangchen,5,2025,3.52,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Legendary Creature — Avatar,Kuno
+The Mind Stone,2,2026,65.47,#ffffff,https://cards.scryfall.io/normal/front/8/7/87f1e69a-6d74-4982-afda-82613637799a.jpg?1783902972,Legendary Artifact — Infinity Stone,Volkan Baǵa
+The Night of the Doctor,6,2023,0.38,#ffffff,https://cards.scryfall.io/normal/front/5/1/513d33fb-becc-4804-806a-764d08fc7b7d.jpg?1783914678,Enchantment — Saga,Borja Pindado
+The Pandorica,3,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/c/1/c1642e04-d39a-46dc-8157-549c225c992f.jpg?1783914681,Legendary Artifact,Craig J Spearing
+The Prydwen- Steel Flagship,6,2024,0.39,#ffffff,https://cards.scryfall.io/normal/front/9/c/9c0a8eda-bfeb-4fd9-9e41-12fce02883d8.jpg?1783912416,Legendary Artifact — Vehicle,Victor Harmatiuk
+The Queen of Dale,2,2026,49.75,#ffffff,https://cards.scryfall.io/normal/front/c/9/c977fb5f-4436-41d0-af68-93b6d05897e5.jpg?1784376948,Legendary Creature — Human Noble,Magali Villeneuve
+The Restoration of Eiganjo // Architect of Restoration,3,2022,0.63,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment — Saga // Enchantment Creature — Fox Monk,Titus Lunter
+The Sentry- Golden Guardian,4,2026,0.41,#ffffff,https://cards.scryfall.io/normal/front/3/f/3f56c0e7-5b07-48e3-b0ca-5d09ddc8de9a.jpg?1783902966,Legendary Creature — Human Hero,Alexander Skripnikov
+The Seriema,3,2025,0.99,#ffffff,https://cards.scryfall.io/normal/front/d/e/dec91ec3-42d3-4922-96f0-dbb50a576084.jpg?1783905989,Legendary Artifact — Spacecraft,Sergey Glushakov
+The Spear of Bashenga,5,2026,0.28,#ffffff,https://cards.scryfall.io/normal/front/b/8/b8cc0703-f626-4d42-90bb-1a26e331a9de.jpg?1783903293,Legendary Artifact — Equipment,Michael Machira
+The Wandering Emperor,4,2022,4.14,#ffffff,https://cards.scryfall.io/normal/front/f/a/fab2d8a9-ab4c-4225-a570-22636293c17d.jpg?1783923909,Legendary Planeswalker,Tommy Arnold
+The Wandering Rescuer,5,2024,2.29,#ffffff,https://cards.scryfall.io/normal/front/e/1/e1ccca86-df8b-4fd9-8fdf-0a5a7b14cdee.jpg?1783909499,Legendary Creature — Human Samurai Noble,Anna Pavleeva
+The War Games,4,2023,0.3,#ffffff,https://cards.scryfall.io/normal/front/0/6/0662fee0-a6bc-4a1c-8a0f-6e7efc6b8a21.jpg?1783914678,Enchantment — Saga,Bartek Fedyczak
+The Wedding of River Song,3,2023,0.27,#ffffff,https://cards.scryfall.io/normal/front/a/d/adc4ce53-7805-4448-bc20-f5bf85fdefa3.jpg?1783914674,Sorcery,Mandy Jurgens
+The Wind Crystal,4,2025,6.78,#ffffff,https://cards.scryfall.io/normal/front/1/9/19bd0885-baaa-40f2-9c59-b1ea53807540.jpg?1783906641,Legendary Artifact,Pablo Mendoza
+Thorough Investigation,3,2021,3.55,#ffffff,https://cards.scryfall.io/normal/front/a/4/a40e6034-aa05-4542-ac12-78e6a76d86e9.jpg?1783926257,Enchantment,Aaron J. Riley
+Thoughtweft Trio,4,2007,0.54,#ffffff,https://cards.scryfall.io/normal/front/9/e/9e48d34d-063c-4703-870b-4a22d5774c89.jpg?1783942908,Creature — Kithkin Soldier,Wayne Reynolds
+Thousand Moons Smithy // Barracks of the Thousand,4,2023,2.8,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Artifact // Legendary Artifact Land,Manuel Castañón
+Thraben Doomsayer,3,2020,0.39,#ffffff,https://cards.scryfall.io/normal/front/0/e/0e0fa5ab-c4d1-4b2d-ad62-feb651e4b11c.jpg?1783931192,Creature — Human Cleric,John Stanko
+Thraben Inspector,1,2022,0.95,#ffffff,https://cards.scryfall.io/normal/front/e/8/e8233004-6d69-44a7-bf21-f13a5e146a1f.jpg?1783921001,Creature — Human Soldier,Yuko Shimizu
+Three Blind Mice,3,2023,0.39,#ffffff,https://cards.scryfall.io/normal/front/0/d/0d2ba371-854c-4529-b72b-e4a1887e33ab.jpg?1783915125,Enchantment — Saga,Andrew Mar
+Three Dreams,5,2016,2.04,#ffffff,https://cards.scryfall.io/normal/front/4/c/4c06b86e-c3fc-4703-affa-0ee2d9613854.jpg?1783936842,Sorcery,Shishizaru
+Thunder Spirit,3,1994,123.38,#ffffff,https://cards.scryfall.io/normal/front/6/1/61a59775-b1cd-4ed0-8abf-c2b37f7be0d5.jpg?1783948079,Creature — Elemental Spirit,Randy Asplund-Faith
+Thurid- Mare of Destiny,4,2024,3.53,#ffffff,https://cards.scryfall.io/normal/front/a/a/aad65c60-b9e8-4a8f-92e8-3dff63232102.jpg?1783908860,Legendary Creature — Pegasus,Ishikawa Kenta
+Timeless Dragon,5,2021,0.3,#ffffff,https://cards.scryfall.io/normal/front/9/6/96fe8889-0ec8-421a-83a4-5d00ab4804db.jpg?1783926882,Creature — Dragon,Anastasia Ovchinnikova
+Timely Ward,3,2024,5.4,#ffffff,https://cards.scryfall.io/normal/front/d/6/d61f8db1-0148-47bd-ae97-9aedccb83813.jpg?1783909630,Enchantment — Aura,Matt Stewart
+Tithe,1,1997,36.4,#ffffff,https://cards.scryfall.io/normal/front/a/a/aae08938-e563-4322-b2eb-db81913ea730.jpg?1783947003,Instant,Jon J Muth
+Tithe Taker,2,2019,0.34,#ffffff,https://cards.scryfall.io/normal/front/b/d/bd26b7b1-992d-4b8c-bc33-51aab5abdf98.jpg?1783933715,Creature — Human Soldier,Aaron Miller
+Tivadar of Thorn,3,2006,0.26,#ffffff,https://cards.scryfall.io/normal/front/f/3/f34d3a74-496e-462d-afa6-370dc2b8347d.jpg?1783943248,Legendary Creature — Human Knight,Carl Critchlow
+Toby- Beastie Befriender,3,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg?1783909502,Legendary Creature — Human Wizard,Jehan Choo
+Tocasia's Welcome,3,2026,0.58,#ffffff,https://cards.scryfall.io/normal/front/9/0/90e38661-292a-45e7-bda9-51af53cf0f68.jpg?1783903797,Enchantment,Johan Grenier
+Tocatli Honor Guard,2,2017,0.31,#ffffff,https://cards.scryfall.io/normal/front/a/3/a3fc3501-e7bd-4589-98c5-4476258842ea.jpg?1783935787,Creature — Human Soldier,Sara Winters
+Together Forever,2,2026,0.32,#ffffff,https://cards.scryfall.io/normal/front/1/b/1b19f82a-9724-41b1-934d-a8ec1493587b.jpg?1783904160,Enchantment,Adam Volker
+Tomik- Distinguished Advokist,2,2024,0.38,#ffffff,https://cards.scryfall.io/normal/front/0/e/0eea32dc-dbac-47a9-97b2-311413f1de9d.jpg?1783913341,Legendary Creature — Human Advisor,Johannes Voss
+Toolcraft Exemplar,1,2016,0.24,#ffffff,https://cards.scryfall.io/normal/front/d/a/daae3dae-3297-4750-9bca-c8aadaf815ea.jpg?1783937228,Creature — Dwarf Artificer,Zezhou Chen
+Touch of the Eternal,7,2012,0.18,#ffffff,https://cards.scryfall.io/normal/front/5/5/55c5f0c2-99e6-42b7-aa16-61d5815d060d.jpg?1783940511,Enchantment,Christopher Moeller
+Touch the Spirit Realm,3,2022,3.17,#ffffff,https://cards.scryfall.io/normal/front/5/d/5d02afc8-0192-4e7d-9d10-60a4434ed8db.jpg?1783923552,Enchantment,Mila Pesic
+Tragic Arrogance,5,2026,0.26,#ffffff,https://cards.scryfall.io/normal/front/9/5/956d4728-e7a3-43f4-a350-86eca1b95d06.jpg?1783903243,Sorcery,Rimas Valeikis
+Transcendence,6,2002,7.45,#ffffff,https://cards.scryfall.io/normal/front/8/4/84e8bee2-9e3d-493c-a937-645bf3dcf0db.jpg?1783945166,Enchantment,Rebecca Guay
+Transcendent Master,3,2010,2.03,#ffffff,https://cards.scryfall.io/normal/front/6/b/6b007f42-9ec2-466b-8d6b-1d55c516080b.jpg?1783942000,Creature — Human Cleric Avatar,Steven Belledin
+Trap Digger,4,2003,0.14,#ffffff,https://cards.scryfall.io/normal/front/0/5/05cd76bf-db08-45f8-b3ae-501bcca6df3c.jpg?1783944889,Creature — Human Soldier,Christopher Moeller
+Trapjaw Tyrant,5,2018,6.87,#ffffff,https://cards.scryfall.io/normal/front/b/2/b2c280c8-3471-4ae1-be96-0f392b095ce2.jpg?1783935330,Creature — Dinosaur,Chris Rahn
+Trial of a Time Lord,3,2023,0.32,#ffffff,https://cards.scryfall.io/normal/front/5/2/52b68ed3-0d26-4334-8d0c-2d28ced8ee4c.jpg?1783914675,Enchantment — Saga,Audrey Benjaminsen
+Triceraton Commander,2,2026,1.62,#ffffff,https://cards.scryfall.io/normal/front/6/4/6445b690-71ce-4371-ae9c-bac0e70dda81.jpg?1783904122,Creature — Dinosaur Soldier,Nathaniel Himawan
+Triumphant Reckoning,9,2020,0.61,#ffffff,https://cards.scryfall.io/normal/front/7/2/72db8e30-e3a4-4141-9ea3-7db4a060ec8e.jpg?1783928870,Sorcery,Svetlin Velinov
+Triumph of Saint Katherine,5,2022,3.27,#ffffff,https://cards.scryfall.io/normal/front/c/c/cc5338e1-26a6-466e-9393-788f69370e15.jpg?1783920942,Creature — Human Warrior,David Astruga
+Trouble in Pairs,4,2024,28.53,#ffffff,https://cards.scryfall.io/normal/front/0/f/0f61e93f-5f97-4c7d-b3d5-0e05242faeb3.jpg?1783913050,Enchantment,Fay Dalton
+Trove Warden,4,2020,0.64,#ffffff,https://cards.scryfall.io/normal/front/3/3/3336593c-c83c-48e7-9173-2c2b74b94d3b.jpg?1783929495,Creature — Cat Beast,Lars Grant-West
+Truce,3,1997,0.74,#ffffff,https://cards.scryfall.io/normal/front/d/e/de4f53fc-69d7-49fb-885b-4cc02bf5facc.jpg?1783946954,Instant,Donato Giancola
+True Believer,2,2007,1.93,#ffffff,https://cards.scryfall.io/normal/front/8/5/85a9c5c4-47d1-4b87-8cbd-2212ee6c5887.jpg?1783943068,Creature — Human Cleric,Alex Horley-Orlandelli
+True Conviction,6,2014,4.78,#ffffff,https://cards.scryfall.io/normal/front/9/e/9e5dc58b-f486-4b9f-9138-33efa31a05e4.jpg?1783938854,Enchantment,Svetlin Velinov
+True Identity,2,2024,0.19,#ffffff,https://cards.scryfall.io/normal/front/9/7/979c3262-7680-49a3-b0dc-12154e44c317.jpg?1783913051,Enchantment,Chris Seaman
+Trynn- Champion of Freedom,4,2020,1.35,#ffffff,https://cards.scryfall.io/normal/front/1/6/168d7532-c925-4a96-a756-2ce4dd0fec33.jpg?1783931235,Legendary Creature — Human Soldier,Jesper Ejsing
+Turncoat Kunoichi,3,2026,0.32,#d78f42,https://cards.scryfall.io/normal/front/3/a/3ae61336-a4ee-40cd-9a18-392d96b873a4.jpg?1783904120,Creature — Mutant Ninja Fox,Manuel Castañón
+Turn the Tables,5,2004,0.5,#ffffff,https://cards.scryfall.io/normal/front/f/7/f79b38c5-4be1-4f33-92e8-6fe0476b5299.jpg?1783944450,Instant,Christopher Moeller
+Turtles Forever,4,2026,0.35,#ffffff,https://cards.scryfall.io/normal/front/f/0/f0db974a-3289-4727-9aaf-e9cca9113c87.jpg?1783904119,Instant,Devin Elle Kurtz
+Twilight Drover,3,2025,0.29,#ffffff,https://cards.scryfall.io/normal/front/4/8/481b1eb5-9fbb-4e27-8d0a-5ca6c34179b6.jpg?1783907115,Creature — Spirit,Dave Allsop
+Twilight Shepherd,6,2014,0.81,#ffffff,https://cards.scryfall.io/normal/front/7/5/753c4ef2-d61a-4cfe-8e8b-8379402c8713.jpg?1783938786,Creature — Angel,Jason Chan
+Ultima,5,2025,0.48,#ffffff,https://cards.scryfall.io/normal/front/3/9/39504a0e-f63f-4907-afd7-c4492f6b8a3b.jpg?1783906642,Sorcery,Gintas Galvanauskas
+Ultimate Magic: Holy,3,2025,0.45,#ffffff,https://cards.scryfall.io/normal/front/8/f/8fdb8414-2f08-42fb-ae0a-c7f0af1e144e.jpg?1783906364,Instant,Ashley Mackenzie
+Ultramarines Honour Guard,4,2022,3.9,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e1915c3-6dda-49fd-be5e-9d4713f00cfd.jpg?1783920940,Creature — Astartes Warrior,Games Workshop
+Umbra Mystic,3,2010,9.26,#ffffff,https://cards.scryfall.io/normal/front/a/5/a55705d3-8640-478e-ace4-f4f900d617c5.jpg?1783942000,Creature — Human Wizard,Matt Stewart
+Unbreakable Formation,3,2024,1.05,#ffffff,https://cards.scryfall.io/normal/front/0/6/06e1cc7b-9319-4f6f-88ee-2e6b6d2efbc6.jpg?1783913340,Instant,Matt Stewart
+Unexpectedly Absent,2,2020,0.32,#ffffff,https://cards.scryfall.io/normal/front/a/1/a1501a42-e233-423b-b68a-1b76630bbccc.jpg?1783931190,Instant,Min Yum
+Unexplained Absence,4,2024,0.39,#ffffff,https://cards.scryfall.io/normal/front/7/8/78f526d3-1e1f-4430-9824-ad377fd0d312.jpg?1783913050,Instant,Rockey Chen
+Unfinished Business,5,2025,0.23,#ffffff,https://cards.scryfall.io/normal/front/7/6/76c9b6c1-05de-4c16-8ebf-ea68aa110a69.jpg?1783906279,Sorcery,Ramza Psyru
+Unidentified Hovership,3,2024,0.24,#ffffff,https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg?1783909501,Artifact — Vehicle,Jana Heidersdorf
+United Battlefront,4,2025,0.35,#ffffff,https://cards.scryfall.io/normal/front/d/f/dff398be-4ba4-4976-9acc-be99d2e07a61.jpg?1783907400,Sorcery,Darren Tan
+United Front,2,2025,2.22,#ffffff,https://cards.scryfall.io/normal/front/d/3/d347caf8-0c12-401f-9e33-9978cb347f89.jpg?1783904994,Sorcery,Mengxuan Li
+Unstable Glyphbridge // Sandswirl Wanderglyph,5,2023,0.29,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Artifact // Artifact Creature — Golem,Bastien Grivet
+Unyielding Gatekeeper,2,2024,0.15,#ffffff,https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg?1783912917,Creature — Elephant Cleric,Borja Pindado
+Urza Assembles the Titans,5,2022,0.34,#ffffff,https://cards.scryfall.io/normal/front/1/0/10a544d7-ead7-42fd-a35a-c1b672771d5b.jpg?1783921356,Enchantment — Saga,Josu Hernaiz
+Urza's Ruinous Blast,5,2023,0.82,#ffffff,https://cards.scryfall.io/normal/front/7/6/76b10977-64eb-4a50-a481-d67cc2950f56.jpg?1783915444,Legendary Sorcery,Slawomir Maniak
+Valiant Endeavor,6,2021,0.6,#ffffff,https://cards.scryfall.io/normal/front/0/4/0445def0-8921-4579-912f-035d9fbce3c0.jpg?1783926254,Sorcery,Antonio José Manzanedo
+Valiant Knight,4,2023,0.51,#ffffff,https://cards.scryfall.io/normal/front/5/a/5a85b8d6-36f7-4bde-a5f5-12509adac68f.jpg?1783917174,Creature — Human Knight,Jakub Kasper
+Valiant Veteran,2,2022,0.35,#ffffff,https://cards.scryfall.io/normal/front/1/8/18b1a4ee-437f-4a08-b176-8342d526143f.jpg?1783921357,Creature — Kor Soldier,Néstor Ossandón Leal
+Valkyrie Harbinger,6,2021,2.55,#ffffff,https://cards.scryfall.io/normal/front/e/d/edab83a9-35b5-4312-b8ee-1c042c02aa31.jpg?1783928124,Creature — Angel Cleric,Tran Nguyen
+Valkyrie's Call,5,2024,1.21,#ffffff,https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg?1783909122,Enchantment,Scott Murphy
+Valley Questcaller,2,2024,0.55,#ffffff,https://cards.scryfall.io/normal/front/b/a/ba629ca8-a368-4282-8a61-9bf6a5c217f0.jpg?1783910855,Creature — Rabbit Warrior,Steve Prescott
+Valor's Flagship,7,2025,0.5,#ffffff,https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg?1783907911,Legendary Artifact — Vehicle,Stephan Martiniere
+Vanguard of the Restless,3,2026,0.23,#ffffff,https://cards.scryfall.io/normal/front/9/1/91211c56-b562-4889-8c5c-110c42be62c8.jpg?1783903864,Creature — Spirit Knight,Néstor Ossandón Leal
+Vanquish the Horde,8,2026,0.25,#ffffff,https://cards.scryfall.io/normal/front/f/3/f392782b-7464-4617-b421-6b5d0e2880fc.jpg?1783903241,Sorcery,Nereida
+Vassal's Duty,4,2004,0.24,#ffffff,https://cards.scryfall.io/normal/front/8/e/8ef25165-2458-4c00-8b7c-0ad6fd98e3af.jpg?1783944331,Enchantment,Dave Dorman
+Vault 101: Birthday Party,4,2024,0.35,#ffffff,https://cards.scryfall.io/normal/front/f/c/fc513659-ea88-4d04-82bd-5bb2e740d957.jpg?1783912412,Enchantment — Saga,Andrea Piparo
+Vault 13: Dweller's Journey,4,2024,0.3,#ffffff,https://cards.scryfall.io/normal/front/a/2/a22ad436-215a-4da1-b12e-1faac474f948.jpg?1783912414,Enchantment — Saga,Gaboleps
+Vault 75: Middle School,4,2024,0.36,#ffffff,https://cards.scryfall.io/normal/front/3/9/3992e262-0491-4379-b74b-13cc8b63065e.jpg?1783912413,Enchantment — Saga,Victor Harmatiuk
+Veiled Ascension,4,2024,0.21,#ffffff,https://cards.scryfall.io/normal/front/5/1/5196eb5b-9330-46f7-b6f7-9c1164ea27d7.jpg?1783913050,Enchantment,Domenico Cava
+Venat- Heart of Hydaelyn // Hydaelyn- the Mothercrystal,3,2025,1.35,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Legendary Creature — Elder Wizard // Legendary Creature — God,Colin Boyer
+Venerated Loxodon,5,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/d/5/d55160fd-a3a7-46b4-9f0d-e3e98cb533d6.jpg?1783917173,Creature — Elephant Cleric,Zack Stella
+Vengeful Archon,7,2010,0.19,#ffffff,https://cards.scryfall.io/normal/front/a/5/a505d07f-61cf-4b00-a1d5-028747899eaa.jpg?1783941830,Creature — Archon,Greg Staples
+Vengeful Dreams,2,2002,0.55,#ffffff,https://cards.scryfall.io/normal/front/4/8/48bfe8b2-cc98-4430-b576-085163bdf0b6.jpg?1783945165,Instant,Mark Tedin
+Verge Rangers,3,2024,0.29,#ffffff,https://cards.scryfall.io/normal/front/c/6/c63a5253-b3b7-48d0-8c2c-700fbd0e4c3f.jpg?1783909629,Creature — Human Scout Ranger,Livia Prima
+Vexilus Praetor,4,2022,15.17,#ffffff,https://cards.scryfall.io/normal/front/6/5/6584cc58-c88e-4cf6-9983-5e08fd8609c3.jpg?1783920939,Creature — Custodes Warrior,Zezhou Chen
+Victory's Envoy,5,2021,0.38,#ffffff,https://cards.scryfall.io/normal/front/b/9/b9fd4bad-0227-484d-ba48-4e7f75bb804d.jpg?1783925348,Creature — Human Cleric,Sara Winters
+Victory's Herald,6,2018,0.31,#ffffff,https://cards.scryfall.io/normal/front/3/3/33366563-6cb8-46f6-82c9-d7541a52af33.jpg?1783934767,Creature — Angel,rk post
+Vikya- Scorching Stalwart,3,2023,0.3,#d78f42,https://cards.scryfall.io/normal/front/f/3/f3a9eac0-cc71-48ae-bb60-ae26160f2000.jpg?1783917775,Legendary Creature — Human Warrior,Zoltan Boros
+Virtue of Loyalty // Ardenvale Fealty,5,2023,6.87,#ffffff,https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1783915127,Enchantment // Instant — Adventure,Piotr Dura
+Visions of Glory,5,2021,0.34,#ffffff,https://cards.scryfall.io/normal/front/1/1/11675d8a-cd81-4055-bdbd-2e709e12ba66.jpg?1783925373,Sorcery,Alexander Mokhov
+Vitality Hunter,4,2020,0.29,#ffffff,https://cards.scryfall.io/normal/front/2/b/2bec0d43-f321-49eb-9402-83632d00d4be.jpg?1783931223,Creature — Nightmare,Tomasz Jedruszek
+Voice of All,4,2017,0.27,#ffffff,https://cards.scryfall.io/normal/front/2/2/220feab0-b799-464e-b9bd-a47949067418.jpg?1783936301,Creature — Angel,rk post
+Voice of the Blessed,2,2025,2.33,#ffffff,https://cards.scryfall.io/normal/front/6/2/62534128-2a85-4a36-bc7b-e4f4c51fa1f6.jpg?1783908172,Creature — Spirit Cleric,Anastasia Ovchinnikova
+Voice of Victory,2,2025,17.21,#ffffff,https://cards.scryfall.io/normal/front/e/c/ec3de5f4-bb55-4ab9-995f-f3e0dc22c1bb.jpg?1783907401,Creature — Human Bard,Joshua Cairos
+Voidstone Gargoyle,5,2007,0.31,#ffffff,https://cards.scryfall.io/normal/front/5/8/583741a1-0faf-4fb3-8536-b9b1cc8a3b6f.jpg?1783943167,Creature — Gargoyle,Terese Nielsen
+Voyager Glidecar,1,2025,0.23,#ffffff,https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg?1783907912,Artifact — Vehicle,Eduardo Francisco
+Vryn Wingmare,3,2015,0.21,#ffffff,https://cards.scryfall.io/normal/front/a/3/a34291dc-103f-493d-b217-bd1b0e946d8d.jpg?1783938356,Creature — Pegasus,Seb McKinnon
+Vulpine Harvester,4,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/4/2/42ebea93-14ba-4405-84a2-95e51a777ed5.jpg?1783917288,Creature — Phyrexian Fox,Brent Hollowell
+Wakening Sun's Avatar,8,2023,0.37,#ffffff,https://cards.scryfall.io/normal/front/8/2/820b6327-2cbf-4054-bc33-4baf9c26dd70.jpg?1783913893,Creature — Dinosaur Avatar,Tyler Jacobson
+Wakestone Gargoyle,4,2025,0.3,#ffffff,https://cards.scryfall.io/normal/front/4/d/4d5f0939-6b99-401d-99c9-e4339a9c5822.jpg?1783907114,Creature — Gargoyle,Jim Murray
+Wall of Mourning,2,2021,0.26,#ffffff,https://cards.scryfall.io/normal/front/9/8/98692a19-c9d4-48bf-9315-d88c44136f8b.jpg?1783925382,Creature — Wall,Kasia 'Kafis' Zielińska
+Wall of Nets,3,1998,5.6,#ffffff,https://cards.scryfall.io/normal/front/c/1/c1da8e79-365d-4a36-87c5-648085828f9f.jpg?1783946527,Creature — Wall,Terese Nielsen
+Wall of Omens,2,2024,5.17,#ffffff,https://cards.scryfall.io/normal/front/8/3/83f4d580-0a3c-4f4f-9700-4a2afed4ded0.jpg?1783913086,Creature — Wall,Alexander Khabbazi
+Wall of Reverence,4,2025,0.36,#ffffff,https://cards.scryfall.io/normal/front/f/2/f23e6f3f-4776-4015-8ee8-8e679ec7ce02.jpg?1783907112,Creature — Spirit Wall,Wayne Reynolds
+Wand of the Worldsoul,3,2023,3.86,#ffffff,https://cards.scryfall.io/normal/front/3/e/3ef9fb7d-1fd5-4dce-afda-6743dec3bbc1.jpg?1783917288,Artifact,Alessandra Pisano
+Warden of the Inner Sky,1,2023,0.27,#ffffff,https://cards.scryfall.io/normal/front/5/4/549fd992-ed37-431d-97cb-9ca017db1d47.jpg?1783913801,Creature — Human Soldier,Raoul Vitale
+War of the Last Alliance,4,2023,1.49,#ffffff,https://cards.scryfall.io/normal/front/6/0/60ddf2cd-5b33-4c8a-a610-8e6a15404dde.jpg?1783916322,Enchantment — Saga,Alexander Forssberg
+Warren Warleader,4,2024,2.24,#ffffff,https://cards.scryfall.io/normal/front/e/b/eb5237a0-5ac3-4ded-9f92-5f782a7bbbd7.jpg?1783910855,Creature — Rabbit Knight,Zack Stella
+Warrior Angel,6,1998,0.59,#ffffff,https://cards.scryfall.io/normal/front/8/1/81d2c6e3-e556-4cc6-94b6-fdbc62d6853e.jpg?1783946570,Creature — Angel Warrior,Brom
+Warrior's Resolve,3,2025,2.65,#ffffff,https://cards.scryfall.io/normal/front/7/2/7263ef64-dc8d-4a58-91b9-ff4f718e53ae.jpg?1783904648,Enchantment,Winona Nelson
+Wave of Reckoning,5,2026,0.42,#ffffff,https://cards.scryfall.io/normal/front/7/b/7be0c25a-5e65-48e1-9560-9391111bb912.jpg?1783903824,Sorcery,Cristi Balanescu
+Wayward Angel,6,2001,0.57,#ffffff,https://cards.scryfall.io/normal/front/1/f/1fb726e8-162d-4143-9778-32476c0e1ab1.jpg?1783945269,Creature — Angel Horror,Mark Tedin
+Weathered Bodyguards,6,2006,0.29,#ffffff,https://cards.scryfall.io/normal/front/9/9/991a18e5-a183-4b84-b157-5a3609b3f910.jpg?1783943248,Creature — Human Soldier,Wayne Reynolds
+Weathered Wayfarer,1,2022,2.22,#ffffff,https://cards.scryfall.io/normal/front/0/9/09656d96-c366-49ec-b687-cad903de1385.jpg?1783921926,Creature — Human Nomad Cleric,Greg Hildebrandt & Tim Hildebrandt
+Wedding Announcement // Wedding Festivity,3,2025,0.43,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Enchantment // Enchantment,Caroline Gariba
+Wedding Ring,4,2021,11.44,#ffffff,https://cards.scryfall.io/normal/front/7/f/7f0b1400-0608-47fd-9c73-b7730bcf6b7f.jpg?1783924997,Artifact,Olena Richards
+Welcoming Vampire,3,2025,3.83,#ffffff,https://cards.scryfall.io/normal/front/3/5/35a69bb5-b8e6-4558-9563-10c7a3662f93.jpg?1783907112,Creature — Vampire,Lorenzo Mastroianni
+Werefox Bodyguard,3,2023,0.46,#ffffff,https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg?1783915124,Creature — Elf Fox Knight,Néstor Ossandón Leal
+We Ride at Dawn,3,2024,0.37,#ffffff,https://cards.scryfall.io/normal/front/f/d/fd95daa3-c1f6-4f4c-8dde-ad5a50bfea00.jpg?1783911970,Enchantment,Miguel Mercado
+What Must Be Done,5,2024,0.34,#ffffff,https://cards.scryfall.io/normal/front/f/e/fe034544-e13f-45fc-ae43-83d0f399ed33.jpg?1783910986,Sorcery,Syd Mills
+Whiskervale Forerunner,4,2024,0.24,#ffffff,https://cards.scryfall.io/normal/front/6/0/60a78d59-af31-4af9-95aa-2573fe553925.jpg?1783910853,Creature — Mouse Bard,Ryan Pancoast
+White Orchid Phantom,2,2026,0.25,#ffffff,https://cards.scryfall.io/normal/front/e/6/e6cebc57-d7b0-4e86-bc9e-ebb1de58f932.jpg?1783903796,Creature — Spirit Knight,Zoltan Boros
+White Plume Adventurer,3,2022,2.46,#ffffff,https://cards.scryfall.io/normal/front/b/2/b256ddc8-8b12-434c-a610-1a872e948f2f.jpg?1783922800,Creature — Orc Cleric,Joseph Weston
+White Sun's Twilight,2,2023,2.31,#ffffff,https://cards.scryfall.io/normal/front/f/f/fff13d77-8133-4328-b91e-efce229bc331.jpg?1783918071,Sorcery,Julian Kok Joon Wen
+White Sun's Zenith,3,2020,0.33,#ffffff,https://cards.scryfall.io/normal/front/0/2/029e0450-ceb1-484d-8a18-e769defac428.jpg?1783928723,Instant,Mike Bierek
+Wilfred Mott,4,2023,0.33,#ffffff,https://cards.scryfall.io/normal/front/1/0/10918b68-b442-4895-b8a6-57f65274a39e.jpg?1783914676,Legendary Creature — Human Soldier,John Di Giovanni
+Will of the Mardu,3,2025,3.16,#ffffff,https://cards.scryfall.io/normal/front/2/6/26f6b519-20ff-4255-926d-5caee6c572d8.jpg?1783907183,Instant,Tuan Duong Chu
+Windborn Muse,4,2024,0.7,#ffffff,https://cards.scryfall.io/normal/front/3/c/3ce8b722-7bc0-4053-8627-7846f9d17eda.jpg?1783913021,Creature — Spirit,Adam Rex
+Windbrisk Raptor,7,2008,8.93,#ffffff,https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg?1783942764,Creature — Bird,Omar Rayyan
+Windshaper Planetar,5,2022,0.37,#ffffff,https://cards.scryfall.io/normal/front/a/2/a2ecf2f5-6d8b-4321-9aa1-d84c291a5c20.jpg?1783922798,Creature — Angel,Ben Hill
+Winds of Abandon,2,2019,3.55,#ffffff,https://cards.scryfall.io/normal/front/3/b/3bb17913-fe4d-4acd-9b75-71f5a90f898b.jpg?1783933150,Sorcery,Noah Bradley
+Winds of Rath,5,2026,0.31,#ffffff,https://cards.scryfall.io/normal/front/8/d/8dee155b-1f06-4d74-afa8-a1244c254978.jpg?1783903794,Sorcery,Drew Tucker
+Wingmate Roc,5,2019,0.59,#ffffff,https://cards.scryfall.io/normal/front/1/6/16930385-796e-4e11-b439-d0dbda63d72d.jpg?1783932784,Creature — Bird,Mark Zug
+Winnow,2,2000,0.3,#ffffff,https://cards.scryfall.io/normal/front/d/6/d61748dd-4010-47da-8717-ca0147877057.jpg?1783945711,Instant,Roger Raupp
+Winnowing,6,2026,0.37,#ffffff,https://cards.scryfall.io/normal/front/f/9/f943a7d8-9550-427e-8c45-ef834329d345.jpg?1783904492,Sorcery,David Palumbo
+Winter Soldier- Reborn Avenger,5,2026,0.39,#ffffff,https://cards.scryfall.io/normal/front/d/e/de13b219-a99c-47ef-8b68-d57463cf5de8.jpg?1783903293,Legendary Creature — Human Soldier Hero,Lucio Parrillo
+Witch Enchanter // Witch-Blessed Meadow,4,2026,32.5,#ffffff,https://cards.scryfall.io/normal/front/f/4/f410ae1c-02de-423e-a478-e1dea243ef1e.jpg?1619395458,Creature — Human Warlock // Land,SimzArt
+Witch Hunter,4,1994,6.62,#ffffff,https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg?1783947945,Creature — Human Cleric,Jesper Myrfors
+With Great Power . . .,4,2025,0.93,#ffffff,https://cards.scryfall.io/normal/front/f/7/f717c096-e161-426e-a8d7-c93b117e16b9.jpg?1783905357,Enchantment — Aura,E. M. Gist
+Wizened Mentor,2,2025,0.29,#ffffff,https://cards.scryfall.io/normal/front/f/9/f903afd3-01b5-4892-bd78-8da1d2f36252.jpg?1783907751,Creature — Zombie Cleric,Bruno Biazotto
+Wojek Investigator,3,2024,0.32,#ffffff,https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg?1783912917,Creature — Angel Detective,Ben Hill
+Wondrous Revival,6,2026,2.1,#ffffff,https://cards.scryfall.io/normal/front/3/9/39733bf4-44f9-41e6-adf5-35199571df81.jpg?1783903104,Sorcery,Riccardo Federici
+Woolly Razorback,4,2006,0.51,#ffffff,https://cards.scryfall.io/normal/front/9/5/95ed6354-161e-496e-9ac7-74432f9b0818.jpg?1783943364,Creature — Boar Beast,Richard Sardinha
+Words of Worship,3,2002,2.19,#ffffff,https://cards.scryfall.io/normal/front/0/e/0ea5c6e0-8361-4214-997b-32a66b19fae9.jpg?1783945089,Enchantment,Rebecca Guay
+World Queller,5,2009,0.37,#ffffff,https://cards.scryfall.io/normal/front/1/3/134ff41d-1645-4d3a-94b6-e13a30dedb8e.jpg?1783942168,Creature — Avatar,James Paick
+Worship,4,2005,1.25,#ffffff,https://cards.scryfall.io/normal/front/4/a/4ad20044-8ed8-49ae-9a07-d4cb18527cc7.jpg?1783944071,Enchantment,Mark Zug
+Worthy Knight,2,2023,0.35,#ffffff,https://cards.scryfall.io/normal/front/b/d/bdbfe895-f806-4490-9ae6-b39b28ea4e28.jpg?1783917174,Creature — Human Knight,Yongjae Choi
+Wrath of God,4,2023,4.05,#ffffff,https://cards.scryfall.io/normal/front/5/3/537d2b05-3f52-45d6-8fe3-26282085d0c6.jpg?1783915706,Sorcery,Willian Murai
+Wrath of the Skies,2,2024,2.21,#ffffff,https://cards.scryfall.io/normal/front/4/e/4ef1882e-b422-4f30-8a6c-bd71c2601660.jpg?1783911294,Sorcery,Franz Vohwinkel
+Yare,3,1996,0.79,#ffffff,https://cards.scryfall.io/normal/front/9/a/9a14343d-c2cd-4a67-ae54-6b6a4677ca85.jpg?1783947114,Instant,Ron Spencer
+Yes Man- Personal Securitron,3,2024,1.81,#ffffff,https://cards.scryfall.io/normal/front/8/e/8e2fac8c-a574-4414-ac68-632fc822ddbb.jpg?1783912412,Legendary Artifact Creature — Robot,Dan Murayama Scott
+Yomiji- Who Bars the Way,7,2005,1.51,#ffffff,https://cards.scryfall.io/normal/front/f/6/f611af49-3c59-4365-a398-93f7e05ff0d0.jpg?1783944208,Legendary Creature — Spirit,Hideaki Takamura
+Yosei- the Morning Star,6,2017,0.84,#ffffff,https://cards.scryfall.io/normal/front/4/7/47af956c-e2ba-47c5-bc5d-ec0ab345ce57.jpg?1783935553,Legendary Creature — Dragon Spirit,Chris Rahn
+Yoshimaru- Ever Faithful,1,2022,8.41,#ffffff,https://cards.scryfall.io/normal/front/a/a/aa409269-3698-42a2-8c51-75557b27a6f6.jpg?1783923987,Legendary Creature — Dog,Ilse Gort
+Youthful Valkyrie,2,2025,7.96,#ffffff,https://cards.scryfall.io/normal/front/5/a/5aa62069-cb37-423a-a0d9-44f4bdebca45.jpg?1783907933,Creature — Angel,Anna Podedworna
+Zephyrim,4,2022,0.59,#ffffff,https://cards.scryfall.io/normal/front/f/7/f78f5b9a-bd80-41e9-873e-826628dc44a7.jpg?1783920939,Creature — Human Warrior,Anna Steinbauer
+Zeriam- Golden Wind,4,2022,0.32,#ffffff,https://cards.scryfall.io/normal/front/e/7/e7efbb9a-e0b3-412c-9ee7-a90123033999.jpg?1783921477,Legendary Creature — Griffin,John Tedrick
+Zetalpa- Primal Dawn,8,2025,0.28,#ffffff,https://cards.scryfall.io/normal/front/7/8/78c71a23-8e73-406e-bbd0-4474c17c1d04.jpg?1783907112,Legendary Creature — Elder Dinosaur,Chris Rallis
+Zhang Fei- Fierce Warrior,6,1999,169.99,#ffffff,https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg?1783946125,Legendary Creature — Human Soldier Warrior,Qiao Dafu
+Zhao Zilong- Tiger General,5,1999,100.0,#ffffff,https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg?1783946125,Legendary Creature — Human Soldier Warrior,Quan Xuejun
+Zuberi- Golden Feather,5,1996,3.04,#ffffff,https://cards.scryfall.io/normal/front/c/1/c1b24a80-b5e1-484f-9e21-886cb6b5db48.jpg?1783947113,Legendary Creature — Griffin,Alan Rabinowitz

--- a/scryfall_scraper.py
+++ b/scryfall_scraper.py
@@ -12,7 +12,7 @@ class ScryfallScraper:
         self.mtg_color_codes = MTGCodes().get_color_codes()
         self.mtg_set_codes = MTGCodes().get_set_codes()
         self.requests_timeout_seconds = 60
-        self.requests_user_agent = {'User-agent': 'application/json;q=0.9,*/*;q=0.8.'}
+        self.requests_user_agent = {"User-agent": "application/json;q=0.9,*/*;q=0.8."}
 
     # Scryfall kindly requests that API users add 50-100ms delay between calls https://scryfall.com/docs/api
     # Over time rate limiting has gotten more aggressive, so add a significant delay to avoid early terminations
@@ -95,12 +95,16 @@ class ScryfallScraper:
 
     def query_card_color_data(self, color_code: str):
         url = f"https://api.scryfall.com/cards/search?q=color%3D{color_code}%28rarity%3Ar+OR+rarity%3Am%29"
-        response = requests.get(url, headers=self.requests_user_agent, timeout=self.requests_timeout_seconds).json()
+        response = requests.get(
+            url, headers=self.requests_user_agent, timeout=self.requests_timeout_seconds
+        ).json()
         card_data = [response.get("data")]
         page_count = 1
         while response.get("has_more"):
             response = requests.get(
-                response.get("next_page"), headers=self.requests_user_agent, timeout=self.requests_timeout_seconds
+                response.get("next_page"),
+                headers=self.requests_user_agent,
+                timeout=self.requests_timeout_seconds,
             ).json()
             card_data.append(response.get("data"))
             logging.info(f"Appended page {page_count} for color {color_code}")
@@ -113,7 +117,9 @@ class ScryfallScraper:
 
     def query_card_set_data(self, set_code: str):
         url = f"https://api.scryfall.com/cards/search?q=set%3A{set_code}+%28rarity%3Ar+OR+rarity%3Am%29"
-        response = requests.get(url, headers=self.requests_user_agent, timeout=self.requests_timeout_seconds).json()
+        response = requests.get(
+            url, headers=self.requests_user_agent, timeout=self.requests_timeout_seconds
+        ).json()
         # Making card_data a single element list is unnecessary but matches paginated color design
         # This allows extract_card_data to be identical for each
         card_data = [response.get("data")]

--- a/scryfall_scraper.py
+++ b/scryfall_scraper.py
@@ -14,8 +14,9 @@ class ScryfallScraper:
         self.requests_timeout_seconds = 60
         self.requests_user_agent = {'User-agent': 'application/json;q=0.9,*/*;q=0.8.'}
 
+    # Scryfall kindly requests that API users add 50-100ms delay between calls https://scryfall.com/docs/api
+    # Over time rate limiting has gotten more aggressive, so add a significant delay to avoid early terminations
     def api_rate_limiter(self, delay_in_milliseconds=2000):
-        # Scryfall kindly requests that API users add 50-100ms delay between calls https://scryfall.com/docs/api
         time.sleep(delay_in_milliseconds / 1000)
 
     def extract_card_data(self, card_data_json_list):
@@ -99,7 +100,7 @@ class ScryfallScraper:
         page_count = 1
         while response.get("has_more"):
             response = requests.get(
-                response.get("next_page"), timeout=self.requests_timeout_seconds
+                response.get("next_page"), headers=self.requests_user_agent, timeout=self.requests_timeout_seconds
             ).json()
             card_data.append(response.get("data"))
             logging.info(f"Appended page {page_count} for color {color_code}")


### PR DESCRIPTION
Similar to #59 the scryfall api began enforcing use of a non-default user agent to be added to api requests.

This PR fixes the request to include that header and re-establishes it with locally generated data